### PR TITLE
Add per-prompt follow-ups and share button

### DIFF
--- a/Connections.xcodeproj/project.pbxproj
+++ b/Connections.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 			path = Connections;
 			sourceTree = "<group>";
 		};
-		BB000002BB90420900000002 /* ConnectionsTests */ = {
+		BB000002BB90420900000002 /* Tests/ConnectionsTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Tests/ConnectionsTests;
 			sourceTree = SOURCE_ROOT;
@@ -63,7 +63,7 @@
 		24B9F1872F94051900486642 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				BB000002BB90420900000002 /* ConnectionsTests */,
+				BB000002BB90420900000002 /* Tests/ConnectionsTests */,
 				24B9F1862F9404EE00486642 /* ConnectionsTests.xctestplan */,
 			);
 			path = Tests;
@@ -127,7 +127,7 @@
 				BB00000BBB90420900000011 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				BB000002BB90420900000002 /* ConnectionsTests */,
+				BB000002BB90420900000002 /* Tests/ConnectionsTests */,
 			);
 			name = ConnectionsTests;
 			packageProductDependencies = (
@@ -344,6 +344,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 56X72VGLKJ;
@@ -361,6 +362,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tanner.Connections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -376,6 +378,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 56X72VGLKJ;
@@ -393,6 +396,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tanner.Connections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;

--- a/Connections/Components/SelectionCard.swift
+++ b/Connections/Components/SelectionCard.swift
@@ -5,14 +5,21 @@
 
 import SwiftUI
 
+/// A reusable tappable card used throughout selection screens (mode, intensity, topic, etc.).
+/// Displays a title and subtitle with an optional tint color and a subtle press animation.
 struct SelectionCard: View {
     let title: String
     let subtitle: String
     var tintColor: Color? = nil
     let action: () -> Void
 
+    /// Tracks whether the user is currently pressing the card, driving the visual feedback.
     @State private var isPressed = false
 
+    /// Resolves the card's background color.
+    /// When a `tintColor` is provided, it uses that color at a low opacity;
+    /// otherwise it falls back to a neutral primary tint.
+    /// Opacity increases slightly while the card is pressed to give tactile feedback.
     private var backgroundFill: Color {
         if let tint = tintColor {
             return tint.opacity(isPressed ? 0.22 : 0.14)
@@ -41,10 +48,14 @@ struct SelectionCard: View {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(backgroundFill)
             )
+            // Scale down slightly while pressed to reinforce the tap interaction.
             .scaleEffect(isPressed ? 0.98 : 1.0)
             .animation(.easeOut(duration: 0.15), value: isPressed)
         }
         .buttonStyle(.plain)
+        // A zero-distance drag gesture is used instead of ButtonStyle to track
+        // press/release independently, allowing the scale + opacity animation
+        // to play without interfering with the button's own tap handling.
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { _ in isPressed = true }

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -100,41 +100,139 @@ private extension PromptBank {
         entries.map { Prompt(text: $0.0, mode: mode, intensity: intensity, depthLevel: depth, topic: $0.1, followUps: defaultFollowUps) }
     }
 
+    /// Overload that accepts per-prompt follow-up strings instead of using the global defaults.
+    static func make(_ entries: [(String, Topic, [String])], mode: Mode, intensity: Intensity, depth: DepthLevel) -> [Prompt] {
+        entries.map { Prompt(text: $0.0, mode: mode, intensity: intensity, depthLevel: depth, topic: $0.1, followUps: $0.2.map { FollowUp(text: $0) }) }
+    }
+
     // MARK: - Couples · Light · Warm Up
 
     static func couples_light_warmUp() -> [Prompt] {
         make([
-            ("If you could know one thing about your future, what would you want to find out?", .dailyLife),
-            ("What's something you're unreasonably stubborn about?", .identity),
-            ("What's something you know you're completely irrational about?", .identity),
-            ("What's a tiny personal preference you feel surprisingly passionate about?", .dailyLife),
-            ("What do you spend way too much money on without any regret?", .dailyLife),
-            ("What do you know you make a bigger deal about than you should?", .communication),
-            ("What would you love to be able to spend more freely on?", .dailyLife),
-            ("Are you more of a host or a guest — and what does that say about you?", .dailyLife),
-            ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife),
-            ("What's your go-to midnight snack raid?", .dailyLife),
-            ("Who or what have you been quietly fascinated by lately?", .intimacy),
-            ("What's the most disastrous date you've ever been on?", .dailyLife),
-            ("What's your favorite real love story — yours or someone else's?", .intimacy),
-            ("What do you need most from me when you're not feeling well?", .communication),
-            ("What are you surprisingly high-maintenance about?", .dailyLife),
-            ("What are you a complete control freak about?", .identity),
-            ("What's the one thing you absolutely cannot be teased about?", .communication),
-            ("What's basically impossible for you to say no to?", .communication),
-            ("What's something about your partner that you fell in love with all over again recently?", .appreciation),
-            ("I feel most sensual when…", .sex),
-            ("I feel most attractive when…", .sex),
-            ("What's a song that always makes you think of us?", .appreciation),
-            ("What's the best surprise you've ever gotten from someone you love?", .appreciation),
-            ("What's your idea of a perfect lazy Sunday together?", .dailyLife),
-            ("What's something small I do that always makes you smile?", .appreciation),
-            ("If we could travel anywhere tomorrow, where would you want to go?", .dailyLife),
-            ("What's a hobby or skill you've always wanted us to try together?", .growth),
-            ("What's the most fun we've ever had doing something totally unplanned?", .past),
-            ("What's a movie or show that reminds you of our relationship?", .dailyLife),
-            ("What's your love language when you're stressed versus when you're happy?", .communication),
-            ("What's a tradition you'd love for us to start?", .values),
+            ("If you could know one thing about your future, what would you want to find out?", .dailyLife, [
+                "Why that answer, specifically?",
+                "How do you think knowing it would change the way you live now?",
+            ]),
+            ("What's something you're unreasonably stubborn about?", .identity, [
+                "What makes that one so hard for you to budge on?",
+                "What do you think it protects in you?",
+            ]),
+            ("What's something you know you're completely irrational about?", .identity, [
+                "What usually triggers that reaction in you?",
+                "Do you think it's tied to something older or deeper?",
+            ]),
+            ("What's a tiny personal preference you feel surprisingly passionate about?", .dailyLife, [
+                "Why do you think that one matters so much to you?",
+                "What does it reveal about the way you like life to feel?",
+            ]),
+            ("What do you spend way too much money on without any regret?", .dailyLife, [
+                "What does spending on that give you beyond the thing itself?",
+                "What would it be hard to replace that feeling with?",
+            ]),
+            ("What do you know you make a bigger deal about than you should?", .communication, [
+                "What does it touch in you that makes it feel bigger than it is?",
+                "What are you usually needing in those moments?",
+            ]),
+            ("What would you love to be able to spend more freely on?", .dailyLife, [
+                "What would that say about the kind of life you want?",
+                "What feeling are you hoping more freedom there would give you?",
+            ]),
+            ("Are you more of a host or a guest — and what does that say about you?", .dailyLife, [
+                "What part of that role feels most natural to you?",
+                "What does that role let you avoid or enjoy most?",
+            ]),
+            ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife, [
+                "What do those choices tell you about what keeps you steady?",
+                "Which one would be the hardest to go without, and why?",
+            ]),
+            ("What's your go-to midnight snack raid?", .dailyLife, [
+                "What mood are you usually in when that craving hits?",
+                "What do you think you're really reaching for in that moment?",
+            ]),
+            ("Who or what have you been quietly fascinated by lately?", .intimacy, [
+                "What is it about them or it that keeps pulling you in?",
+                "Do you think it connects to something you're wanting more of in your own life?",
+            ]),
+            ("What's the most disastrous date you've ever been on?", .dailyLife, [
+                "What made it go wrong so fast?",
+                "What did that experience teach you about yourself or dating?",
+            ]),
+            ("What's your favorite real love story — yours or someone else's?", .intimacy, [
+                "What part of that story moves you the most?",
+                "What does it reveal about the kind of love you believe in?",
+            ]),
+            ("What do you need most from me when you're not feeling well?", .communication, [
+                "What helps you feel cared for instead of just looked after?",
+                "What's easy for me to miss in those moments?",
+            ]),
+            ("What are you surprisingly high-maintenance about?", .dailyLife, [
+                "What makes that one worth the extra fuss to you?",
+                "Do you think it's more about comfort, control, or feeling cared for?",
+            ]),
+            ("What are you a complete control freak about?", .identity, [
+                "What feels at risk when you're not in control there?",
+                "Where do you think that need for control comes from?",
+            ]),
+            ("What's the one thing you absolutely cannot be teased about?", .communication, [
+                "What makes that one land differently than other jokes?",
+                "What does it touch in you that's still tender?",
+            ]),
+            ("What's basically impossible for you to say no to?", .communication, [
+                "What makes it so hard to resist?",
+                "What need in you does saying yes satisfy?",
+            ]),
+            ("What's something about your partner that you fell in love with all over again recently?", .appreciation, [
+                "What was it about that moment that hit you so strongly?",
+                "What did it remind you of about why you chose them?",
+            ]),
+            ("I feel most sensual when…", .sex, [
+                "What helps you settle into that feeling most naturally?",
+                "What tends to pull you away from it?",
+            ]),
+            ("I feel most attractive when…", .sex, [
+                "What is it about that moment that makes you feel seen that way?",
+                "How much of that feeling comes from you versus someone else's response?",
+            ]),
+            ("What's a song that always makes you think of us?", .appreciation, [
+                "What memory or feeling does it bring back first?",
+                "What part of us does that song seem to capture?",
+            ]),
+            ("What's the best surprise you've ever gotten from someone you love?", .appreciation, [
+                "What made that surprise feel so meaningful to you?",
+                "What did it show you about how that person knew you?",
+            ]),
+            ("What's your idea of a perfect lazy Sunday together?", .dailyLife, [
+                "What part of that day feels most nourishing to you?",
+                "What does that version of Sunday give you that everyday life doesn't?",
+            ]),
+            ("What's something small I do that always makes you smile?", .appreciation, [
+                "Why do you think that tiny thing means so much to you?",
+                "What does it make you feel in that moment?",
+            ]),
+            ("If we could travel anywhere tomorrow, where would you want to go?", .dailyLife, [
+                "What about that place feels right for us?",
+                "What are you hoping we'd feel there together?",
+            ]),
+            ("What's a hobby or skill you've always wanted us to try together?", .growth, [
+                "What do you imagine that bringing out in us?",
+                "What makes doing it together matter more than doing it alone?",
+            ]),
+            ("What's the most fun we've ever had doing something totally unplanned?", .past, [
+                "What do you think made that moment feel so alive?",
+                "What does it tell you about us at our best?",
+            ]),
+            ("What's a movie or show that reminds you of our relationship?", .dailyLife, [
+                "What dynamic or moment in it feels most like us?",
+                "Is that comparison sweet, funny, or a little too accurate?",
+            ]),
+            ("What's your love language when you're stressed versus when you're happy?", .communication, [
+                "How can someone tell which version of you they're getting?",
+                "What do you most want from me when you're in each state?",
+            ]),
+            ("What's a tradition you'd love for us to start?", .values, [
+                "What do you think that tradition would create between us over time?",
+                "Why does that kind of ritual matter to you?",
+            ]),
         ], mode: .couples, intensity: .light, depth: .warmUp)
     }
 

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import MessageUI
 
 struct SessionPlayView: View {
     @Environment(SessionManager.self) private var session
@@ -15,8 +14,6 @@ struct SessionPlayView: View {
     @State private var promptTransitionID = UUID()
     @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
-    @State private var showShareSheet = false
-
     var body: some View {
         VStack(spacing: 0) {
 
@@ -47,11 +44,9 @@ struct SessionPlayView: View {
                         ConnectionHeartView(fillAmount: session.connectionTracker.fillAmount, size: 16)
                     }
 
-                    if session.currentPrompt != nil && !session.isSessionComplete && MFMessageComposeViewController.canSendText() {
-                        Button {
-                            showShareSheet = true
-                        } label: {
-                            Image(systemName: "message")
+                    if let prompt = session.currentPrompt, !session.isSessionComplete {
+                        ShareLink(item: prompt.text) {
+                            Image(systemName: "square.and.arrow.up")
                                 .font(.system(size: 14, weight: .medium))
                                 .foregroundStyle(.secondary)
                         }
@@ -137,11 +132,6 @@ struct SessionPlayView: View {
         .background((session.selectedIntensity?.backgroundTint ?? Color.clear).ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
-        .sheet(isPresented: $showShareSheet) {
-            if let prompt = session.currentPrompt {
-                MessageComposer(body: prompt.text)
-            }
-        }
         .animation(.easeInOut(duration: 0.3), value: session.showFeelingCheckIn)
         .animation(.easeInOut(duration: 0.3), value: session.isSessionComplete)
     }
@@ -368,38 +358,6 @@ struct SessionPlayView: View {
             withAnimation(.easeInOut(duration: 0.25)) {
                 promptTransitionID = UUID()
             }
-        }
-    }
-}
-
-// MARK: - Message Composer
-
-private struct MessageComposer: UIViewControllerRepresentable {
-    let body: String
-    @Environment(\.dismiss) private var dismiss
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(dismiss: dismiss)
-    }
-
-    func makeUIViewController(context: Context) -> MFMessageComposeViewController {
-        let controller = MFMessageComposeViewController()
-        controller.body = body
-        controller.messageComposeDelegate = context.coordinator
-        return controller
-    }
-
-    func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {}
-
-    class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
-        let dismiss: DismissAction
-
-        init(dismiss: DismissAction) {
-            self.dismiss = dismiss
-        }
-
-        func messageComposeViewController(_ controller: MFMessageComposeViewController, didFinishWith result: MessageComposeResult) {
-            dismiss()
         }
     }
 }

--- a/ConnectionsTests/FallInLoveManagerTests.swift
+++ b/ConnectionsTests/FallInLoveManagerTests.swift
@@ -1,74 +1,67 @@
-import XCTest
+import Testing
 @testable import Connections
 
-final class FallInLoveManagerTests: XCTestCase {
+private let progressKey = "layers_fallInLove_progress"
 
-    private let progressKey = "layers_fallInLove_progress"
+@Suite("FallInLoveManager", .serialized)
+struct FallInLoveManagerTests {
 
-    override func setUp() {
-        super.setUp()
+    init() {
         UserDefaults.standard.removeObject(forKey: progressKey)
     }
 
-    override func tearDown() {
-        super.tearDown()
-        UserDefaults.standard.removeObject(forKey: progressKey)
-    }
-
-    func testAdvanceIncrementsIndex() {
+    @Test func advanceIncrementsIndex() {
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(manager.currentIndex == 0)
         manager.advance()
-        XCTAssertEqual(manager.currentIndex, 1)
+        #expect(manager.currentIndex == 1)
     }
 
-    func testAdvanceDoesNotIncrementPastEnd() {
+    @Test func advanceDoesNotIncrementPastEnd() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<total { manager.advance() }
-        // currentIndex stays at totalPrompts - 1 when isComplete flips
-        XCTAssertEqual(manager.currentIndex, total - 1)
+        #expect(manager.currentIndex == total - 1)
     }
 
-    func testIsCompleteFlipsAtLastPrompt() {
+    @Test func isCompleteFlipsAtLastPrompt() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<(total - 1) { manager.advance() }
-        XCTAssertFalse(manager.isComplete)
+        #expect(!manager.isComplete)
         manager.advance()
-        XCTAssertTrue(manager.isComplete)
+        #expect(manager.isComplete)
     }
 
-    func testGoBackDecrementsIndex() {
+    @Test func goBackDecrementsIndex() {
         UserDefaults.standard.set(3, forKey: progressKey)
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 3)
+        #expect(manager.currentIndex == 3)
         manager.goBack()
-        XCTAssertEqual(manager.currentIndex, 2)
+        #expect(manager.currentIndex == 2)
     }
 
-    func testGoBackClampsAtZero() {
+    @Test func goBackClampsAtZero() {
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 0)
         manager.goBack()
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(manager.currentIndex == 0)
     }
 
-    func testResetClearsIndexAndCompleteFlag() {
+    @Test func resetClearsIndexAndCompleteFlag() {
         UserDefaults.standard.set(5, forKey: progressKey)
         let manager = FallInLoveManager()
         manager.reset()
-        XCTAssertEqual(manager.currentIndex, 0)
-        XCTAssertFalse(manager.isComplete)
+        #expect(manager.currentIndex == 0)
+        #expect(!manager.isComplete)
     }
 
-    func testResetAfterCompletionAllowsRestart() {
+    @Test func resetAfterCompletionAllowsRestart() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<total { manager.advance() }
-        XCTAssertTrue(manager.isComplete)
+        #expect(manager.isComplete)
         manager.reset()
-        XCTAssertFalse(manager.isComplete)
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(!manager.isComplete)
+        #expect(manager.currentIndex == 0)
     }
 }


### PR DESCRIPTION
## Summary
- **Per-prompt follow-ups**: Added `make()` overload that accepts context-specific follow-up questions per prompt. Converted `couples_light_warmUp()` as the first section with 2 tailored follow-ups per prompt instead of the generic defaults.
- **Share button**: Replaced `MFMessageComposeViewController` (which was hidden on some devices due to `canSendText()` returning false) with SwiftUI `ShareLink` — the share icon now always appears during active prompts.
- **SelectionCard comments**: Added descriptive comments to `SelectionCard.swift` explaining the component's purpose, press animation, and background tint logic.

## Test plan
- [ ] Run on a physical device and verify the share icon appears in the top bar during a session
- [ ] Tap share and confirm the prompt text is pre-filled in the share sheet
- [ ] Start a Couples · Light session and tap "Go deeper" — verify follow-ups are specific to the prompt, not generic
- [ ] Verify other mode/intensity combos still show the 3 default follow-ups (unchanged sections)
- [ ] Build and confirm no warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)