### PR TITLE
Add onboarding, reflection tracking, and session polish

### DIFF
--- a/Connections.xcodeproj/project.pbxproj
+++ b/Connections.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 			path = Connections;
 			sourceTree = "<group>";
 		};
-		BB000002BB90420900000002 /* ConnectionsTests */ = {
+		BB000002BB90420900000002 /* Tests/ConnectionsTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Tests/ConnectionsTests;
 			sourceTree = SOURCE_ROOT;
@@ -63,7 +63,7 @@
 		24B9F1872F94051900486642 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				BB000002BB90420900000002 /* ConnectionsTests */,
+				BB000002BB90420900000002 /* Tests/ConnectionsTests */,
 				24B9F1862F9404EE00486642 /* ConnectionsTests.xctestplan */,
 			);
 			path = Tests;
@@ -127,7 +127,7 @@
 				BB00000BBB90420900000011 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				BB000002BB90420900000002 /* ConnectionsTests */,
+				BB000002BB90420900000002 /* Tests/ConnectionsTests */,
 			);
 			name = ConnectionsTests;
 			packageProductDependencies = (
@@ -344,6 +344,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 56X72VGLKJ;
@@ -361,6 +362,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tanner.Connections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -376,6 +378,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 56X72VGLKJ;
@@ -393,6 +396,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tanner.Connections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;

--- a/Connections/Components/AtmosphericBackground.swift
+++ b/Connections/Components/AtmosphericBackground.swift
@@ -7,83 +7,171 @@ import SwiftUI
 
 struct AtmosphericBackground: View {
     let intensity: Intensity?
+    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         ZStack {
-            switch intensity {
-            case .light:
-                ZStack {
-                    Color(red: 0.99, green: 0.96, blue: 0.90)
-                    LinearGradient(
-                        colors: [
-                            Color(red: 0.99, green: 0.97, blue: 0.93),
-                            Color(red: 0.975, green: 0.94, blue: 0.88)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                    RadialGradient(
-                        colors: [
-                            Color.white.opacity(0.07),
-                            Color.white.opacity(0.0)
-                        ],
-                        center: .top,
-                        startRadius: 0,
-                        endRadius: 500
-                    )
-                    Color.black.opacity(0.015)
-                }
-
-            case .honest:
-                ZStack {
-                    Color(red: 0.93, green: 0.96, blue: 0.99)
-                    LinearGradient(
-                        colors: [
-                            Color(red: 0.96, green: 0.98, blue: 1.0),
-                            Color(red: 0.86, green: 0.91, blue: 0.96)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                    RadialGradient(
-                        colors: [
-                            Color(red: 0.90, green: 0.95, blue: 1.0).opacity(0.13),
-                            Color.white.opacity(0.0)
-                        ],
-                        center: .top,
-                        startRadius: 0,
-                        endRadius: 500
-                    )
-                    Color.black.opacity(0.035)
-                }
-
-            case .unfiltered:
-                ZStack {
-                    Color(red: 0.97, green: 0.95, blue: 0.985)
-                    LinearGradient(
-                        colors: [
-                            Color(red: 0.98, green: 0.96, blue: 0.99),
-                            Color(red: 0.92, green: 0.90, blue: 0.96)
-                        ],
-                        startPoint: .topLeading,
-                        endPoint: .bottomTrailing
-                    )
-                    RadialGradient(
-                        colors: [
-                            Color(red: 0.94, green: 0.92, blue: 1.0).opacity(0.055),
-                            Color.white.opacity(0.0)
-                        ],
-                        center: .top,
-                        startRadius: 0,
-                        endRadius: 500
-                    )
-                    Color.black.opacity(0.02)
-                }
-
-            default:
-                Color(red: 0.99, green: 0.96, blue: 0.90)
+            if colorScheme == .dark {
+                darkBackground
+            } else {
+                lightBackground
             }
         }
         .ignoresSafeArea()
+    }
+
+    // MARK: - Light Mode
+
+    @ViewBuilder
+    private var lightBackground: some View {
+        switch intensity {
+        case .light:
+            ZStack {
+                Color(red: 0.99, green: 0.96, blue: 0.90)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.99, green: 0.97, blue: 0.93),
+                        Color(red: 0.975, green: 0.94, blue: 0.88)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color.white.opacity(0.07),
+                        Color.white.opacity(0.0)
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+                Color.black.opacity(0.015)
+            }
+
+        case .honest:
+            ZStack {
+                Color(red: 0.93, green: 0.96, blue: 0.99)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.96, green: 0.98, blue: 1.0),
+                        Color(red: 0.86, green: 0.91, blue: 0.96)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.90, green: 0.95, blue: 1.0).opacity(0.13),
+                        Color.white.opacity(0.0)
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+                Color.black.opacity(0.035)
+            }
+
+        case .unfiltered:
+            ZStack {
+                Color(red: 0.97, green: 0.95, blue: 0.985)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.98, green: 0.96, blue: 0.99),
+                        Color(red: 0.92, green: 0.90, blue: 0.96)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.94, green: 0.92, blue: 1.0).opacity(0.055),
+                        Color.white.opacity(0.0)
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+                Color.black.opacity(0.02)
+            }
+
+        default:
+            Color(red: 0.99, green: 0.96, blue: 0.90)
+        }
+    }
+
+    // MARK: - Dark Mode
+
+    @ViewBuilder
+    private var darkBackground: some View {
+        switch intensity {
+        case .light:
+            ZStack {
+                Color(red: 0.09, green: 0.08, blue: 0.07)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.10, green: 0.09, blue: 0.07),
+                        Color(red: 0.07, green: 0.06, blue: 0.05)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.14, green: 0.12, blue: 0.09).opacity(0.3),
+                        Color.clear
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+            }
+
+        case .honest:
+            ZStack {
+                Color(red: 0.07, green: 0.08, blue: 0.10)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.08, green: 0.09, blue: 0.12),
+                        Color(red: 0.06, green: 0.07, blue: 0.09)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.10, green: 0.13, blue: 0.18).opacity(0.25),
+                        Color.clear
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+            }
+
+        case .unfiltered:
+            ZStack {
+                Color(red: 0.09, green: 0.07, blue: 0.10)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.10, green: 0.08, blue: 0.12),
+                        Color(red: 0.07, green: 0.06, blue: 0.09)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.13, green: 0.10, blue: 0.16).opacity(0.25),
+                        Color.clear
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+            }
+
+        default:
+            Color(red: 0.09, green: 0.08, blue: 0.07)
+        }
     }
 }

--- a/Connections/Components/AtmosphericBackground.swift
+++ b/Connections/Components/AtmosphericBackground.swift
@@ -1,0 +1,89 @@
+//
+//  AtmosphericBackground.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct AtmosphericBackground: View {
+    let intensity: Intensity?
+
+    var body: some View {
+        ZStack {
+            switch intensity {
+            case .light:
+                ZStack {
+                    Color(red: 0.99, green: 0.96, blue: 0.90)
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.99, green: 0.97, blue: 0.93),
+                            Color(red: 0.975, green: 0.94, blue: 0.88)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    RadialGradient(
+                        colors: [
+                            Color.white.opacity(0.07),
+                            Color.white.opacity(0.0)
+                        ],
+                        center: .top,
+                        startRadius: 0,
+                        endRadius: 500
+                    )
+                    Color.black.opacity(0.015)
+                }
+
+            case .honest:
+                ZStack {
+                    Color(red: 0.93, green: 0.96, blue: 0.99)
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.96, green: 0.98, blue: 1.0),
+                            Color(red: 0.86, green: 0.91, blue: 0.96)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    RadialGradient(
+                        colors: [
+                            Color(red: 0.90, green: 0.95, blue: 1.0).opacity(0.13),
+                            Color.white.opacity(0.0)
+                        ],
+                        center: .top,
+                        startRadius: 0,
+                        endRadius: 500
+                    )
+                    Color.black.opacity(0.035)
+                }
+
+            case .unfiltered:
+                ZStack {
+                    Color(red: 0.97, green: 0.95, blue: 0.985)
+                    LinearGradient(
+                        colors: [
+                            Color(red: 0.98, green: 0.96, blue: 0.99),
+                            Color(red: 0.92, green: 0.90, blue: 0.96)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                    RadialGradient(
+                        colors: [
+                            Color(red: 0.94, green: 0.92, blue: 1.0).opacity(0.055),
+                            Color.white.opacity(0.0)
+                        ],
+                        center: .top,
+                        startRadius: 0,
+                        endRadius: 500
+                    )
+                    Color.black.opacity(0.02)
+                }
+
+            default:
+                Color(red: 0.99, green: 0.96, blue: 0.90)
+            }
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/Connections/Components/NeutralBackground.swift
+++ b/Connections/Components/NeutralBackground.swift
@@ -6,30 +6,55 @@
 import SwiftUI
 
 struct NeutralBackground: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
         ZStack {
-            Color(red: 0.98, green: 0.95, blue: 0.89)
+            if colorScheme == .dark {
+                Color(red: 0.08, green: 0.07, blue: 0.06)
 
-            LinearGradient(
-                colors: [
-                    Color(red: 0.99, green: 0.96, blue: 0.91),
-                    Color(red: 0.96, green: 0.92, blue: 0.85)
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.09, green: 0.08, blue: 0.07),
+                        Color(red: 0.06, green: 0.06, blue: 0.05)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
 
-            RadialGradient(
-                colors: [
-                    Color.white.opacity(0.08),
-                    Color.white.opacity(0.0)
-                ],
-                center: .init(x: 0.5, y: 0.2),
-                startRadius: 0,
-                endRadius: 500
-            )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.12, green: 0.10, blue: 0.08).opacity(0.25),
+                        Color.clear
+                    ],
+                    center: .init(x: 0.5, y: 0.2),
+                    startRadius: 0,
+                    endRadius: 500
+                )
+            } else {
+                Color(red: 0.98, green: 0.95, blue: 0.89)
 
-            Color.black.opacity(0.035)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.99, green: 0.96, blue: 0.91),
+                        Color(red: 0.96, green: 0.92, blue: 0.85)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+
+                RadialGradient(
+                    colors: [
+                        Color.white.opacity(0.08),
+                        Color.white.opacity(0.0)
+                    ],
+                    center: .init(x: 0.5, y: 0.2),
+                    startRadius: 0,
+                    endRadius: 500
+                )
+
+                Color.black.opacity(0.035)
+            }
         }
         .ignoresSafeArea()
     }

--- a/Connections/Components/NeutralBackground.swift
+++ b/Connections/Components/NeutralBackground.swift
@@ -21,7 +21,7 @@ struct NeutralBackground: View {
 
             RadialGradient(
                 colors: [
-                    Color.white.opacity(0.10),
+                    Color.white.opacity(0.08),
                     Color.white.opacity(0.0)
                 ],
                 center: .init(x: 0.5, y: 0.2),
@@ -29,7 +29,7 @@ struct NeutralBackground: View {
                 endRadius: 500
             )
 
-            Color.black.opacity(0.02)
+            Color.black.opacity(0.035)
         }
         .ignoresSafeArea()
     }

--- a/Connections/Components/NeutralBackground.swift
+++ b/Connections/Components/NeutralBackground.swift
@@ -1,0 +1,36 @@
+//
+//  NeutralBackground.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct NeutralBackground: View {
+    var body: some View {
+        ZStack {
+            Color(red: 0.98, green: 0.95, blue: 0.89)
+
+            LinearGradient(
+                colors: [
+                    Color(red: 0.99, green: 0.96, blue: 0.91),
+                    Color(red: 0.96, green: 0.92, blue: 0.85)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+
+            RadialGradient(
+                colors: [
+                    Color.white.opacity(0.10),
+                    Color.white.opacity(0.0)
+                ],
+                center: .init(x: 0.5, y: 0.2),
+                startRadius: 0,
+                endRadius: 500
+            )
+
+            Color.black.opacity(0.02)
+        }
+        .ignoresSafeArea()
+    }
+}

--- a/Connections/Components/SelectionCard.swift
+++ b/Connections/Components/SelectionCard.swift
@@ -5,14 +5,21 @@
 
 import SwiftUI
 
+/// A reusable tappable card used throughout selection screens (mode, intensity, topic, etc.).
+/// Displays a title and subtitle with an optional tint color and a subtle press animation.
 struct SelectionCard: View {
     let title: String
     let subtitle: String
     var tintColor: Color? = nil
     let action: () -> Void
 
+    /// Tracks whether the user is currently pressing the card, driving the visual feedback.
     @State private var isPressed = false
 
+    /// Resolves the card's background color.
+    /// When a `tintColor` is provided, it uses that color at a low opacity;
+    /// otherwise it falls back to a neutral primary tint.
+    /// Opacity increases slightly while the card is pressed to give tactile feedback.
     private var backgroundFill: Color {
         if let tint = tintColor {
             return tint.opacity(isPressed ? 0.22 : 0.14)
@@ -41,10 +48,14 @@ struct SelectionCard: View {
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .fill(backgroundFill)
             )
+            // Scale down slightly while pressed to reinforce the tap interaction.
             .scaleEffect(isPressed ? 0.98 : 1.0)
             .animation(.easeOut(duration: 0.15), value: isPressed)
         }
         .buttonStyle(.plain)
+        // A zero-distance drag gesture is used instead of ButtonStyle to track
+        // press/release independently, allowing the scale + opacity animation
+        // to play without interfering with the button's own tap handling.
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { _ in isPressed = true }

--- a/Connections/Components/SelectionCard.swift
+++ b/Connections/Components/SelectionCard.swift
@@ -18,6 +18,7 @@ struct SelectionCard: View {
 
     /// Tracks whether the user is currently pressing the card, driving the visual feedback.
     @State private var isPressed = false
+    @Environment(\.colorScheme) private var colorScheme
 
     /// Flat background fill for the default (non-glass) mode.
     private var backgroundFill: Color {
@@ -41,11 +42,11 @@ struct SelectionCard: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
                         .font(.system(size: 17, weight: .medium))
-                        .foregroundColor(glassEffect ? Color.black.opacity(0.96) : Color.primary)
+                        .foregroundColor(glassEffect && colorScheme == .light ? Color.black.opacity(0.96) : Color.primary)
 
                     Text(subtitle)
                         .font(.system(size: 14))
-                        .foregroundColor(glassEffect ? Color.black.opacity(0.46) : Color.secondary)
+                        .foregroundColor(glassEffect && colorScheme == .light ? Color.black.opacity(0.46) : Color.secondary)
                 }
 
                 Spacer()
@@ -86,7 +87,8 @@ struct SelectionCard: View {
             .fill(.ultraThinMaterial)
             .overlay(shape.fill(tint.opacity(tintOpacity)))
             .overlay(
-                shape.fill(
+                colorScheme == .light
+                ? shape.fill(
                     LinearGradient(
                         colors: [
                             Color.white.opacity(isSelected ? 0.28 : 0.20),
@@ -96,13 +98,14 @@ struct SelectionCard: View {
                         endPoint: .bottomTrailing
                     )
                 )
+                : nil
             )
             .overlay(
                 shape.strokeBorder(
                     LinearGradient(
                         colors: [
-                            Color.white.opacity(isSelected ? 0.35 : 0.16),
-                            Color.white.opacity(isSelected ? 0.12 : 0.04)
+                            Color.white.opacity(colorScheme == .dark ? (isSelected ? 0.12 : 0.06) : (isSelected ? 0.35 : 0.16)),
+                            Color.white.opacity(colorScheme == .dark ? (isSelected ? 0.04 : 0.02) : (isSelected ? 0.12 : 0.04))
                         ],
                         startPoint: .topLeading,
                         endPoint: .bottomTrailing

--- a/Connections/Components/SelectionCard.swift
+++ b/Connections/Components/SelectionCard.swift
@@ -7,24 +7,32 @@ import SwiftUI
 
 /// A reusable tappable card used throughout selection screens (mode, intensity, topic, etc.).
 /// Displays a title and subtitle with an optional tint color and a subtle press animation.
+/// When `glassEffect` is enabled, renders with a translucent layered-glass treatment.
 struct SelectionCard: View {
     let title: String
     let subtitle: String
     var tintColor: Color? = nil
+    var isSelected: Bool = false
+    var glassEffect: Bool = false
     let action: () -> Void
 
     /// Tracks whether the user is currently pressing the card, driving the visual feedback.
     @State private var isPressed = false
 
-    /// Resolves the card's background color.
-    /// When a `tintColor` is provided, it uses that color at a low opacity;
-    /// otherwise it falls back to a neutral primary tint.
-    /// Opacity increases slightly while the card is pressed to give tactile feedback.
+    /// Flat background fill for the default (non-glass) mode.
     private var backgroundFill: Color {
         if let tint = tintColor {
-            return tint.opacity(isPressed ? 0.22 : 0.14)
+            let opacity = isSelected ? 0.28 : (isPressed ? 0.22 : 0.14)
+            return tint.opacity(opacity)
         }
-        return Color.primary.opacity(isPressed ? 0.08 : 0.04)
+        let opacity = isSelected ? 0.12 : (isPressed ? 0.08 : 0.04)
+        return Color.primary.opacity(opacity)
+    }
+
+    private var cardScale: CGFloat {
+        if isPressed { return 0.98 }
+        if glassEffect && isSelected { return 1.025 }
+        return 1.0
     }
 
     var body: some View {
@@ -33,33 +41,80 @@ struct SelectionCard: View {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
                         .font(.system(size: 17, weight: .medium))
-                        .foregroundStyle(.primary)
+                        .foregroundColor(glassEffect ? Color.black.opacity(0.96) : Color.primary)
 
                     Text(subtitle)
                         .font(.system(size: 14))
-                        .foregroundStyle(.secondary)
+                        .foregroundColor(glassEffect ? Color.black.opacity(0.46) : Color.secondary)
                 }
 
                 Spacer()
             }
             .padding(.horizontal, 20)
             .padding(.vertical, 18)
-            .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(backgroundFill)
-            )
-            // Scale down slightly while pressed to reinforce the tap interaction.
-            .scaleEffect(isPressed ? 0.98 : 1.0)
-            .animation(.easeOut(duration: 0.15), value: isPressed)
+            .frame(minHeight: glassEffect ? 120 : 0)
+            .background {
+                if glassEffect {
+                    glassBackground
+                } else {
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(backgroundFill)
+                }
+            }
+            .scaleEffect(cardScale)
+            .animation(.easeInOut(duration: 0.16), value: isSelected)
+            .animation(.easeInOut(duration: 0.16), value: isPressed)
         }
         .buttonStyle(.plain)
-        // A zero-distance drag gesture is used instead of ButtonStyle to track
-        // press/release independently, allowing the scale + opacity animation
-        // to play without interfering with the button's own tap handling.
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { _ in isPressed = true }
                 .onEnded { _ in isPressed = false }
         )
+    }
+
+    // MARK: - Glass Background
+
+    /// Layered glass surface: material → tint → white highlight → border stroke → shadow.
+    @ViewBuilder
+    private var glassBackground: some View {
+        let tint = tintColor ?? Color.primary
+        let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
+        let tintOpacity = isSelected ? 0.30 : (isPressed ? 0.18 : 0.12)
+
+        shape
+            .fill(.ultraThinMaterial)
+            .overlay(shape.fill(tint.opacity(tintOpacity)))
+            .overlay(
+                shape.fill(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(isSelected ? 0.28 : 0.20),
+                            Color.white.opacity(isSelected ? 0.02 : 0.00)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    )
+                )
+            )
+            .overlay(
+                shape.strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color.white.opacity(isSelected ? 0.35 : 0.16),
+                            Color.white.opacity(isSelected ? 0.12 : 0.04)
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: isSelected ? 1.4 : 1
+                )
+            )
+            .shadow(
+                color: Color.black.opacity(isSelected ? 0.14 : 0.06),
+                radius: isSelected ? 14 : 6,
+                x: 0,
+                y: isSelected ? 5 : 3
+            )
     }
 }

--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -53,7 +53,7 @@ enum AppColor {
     // Accent / interactive
     static let accent = Color(.darkGray)
     static let accentText = Color.white
-    static let toggleTint = Color(red: 0.45, green: 0.42, blue: 0.38)
+    static let toggleTint = Color.blue
 
     // Borders and shadows
     static let subtleStroke = Color.primary.opacity(0.06)

--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -11,34 +11,34 @@ import SwiftUI
 // MARK: - Design Tokens
 
 enum AppFont {
-    static func screenTitle(_ size: CGFloat = 28) -> Font {
+    static func screenTitle(_ size: CGFloat = 32) -> Font {
         .system(size: size, weight: .regular, design: .serif)
     }
-    static func heroTitle(_ size: CGFloat = 44) -> Font {
+    static func heroTitle(_ size: CGFloat = 50) -> Font {
         .system(size: size, weight: .regular, design: .serif)
     }
-    static func promptText(_ size: CGFloat = 24) -> Font {
+    static func promptText(_ size: CGFloat = 28) -> Font {
         .system(size: size, weight: .regular, design: .serif)
     }
-    static func buttonPrimary(_ size: CGFloat = 17) -> Font {
+    static func buttonPrimary(_ size: CGFloat = 20) -> Font {
         .system(size: size, weight: .semibold)
     }
-    static func buttonSecondary(_ size: CGFloat = 15) -> Font {
+    static func buttonSecondary(_ size: CGFloat = 17) -> Font {
         .system(size: size, weight: .medium)
     }
-    static func subtitle(_ size: CGFloat = 15) -> Font {
+    static func subtitle(_ size: CGFloat = 17) -> Font {
         .system(size: size)
     }
-    static func label(_ size: CGFloat = 14) -> Font {
+    static func label(_ size: CGFloat = 16) -> Font {
         .system(size: size, weight: .medium)
     }
-    static func caption(_ size: CGFloat = 13) -> Font {
+    static func caption(_ size: CGFloat = 15) -> Font {
         .system(size: size)
     }
-    static func detail(_ size: CGFloat = 12) -> Font {
+    static func detail(_ size: CGFloat = 14) -> Font {
         .system(size: size)
     }
-    static func fine(_ size: CGFloat = 11) -> Font {
+    static func fine(_ size: CGFloat = 13) -> Font {
         .system(size: size)
     }
 }

--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -72,6 +72,23 @@ enum AppColor {
     static let chipSelected = accent
     static let chipAvailable = surfacePrimary
     static let chipLocked = surfaceMuted
+
+    // MARK: - Dark-mode adaptive helpers
+
+    /// Primary button background — dark gray in light, subtle white in dark.
+    static func primaryButtonBg(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.white.opacity(0.12) : Color(.darkGray)
+    }
+
+    /// Secondary/card surface — slightly more visible in dark mode.
+    static func surface(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.white.opacity(0.07) : Color.primary.opacity(0.04)
+    }
+
+    /// Subtle surface for muted elements in dark mode.
+    static func surfaceSubtle(_ colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? Color.white.opacity(0.04) : Color.primary.opacity(0.02)
+    }
 }
 
 enum AppSpacing {
@@ -109,24 +126,26 @@ enum AppAnimation {
 // MARK: - Reusable View Modifiers
 
 struct PrimaryButtonStyle: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
     func body(content: Content) -> some View {
         content
             .font(AppFont.buttonPrimary())
             .foregroundColor(AppColor.primaryButtonText)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 18)
-            .background(AppColor.primaryButton, in: .capsule)
+            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
     }
 }
 
 struct SecondaryButtonStyle: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
     func body(content: Content) -> some View {
         content
             .font(AppFont.buttonSecondary())
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(AppColor.secondaryButtonFill, in: .capsule)
+            .background(AppColor.surface(colorScheme), in: .capsule)
     }
 }
 

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -132,84 +132,84 @@ private extension PromptBank {
                 "Why do you think that one matters so much to you?",
                 "What does it reveal about the way you like life to feel?",
             ]),
-            ("What do you spend way too much money on without any regret?", .dailyLife, [
+            ("What do you spend a lot of money on without any regrets?", .dailyLife, [
                 "What does spending on that give you beyond the thing itself?",
-                "What would it be hard to replace that feeling with?",
+                "What would it be hard to replace that feeling with anything else?",
             ]),
-            ("What do you know you make a bigger deal about than you should?", .communication, [
+            ("What do you to excited about than you probably shouldn't?", .communication, [
                 "What does it touch in you that makes it feel bigger than it is?",
                 "What are you usually needing in those moments?",
             ]),
             ("What would you love to be able to spend more freely on?", .dailyLife, [
-                "What would that say about the kind of life you want?",
-                "What feeling are you hoping more freedom there would give you?",
+                "How would that change things for you or in your life?",
+                "What feeling are you hoping more of that this spending would provide you?",
             ]),
-            ("Are you more of a host or a guest — and what does that say about you?", .dailyLife, [
+            ("Do you like being a host or would your rather be the guest?", .dailyLife, [
                 "What part of that role feels most natural to you?",
-                "What does that role let you avoid or enjoy most?",
+                "What does that role let you avoid?",
             ]),
             ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife, [
                 "What do those choices tell you about what keeps you steady?",
                 "Which one would be the hardest to go without, and why?",
             ]),
-            ("What's your go-to midnight snack raid?", .dailyLife, [
+            ("What's your go-to midnight snack?", .dailyLife, [
                 "What mood are you usually in when that craving hits?",
-                "What do you think you're really reaching for in that moment?",
+                "Are there more positives to this snack adventure than negatives?",
             ]),
             ("Who or what have you been quietly fascinated by lately?", .intimacy, [
-                "What is it about them or it that keeps pulling you in?",
-                "Do you think it connects to something you're wanting more of in your own life?",
+                "What about them or it attracts you?",
+                "Does it help motivate or give you pleasure?",
             ]),
             ("What's the most disastrous date you've ever been on?", .dailyLife, [
                 "What made it go wrong so fast?",
-                "What did that experience teach you about yourself or dating?",
+                "What did that experience teach you about yourself and or dating?",
             ]),
             ("What's your favorite real love story — yours or someone else's?", .intimacy, [
                 "What part of that story moves you the most?",
-                "What does it reveal about the kind of love you believe in?",
+                "Are there aspects of this love story that exist in your life?",
             ]),
             ("What do you need most from me when you're not feeling well?", .communication, [
                 "What helps you feel cared for instead of just looked after?",
-                "What's easy for me to miss in those moments?",
+                "What's easy for me to miss in those moments that would make you happy?",
             ]),
-            ("What are you surprisingly high-maintenance about?", .dailyLife, [
-                "What makes that one worth the extra fuss to you?",
-                "Do you think it's more about comfort, control, or feeling cared for?",
+            ("What do you feel is high-maintenance about you?", .dailyLife, [
+                "What makes that one thing worth the extra effort for you?",
+                "Do you think it's about comfort, control, or feeling cared for?",
             ]),
-            ("What are you a complete control freak about?", .identity, [
-                "What feels at risk when you're not in control there?",
-                "Where do you think that need for control comes from?",
+            ("What are you a often complete control freak about?", .identity, [
+                "What feels at risk when you're not in control?",
+                "Why do you think you control over this for?",
             ]),
-            ("What's the one thing you absolutely cannot be teased about?", .communication, [
-                "What makes that one land differently than other jokes?",
-                "What does it touch in you that's still tender?",
+            ("What's the one thing you absolutely do not like being teased about?", .communication, [
+                "Why does that cause you discomfort?",
+                "What part of your past does it touch in you that's still tender?",
             ]),
-            ("What's basically impossible for you to say no to?", .communication, [
-                "What makes it so hard to resist?",
-                "What need in you does saying yes satisfy?",
+            ("What or who is it basically impossible for you to say no to?", .communication, [
+                "Is this a wonderful guilty pleasure?",
+                "Do you feel pressure to always say yes?",
             ]),
             ("What's something about your partner that you fell in love with all over again recently?", .appreciation, [
                 "What was it about that moment that hit you so strongly?",
                 "What did it remind you of about why you chose them?",
             ]),
-            ("I feel most sensual when…", .sex, [
-                "What helps you settle into that feeling most naturally?",
-                "What tends to pull you away from it?",
+            ("You feel most sensual when I…", .sex, [
+                "What can I do to help you settle into that feeling most naturally?",
+                "Is there anything I do that tends to pull you away from it?",
             ]),
-            ("I feel most attractive when…", .sex, [
-                "What is it about that moment that makes you feel seen that way?",
-                "How much of that feeling comes from you versus someone else's response?",
+            ("You feel most attractive when I do or say…", .sex, [
+                "When was the last time I did or said that?",
+                "Can you help me remember and recognize when I do it correctly?",
             ]),
             ("What's a song that always makes you think of us?", .appreciation, [
                 "What memory or feeling does it bring back first?",
-                "What part of us does that song seem to capture?",
+                "What part of our relationship does that song seem to capture?",
             ]),
             ("What's the best surprise you've ever gotten from someone you love?", .appreciation, [
                 "What made that surprise feel so meaningful to you?",
                 "What did it show you about how that person knew you?",
             ]),
-            ("What's your idea of a perfect lazy Sunday together?", .dailyLife, [
-                "What part of that day feels most nourishing to you?",
+            ("What's your idea of a perfect lazy vacation day together?", .dailyLife, [
+                "What can I do to make those days feels most nourishing to you?",
                 "What does that version of Sunday give you that everyday life doesn't?",
             ]),
             ("What's something small I do that always makes you smile?", .appreciation, [
@@ -217,28 +217,36 @@ private extension PromptBank {
                 "What does it make you feel in that moment?",
             ]),
             ("If we could travel anywhere tomorrow, where would you want to go?", .dailyLife, [
-                "What about that place feels right for us?",
+                "Why do you want to go there with me?",
                 "What are you hoping we'd feel there together?",
             ]),
             ("What's a hobby or skill you've always wanted us to try together?", .growth, [
-                "What do you imagine that bringing out in us?",
-                "What makes doing it together matter more than doing it alone?",
+                "How do you imagine doing that together will bring us closer together?",
+                "Why do you think doing it together matters more than doing it alone?",
             ]),
             ("What's the most fun we've ever had doing something totally unplanned?", .past, [
-                "What do you think made that moment feel so alive?",
-                "What does it tell you about us at our best?",
+                "Do you want to do more spontaneous activities?",
+                "Would you like me to surprise you with more spontaneous activities, and what kind?",
             ]),
             ("What's a movie or show that reminds you of our relationship?", .dailyLife, [
-                "What dynamic or moment in it feels most like us?",
-                "Is that comparison sweet, funny, or a little too accurate?",
+                "What's your favorite part of the movie and why?",
+                "What can I do to help bring more of that favorite part into our relationship?",
             ]),
             ("What's your love language when you're stressed versus when you're happy?", .communication, [
-                "How can someone tell which version of you they're getting?",
+                "Help me understand how to speak it or what to do to help you during these times?",
                 "What do you most want from me when you're in each state?",
             ]),
             ("What's a tradition you'd love for us to start?", .values, [
                 "What do you think that tradition would create between us over time?",
-                "Why does that kind of ritual matter to you?",
+                "Is there anything in your life that makes that kind of ritual important to you?",
+            ]),
+            ("What's a small thing that can instantly shift your mood for the better?", .emotions, [
+                "Does your partner know about that one?",
+                "What's the opposite — the tiny thing that can ruin a good mood?",
+            ]),
+            ("What's the silliest thing we've ever actually disagreed about?", .conflict, [
+                "What made it feel like a bigger deal in the moment?",
+                "Can you laugh about it now?",
             ]),
         ], mode: .couples, intensity: .light, depth: .warmUp)
     }
@@ -742,6 +750,10 @@ private extension PromptBank {
                 "What does the embarrassment protect?",
                 "Would telling someone actually change anything?",
             ]),
+            ("What's a household habit of mine that quietly drives you crazy?", .dailyLife, [
+                "Have you ever tried to bring it up, or do you just absorb it?",
+                "What would it mean if I actually changed it?",
+            ]),
         ], mode: .couples, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -784,6 +796,10 @@ private extension PromptBank {
             ("The word \u{201C}forbidden\u{201D} makes me think of…", .sex, [
                 "What is it about that edge that pulls you in?",
                 "How do you feel about having that thought?",
+            ]),
+            ("What's an invisible expectation you carry at home that I've never acknowledged?", .dailyLife, [
+                "How long have you been holding that without saying anything?",
+                "What would it look like if I actually saw it?",
             ]),
         ], mode: .couples, intensity: .unfiltered, depth: .realTalk)
     }
@@ -839,6 +855,10 @@ private extension PromptBank {
             ("A recurring fantasy I've had is…", .sex, [
                 "What do you think that fantasy is really reaching for?",
                 "How do you feel about the fact that it keeps coming back?",
+            ]),
+            ("What part of our daily life together feels like it's slowly wearing you down?", .dailyLife, [
+                "When did you first notice the weight of it?",
+                "What would need to change for it to feel sustainable again?",
             ]),
         ], mode: .couples, intensity: .unfiltered, depth: .deepDive)
     }
@@ -966,6 +986,10 @@ private extension PromptBank {
             ("What's something you only do when nobody's watching?", .identity, [
                 "Why do you keep it private?",
                 "What would happen if someone caught you?",
+            ]),
+            ("What's a feeling you've had recently that caught you off guard?", .emotions, [
+                "What do you think triggered it?",
+                "Did you tell anyone about it or just sit with it?",
             ]),
         ], mode: .friends, intensity: .light, depth: .warmUp)
     }
@@ -1136,6 +1160,10 @@ private extension PromptBank {
                 "What made you step up in that moment?",
                 "How did it feel to be that person for them?",
             ]),
+            ("How much effort does it actually take to keep your friendships going right now?", .dailyLife, [
+                "Which ones feel easy and which ones feel like work?",
+                "What does that effort say about where you are in life?",
+            ]),
         ], mode: .friends, intensity: .honest, depth: .warmUp)
     }
 
@@ -1207,6 +1235,10 @@ private extension PromptBank {
                 "What kept pulling you back into the same mistake?",
                 "What finally made it stick?",
             ]),
+            ("When was the last time you felt like a friend wasn't really there when it mattered?", .dailyLife, [
+                "Did you say anything or just let it go?",
+                "How did it change what you expect from that friendship?",
+            ]),
         ], mode: .friends, intensity: .honest, depth: .realTalk)
     }
 
@@ -1225,6 +1257,10 @@ private extension PromptBank {
             ("Who's a friend you haven't shown up for the way you should have?", .conflict, [
                 "What got in the way?",
                 "If you could go back to that moment, what would you do differently?",
+            ]),
+            ("How do you decide which friendships are worth the effort when life gets overwhelming?", .dailyLife, [
+                "Have you ever let a friendship slip away that you now regret?",
+                "What does it take for someone to stay in your inner circle?",
             ]),
         ], mode: .friends, intensity: .honest, depth: .deepDive)
     }
@@ -1353,6 +1389,10 @@ private extension PromptBank {
                 "What's the honest answer you'd have to give?",
                 "What makes that truth feel so dangerous?",
             ]),
+            ("What's something you do in your daily routine that you know is avoidance?", .dailyLife, [
+                "What are you actually avoiding when you do it?",
+                "What would your day look like if you stopped?",
+            ]),
         ], mode: .friends, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -1388,6 +1428,10 @@ private extension PromptBank {
                 "When has your loyalty been tested the hardest?",
                 "Where do you draw the line between loyalty and self-respect?",
             ]),
+            ("How honest are you about how much emotional labor you actually put into your friendships?", .dailyLife, [
+                "Who gets the most from you, and do they even know it?",
+                "What would happen if you stopped carrying that weight?",
+            ]),
         ], mode: .friends, intensity: .unfiltered, depth: .realTalk)
     }
 
@@ -1406,6 +1450,10 @@ private extension PromptBank {
             ("When did someone break your trust in a way that changed how you operate?", .conflict, [
                 "What defense did you build because of it?",
                 "Has anyone since earned back the kind of trust you lost?",
+            ]),
+            ("What's a way you've quietly stopped making effort in a friendship without ever saying why?", .dailyLife, [
+                "Was it a conscious decision or did it just happen?",
+                "Do you think they noticed, and does that matter to you?",
             ]),
         ], mode: .friends, intensity: .unfiltered, depth: .deepDive)
     }
@@ -1533,6 +1581,14 @@ private extension PromptBank {
             ("Who in your family always knows how to make you feel better?", .appreciation, [
                 "What do they do that works so well?",
                 "Do they know they have that power?",
+            ]),
+            ("What's something your family always talks about at every gathering?", .communication, [
+                "Is it something everyone enjoys or just a habit at this point?",
+                "What topic do you wish would come up more instead?",
+            ]),
+            ("What's something your family playfully argues about every time you get together?", .conflict, [
+                "Does anyone actually get heated or is it all in good fun?",
+                "Which side are you always on?",
             ]),
         ], mode: .family, intensity: .light, depth: .warmUp)
     }
@@ -1711,6 +1767,10 @@ private extension PromptBank {
                 "What sparked that pride?",
                 "Do you think your family knows you feel that way?",
             ]),
+            ("What's a family obligation you show up for even though it drains you?", .dailyLife, [
+                "What keeps you going through the motions?",
+                "What would happen if you were honest about how it feels?",
+            ]),
         ], mode: .family, intensity: .honest, depth: .warmUp)
     }
 
@@ -1750,6 +1810,10 @@ private extension PromptBank {
                 "What principle are you standing on?",
                 "Does anyone in your life still hold it against you?",
             ]),
+            ("Who in your family carries the most invisible labor, and does anyone acknowledge it?", .dailyLife, [
+                "How did that role get assigned?",
+                "What would change if they stopped doing it for a week?",
+            ]),
         ], mode: .family, intensity: .honest, depth: .realTalk)
     }
 
@@ -1780,6 +1844,10 @@ private extension PromptBank {
             ("What would you go back and whisper to your younger self?", .past, [
                 "What's the one thing that kid needed to hear most?",
                 "Do you think they would have listened?",
+            ]),
+            ("What's a routine your family had that shaped you more than anyone realizes?", .dailyLife, [
+                "Was it something intentional or just the way things were?",
+                "How does it still show up in your life now?",
             ]),
         ], mode: .family, intensity: .honest, depth: .deepDive)
     }
@@ -1908,6 +1976,10 @@ private extension PromptBank {
                 "What would acknowledging it require from everyone?",
                 "Do you think anyone else in the family sees it too?",
             ]),
+            ("What's a family gathering tradition that feels more like a performance than a real connection?", .dailyLife, [
+                "Who is the performance really for?",
+                "What would it look like if everyone just dropped the act?",
+            ]),
         ], mode: .family, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -1930,6 +2002,10 @@ private extension PromptBank {
             ("What's a question you've always wanted to ask your parents but never have?", .communication, [
                 "What are you afraid the answer might be?",
                 "What would it change if you finally asked?",
+            ]),
+            ("What household role were you assigned growing up that you never actually agreed to?", .dailyLife, [
+                "How did it shape the way you show up in your family now?",
+                "Have you ever tried to hand it back?",
             ]),
         ], mode: .family, intensity: .unfiltered, depth: .realTalk)
     }
@@ -1965,6 +2041,10 @@ private extension PromptBank {
             ("What's a conversation from your past you wish you could have one more time?", .communication, [
                 "What would you say differently?",
                 "What do you wish you had heard?",
+            ]),
+            ("What's a practical tension in your family that everyone just works around instead of fixing?", .dailyLife, [
+                "What would it take to actually address it head-on?",
+                "Who benefits most from leaving it unresolved?",
             ]),
         ], mode: .family, intensity: .unfiltered, depth: .deepDive)
     }
@@ -2092,6 +2172,14 @@ private extension PromptBank {
             ("What's something you do purely for the joy of it, with no goal attached?", .dailyLife, [
                 "How did you find that thing?",
                 "What does it give you that goal-driven things don't?",
+            ]),
+            ("What's something you've been meaning to say to someone but keep putting off?", .communication, [
+                "What's making it hard to bring up?",
+                "How do you think you'd feel once you finally said it?",
+            ]),
+            ("What's a small disagreement you had recently that stuck with you longer than it should have?", .conflict, [
+                "What do you think it was really about underneath?",
+                "Did you resolve it or just let it fade?",
             ]),
         ], mode: .soloReflection, intensity: .light, depth: .warmUp)
     }
@@ -2479,6 +2567,14 @@ private extension PromptBank {
                 "Is this something you can change or do you need help from others? Who?",
                 "What would healing actually require and what would be the benefits?",
             ]),
+            ("What's a habit you keep returning to that you know isn't good for you?", .dailyLife, [
+                "What does it give you in the moment that's hard to get elsewhere?",
+                "What would your life actually look like if you finally stopped?",
+            ]),
+            ("What's something you've wanted to say to someone for a long time but know you probably never will?", .communication, [
+                "What would saying it actually cost you?",
+                "What does keeping it inside cost you instead?",
+            ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -2513,6 +2609,10 @@ private extension PromptBank {
             ("When did you first realize that you will one day die?", .emotions, [
                 "How old were you, and what made that realization land?",
                 "Does that awareness change how you think about your life now?",
+            ]),
+            ("How much of your daily life is built around avoiding things you don't want to feel?", .dailyLife, [
+                "What feelings are you most skilled at dodging?",
+                "What would a day without that avoidance actually look like?",
             ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .realTalk)
     }
@@ -2580,6 +2680,10 @@ private extension PromptBank {
             ("What principle would you never compromise on, no matter what?", .values, [
                 "When has that principle been tested the hardest?",
                 "What does it protect in you that nothing else can?",
+            ]),
+            ("What part of your daily routine is actually a coping mechanism you've never examined?", .dailyLife, [
+                "When did it start, and what were you going through at the time?",
+                "What would you have to face if you took it away?",
             ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .deepDive)
     }

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -37,9 +37,9 @@ struct PromptBank {
 private extension PromptBank {
 
     static let defaultFollowUps = [
-        FollowUp(text: "Why that?"),
-        FollowUp(text: "Has that always been true?"),
-        FollowUp(text: "What changed?")
+        FollowUp(text: "Why that?", style: .origin),
+        FollowUp(text: "Has that always been true?", style: .meaning),
+        FollowUp(text: "What changed?", style: .impact)
     ]
 
     static func buildPrompts() -> [Prompt] {
@@ -101,8 +101,15 @@ private extension PromptBank {
     }
 
     /// Overload that accepts per-prompt follow-up strings instead of using the global defaults.
+    /// Auto-assigns styles cycling through: origin, impact, meaning, need, tension.
     static func make(_ entries: [(String, Topic, [String])], mode: Mode, intensity: Intensity, depth: DepthLevel) -> [Prompt] {
-        entries.map { Prompt(text: $0.0, mode: mode, intensity: intensity, depthLevel: depth, topic: $0.1, followUps: $0.2.map { FollowUp(text: $0) }) }
+        let autoStyles: [FollowUpStyle] = [.origin, .impact, .meaning, .need, .tension]
+        return entries.map { entry in
+            let followUps = entry.2.enumerated().map { (i, text) in
+                FollowUp(text: text, style: autoStyles[i % autoStyles.count])
+            }
+            return Prompt(text: entry.0, mode: mode, intensity: intensity, depthLevel: depth, topic: entry.1, followUps: followUps)
+        }
     }
 
     // MARK: - Couples · Light · Warm Up
@@ -240,19 +247,58 @@ private extension PromptBank {
 
     static func couples_light_realTalk() -> [Prompt] {
         make([
-            ("What's the most unexpected compliment you've ever received?", .appreciation),
-            ("When was the last time you got completely lost in a great experience?", .dailyLife),
-            ("What's the funniest thing that's happened to us that we never get tired of retelling?", .dailyLife),
-            ("Something I do that turns me off is…", .sex),
-            ("Something that tends to turn me on is…", .sex),
-            ("One of the most sensual experiences I've had that didn't involve sex was…", .sex),
-            ("I still remember a time I felt deeply desired when…", .sex),
-            ("An intimate memory that still makes me cringe a little is…", .sex),
-            ("One of the most memorable intimate moments I've had was…", .sex),
-            ("Something I do that helps make intimacy more engaging is…", .sex),
-            ("An embarrassing intimate moment I've experienced was…", .sex),
-            ("What makes me feel most desired by you is…", .sex),
-            ("A moment I felt truly connected to you physically was…", .sex),
+            ("What's the most unexpected compliment you've ever received?", .appreciation, [
+                "Why do you think that one suprised you so much?",
+                "What did it make you feel about yourself in that moment?",
+            ]),
+            ("When was the last time you were completely lost in a great experience?", .dailyLife, [
+                "What was it about that moment that pulled you all the way in?",
+                "How often do you let yourself get that absorbed in something?",
+            ]),
+            ("What's the funniest thing that's happened to us that we never get tired of retelling?", .dailyLife, [
+                "Why do you think that story is so endearing to us?",
+                "What does the reason we laugh about it say about us?",
+            ]),
+            ("Something I do that turns me off is…", .sex, [
+                "Why do you think it turns you off?",
+                "Is that something you'd want to talk through or just have me know?",
+            ]),
+            ("Something that tends to turn me on is…", .sex, [
+                "When did you first notice that about yourself?",
+                "What is it about that thing that gets to you?",
+            ]),
+            ("One of the most sensual experiences I've had that didn't involve sex was…", .sex, [
+                "What made that moment feel so charged?",
+                "What does sensuality mean to you outside the bedroom?",
+            ]),
+            ("I still remember a time I felt deeply desired when…", .sex, [
+                "What about that moment made you feel so wanted?",
+                "How does feeling desired change the way you show up?",
+            ]),
+            ("An intimate memory that still makes me cringe a little is…", .sex, [
+                "What makes it cringeworthy — and do you laugh about it now?",
+                "Did it change anything about how you approach intimacy?",
+            ]),
+            ("One of the most memorable intimate moments I've had was…", .sex, [
+                "What made that one stand out above the rest?",
+                "What do you think made the connection feel so strong?",
+            ]),
+            ("Something I do that helps make intimacy more engaging is…", .sex, [
+                "How did you figure that out about yourself?",
+                "What does it feel like when that effort lands?",
+            ]),
+            ("An embarrassing intimate moment I've experienced was…", .sex, [
+                "How did you recover from it in the moment?",
+                "Did it end up bringing you closer or making things awkward?",
+            ]),
+            ("What makes me feel most desired by you is…", .sex, [
+                "What is it about that gesture that gets through to you?",
+                "Do you think I know how much that matters to you?",
+            ]),
+            ("A moment I felt truly connected to you physically was…", .sex, [
+                "What made the emotional and physical feel so aligned?",
+                "What do you think creates that kind of connection between us?",
+            ]),
         ], mode: .couples, intensity: .light, depth: .realTalk)
     }
 
@@ -260,10 +306,22 @@ private extension PromptBank {
 
     static func couples_light_deepDive() -> [Prompt] {
         make([
-            ("What moment made you think — okay, this person really gets me?", .intimacy),
-            ("What's something about us you'd never want to change?", .appreciation),
-            ("How do you think we've changed each other for the better?", .growth),
-            ("What's your favorite chapter of our story so far?", .past),
+            ("What moment made you think — okay, this person really gets me?", .intimacy, [
+                "What did I do different from others that made you feel like that?",
+                "How did that moment change the way you saw me?",
+            ]),
+            ("What's something about us you'd never want to change?", .appreciation, [
+                "What would it feel like if that thing started to shift?",
+                "Do you think we both see that the same way?",
+            ]),
+            ("How do you think we've changed each other for the better?", .growth, [
+                "Is there a version of yourself before us that you don't miss?",
+                "What growth in me are you most proud of?",
+            ]),
+            ("What's your favorite chapter of our story so far?", .past, [
+                "What made that chapter feel so special compared to the rest?",
+                "What kind of chapter do you hope comes next?",
+            ]),
         ], mode: .couples, intensity: .light, depth: .deepDive)
     }
 
@@ -271,36 +329,126 @@ private extension PromptBank {
 
     static func couples_honest_warmUp() -> [Prompt] {
         make([
-            ("What's been on your mind late at night recently?", .emotions),
-            ("What's weighing on you the most right now?", .emotions),
-            ("When was the last time you got way more upset than the situation deserved?", .conflict),
-            ("I feel most sensual when…", .sex),
-            ("I feel most attractive when…", .sex),
-            ("What's something you wish I understood better about you?", .communication),
-            ("What's a fear you haven't told me about?", .emotions),
-            ("When do you feel most disconnected from me?", .intimacy),
-            ("What's something I do that makes you feel truly seen?", .appreciation),
-            ("What's a part of your day you wish we could share more?", .dailyLife),
-            ("What's a habit of mine that quietly frustrates you?", .conflict),
-            ("What's something you've been meaning to apologize for?", .conflict),
-            ("When do you feel the safest with me?", .intimacy),
-            ("What's something about our relationship that surprised you?", .growth),
-            ("What's something you admire about the way I love you?", .appreciation),
-            ("What's a conversation we had that stuck with you?", .communication),
-            ("What do you think we're both avoiding right now?", .communication),
-            ("When was the last time I really made you laugh?", .appreciation),
-            ("What's a way I've helped you grow that you haven't mentioned?", .growth),
-            ("What do you wish we did more of together?", .dailyLife),
-            ("What's something about our early days that you miss?", .past),
-            ("How do you feel about how we handle money together?", .values),
-            ("What's a boundary you need me to respect more?", .communication),
-            ("What's something you're proud of us for getting through?", .growth),
-            ("When do you feel most like yourself around me?", .identity),
-            ("What's an insecurity that still shows up in our relationship?", .emotions),
-            ("What's something I said recently that meant more than I probably realized?", .appreciation),
-            ("What do you need from me that you find hard to ask for?", .communication),
-            ("What's a small moment between us that you keep replaying?", .intimacy),
-            ("What's something you've learned about love from being with me?", .growth),
+            ("What's been on your mind late at night recently?", .emotions, [
+                "What keeps pulling your thoughts back there?",
+                "What would help quiet that for you?",
+            ]),
+            ("What's weighing on you the most right now?", .emotions, [
+                "How long have you been carrying that?",
+                "What would it take for that weight to lift even a little?",
+            ]),
+            ("When was the last time you got way more upset than the situation deserved?", .conflict, [
+                "What do you think was really underneath that reaction?",
+                "Did you realize it in the moment or only after?",
+            ]),
+            ("I feel most sensual when…", .sex, [
+                "What helps you settle into that feeling most naturally?",
+                "What tends to pull you away from it?",
+            ]),
+            ("I feel most attractive when…", .sex, [
+                "What is it about that moment that makes you feel seen that way?",
+                "How much of that feeling comes from you versus someone else's response?",
+            ]),
+            ("What's something you wish I understood better about you?", .communication, [
+                "What's the part of it that's hardest to explain?",
+                "How would things feel different for you if I could understood this better?",
+            ]),
+            ("What's a fear you haven't told me about?", .emotions, [
+                "What's kept you from saying it out loud?",
+                "What would it mean for you if I knew?",
+            ]),
+            ("When do you feel most disconnected from me?", .intimacy, [
+                "What's happening in you during those moments?",
+                "What would help you feel like we're back on the same page?",
+            ]),
+            ("What's something I do that makes you feel truly seen?", .appreciation, [
+                "What is it about that gesture that reaches you?",
+                "Do you think I know how much it matters?",
+            ]),
+            ("What's a part of your day you wish we could share more?", .dailyLife, [
+                "What would it give you to have me in that part of your life?",
+                "What keeps us from sharing it now?",
+            ]),
+            ("What's a habit of mine that quietly frustrates you?", .conflict, [
+                "What does it bring up in you when it happens?",
+                "Have you ever tried to say something about it? If not why not?",
+            ]),
+            ("What's something you've been meaning to apologize for?", .conflict, [
+                "What's been holding the apology back?",
+                "What do you think it would change if you said it?",
+            ]),
+            ("When do you feel the safest with me?", .intimacy, [
+                "What is it about those moments that lets your guard down?",
+                "How does that safety change the way you show up?",
+            ]),
+            ("What's something about our relationship that surprised you?", .growth, [
+                "Was it a good surprise or something you had to sit with?",
+                "How did it change what you expected from us?",
+            ]),
+            ("What's something you admire about the way I love you?", .appreciation, [
+                "When do you notice it the most?",
+                "Is there something about it you wish you could mirror back?",
+            ]),
+            ("What's a conversation we had that stuck with you?", .communication, [
+                "What about it kept echoing after it ended?",
+                "Did it change anything about how you see us?",
+            ]),
+            ("What do you think we're both avoiding right now?", .communication, [
+                "What makes that topic feel so untouchable?",
+                "What do you think would happen if we actually went there?",
+            ]),
+            ("When was the last time I really made you laugh?", .appreciation, [
+                "What was it about that moment that got you?",
+                "How important is laughter to you in a relationship?",
+            ]),
+            ("What's a way I've helped you grow that you haven't mentioned?", .growth, [
+                "What part of you shifted because of it?",
+                "Do you think I even realize I had that effect?",
+            ]),
+            ("What do you wish we did more of together?", .dailyLife, [
+                "What do you think we'd discover about each other if we did?",
+                "What's been getting in the way?",
+            ]),
+            ("What's something about our early days that you miss?", .past, [
+                "What made that time feel so different?",
+                "Is there a way to bring some of that energy back?",
+            ]),
+            ("How do you feel about how we handle money together?", .values, [
+                "Where does the tension show up the most?",
+                "What would your ideal version of that look like?",
+            ]),
+            ("What's a boundary you need me to respect more?", .communication, [
+                "What happens inside you when it gets crossed?",
+                "What would it feel like if I consistently honored it?",
+            ]),
+            ("What's something you're proud of us for getting through?", .growth, [
+                "What did that challenge reveal about who we are together?",
+                "Did it change the way you trust us?",
+            ]),
+            ("When do you feel most like yourself around me?", .identity, [
+                "What is it about those moments that lets you drop the act?",
+                "Are there times you feel less like yourself with me?",
+            ]),
+            ("What's an insecurity that still shows up in our relationship?", .emotions, [
+                "When does it tend to surface the most?",
+                "What would help you feel more settled about it?",
+            ]),
+            ("What's something I said recently that meant more than I probably realized?", .appreciation, [
+                "What nerve did it touch in a good way?",
+                "Do you wish I said things like that more often?",
+            ]),
+            ("What do you need from me that you find hard to ask for?", .communication, [
+                "What makes that request feel so difficult to voice?",
+                "What would it mean to you if I just knew to offer it?",
+            ]),
+            ("What's a small moment between us that you keep replaying?", .intimacy, [
+                "What is it about that moment that holds so much weight?",
+                "Does replaying it bring you comfort or longing?",
+            ]),
+            ("What's something you've learned about love from being with me?", .growth, [
+                "How is that different from what you believed before us?",
+                "Has it changed what you want going forward?",
+            ]),
         ], mode: .couples, intensity: .honest, depth: .warmUp)
     }
 
@@ -308,29 +456,98 @@ private extension PromptBank {
 
     static func couples_honest_realTalk() -> [Prompt] {
         make([
-            ("What does money actually mean to you — beyond the obvious?", .values),
-            ("What's something in your life that's worth fighting harder for?", .values),
-            ("When was the last time you really cried, and what brought it on?", .emotions),
-            ("What's the last promise you broke, and does it still bother you?", .conflict),
-            ("When was the last time you held back tears and pretended you were fine?", .emotions),
-            ("Who would you most want to show the person you've become?", .appreciation),
-            ("What's a conversation you know you need to have but keep putting off?", .communication),
-            ("How do you feel when you notice yourself getting older?", .emotions),
-            ("What's something you really want from me but haven't been able to ask for?", .communication),
-            ("Where do you feel the most friction between us right now?", .conflict),
-            ("What would you change about how you handle conflict with the people you love?", .conflict),
-            ("When do you wish you had spoken up instead of staying quiet?", .communication),
-            ("When was the last time jealousy really got under your skin?", .emotions),
-            ("What do you admire most about the way your partner handles hard things?", .appreciation),
-            ("I wish someone had prepared me better for sex by telling me…", .sex),
-            ("I tend to lose interest during intimacy when…", .sex),
-            ("A message I sometimes imagine sending you is…", .sex),
-            ("A message I secretly wish I'd receive from you is…", .sex),
-            ("In terms of energy or dynamic, I tend to lean more toward…", .sex),
-            ("When it comes to initiating intimacy, I usually…", .sex),
-            ("Most of what I've learned about sex has come from…", .sex),
-            ("One thing I wish we talked about more openly is…", .sex),
-            ("Something I'd like us to explore together is…", .sex),
+            ("What does money actually mean to you — beyond the obvious?", .values, [
+                "Where did that relationship with money come from?",
+                "How does it shape the choices you make day to day?",
+            ]),
+            ("What's something in your life that's worth fighting harder for?", .values, [
+                "What's been holding you back from fighting for it?",
+                "What would it look like if you went all in?",
+            ]),
+            ("When was the last time you really cried, and what brought it on?", .emotions, [
+                "Did you let yourself fully feel it or try to hold back?",
+                "What did it release in you?",
+            ]),
+            ("What's the last promise you broke, and does it still bother you?", .conflict, [
+                "What got in the way of keeping it?",
+                "What would you do differently if you could?",
+            ]),
+            ("When was the last time you held back tears and pretended you were fine?", .emotions, [
+                "What were you protecting yourself from by holding it in?",
+                "What would have happened if you had let yourself cry?",
+            ]),
+            ("Who would you most want to show the person you've become?", .appreciation, [
+                "What would you want them to see in you now?",
+                "What do you think they'd say?",
+            ]),
+            ("What's a conversation you know you need to have but keep putting off?", .communication, [
+                "What are you most afraid of hearing in return?",
+                "What would finally push you to have it?",
+            ]),
+            ("How do you feel when you notice yourself getting older?", .emotions, [
+                "What part of aging unsettles you the most?",
+                "Is there anything about it that quietly excites you?",
+            ]),
+            ("What's something you really want from me but haven't been able to ask for?", .communication, [
+                "What makes that request feel so vulnerable?",
+                "How do you think I'd respond if you asked?",
+            ]),
+            ("Where do you feel the most friction between us right now?", .conflict, [
+                "What do you think is underneath that friction?",
+                "What would resolution actually look like to you?",
+            ]),
+            ("What would you change about how you handle conflict with the people you love?", .conflict, [
+                "Where did you learn that pattern?",
+                "What would the healthier version look like for you?",
+            ]),
+            ("When do you wish you had spoken up instead of staying quiet?", .communication, [
+                "What stopped you from saying it?",
+                "What do you think would have changed if you had?",
+            ]),
+            ("When was the last time jealousy really got under your skin?", .emotions, [
+                "What was the deeper fear underneath it?",
+                "How did you handle it — and was that the right call?",
+            ]),
+            ("What do you admire most about the way your partner handles hard things?", .appreciation, [
+                "Is there a specific moment that showed you that strength?",
+                "What does watching them handle it bring up in you?",
+            ]),
+            ("I wish someone had prepared me better for sex by telling me…", .sex, [
+                "How did figuring that out on your own affect you?",
+                "What would you want someone younger to know?",
+            ]),
+            ("I tend to lose interest during intimacy when…", .sex, [
+                "What do you think is happening emotionally in those moments?",
+                "What would help you stay present instead?",
+            ]),
+            ("A message I sometimes imagine sending you is…", .sex, [
+                "What stops you from actually sending it?",
+                "What response are you hoping for in your imagination?",
+            ]),
+            ("A message I secretly wish I'd receive from you is…", .sex, [
+                "What would reading that message do to you?",
+                "What need would it speak to?",
+            ]),
+            ("In terms of energy or dynamic, I tend to lean more toward…", .sex, [
+                "Has that always been the case, or did it develop over time?",
+                "What does leaning into that side give you?",
+            ]),
+            ("When it comes to initiating intimacy, I usually…", .sex, [
+                "What makes initiating feel easy or hard for you?",
+                "What response do you need to feel safe taking that step?",
+            ]),
+            ("Most of what I've learned about sex has come from…", .sex, [
+                "How do you feel about those sources looking back?",
+                "What have you had to unlearn along the way?",
+            ]),
+            ("One thing I wish we talked about more openly is…", .sex, [
+                "What makes that topic feel hard to bring up?",
+                "What would it give us if we could go there together?",
+            ]),
+            ("Something I'd like us to explore together is…", .sex, [
+                "What draws you to that idea?",
+                "What would you need from me to feel safe trying it?",
+            ]),
         ], mode: .couples, intensity: .honest, depth: .realTalk)
     }
 
@@ -338,21 +555,66 @@ private extension PromptBank {
 
     static func couples_honest_deepDive() -> [Prompt] {
         make([
-            ("What does your heart need to hear from me right now?", .emotions),
-            ("What moment completely changed how you think about love?", .intimacy),
-            ("What about our future excites you and scares you at the same time?", .emotions),
-            ("I think the idea of marriage, when it comes to intimacy, is…", .sex),
-            ("During intimacy, everything else fades away when…", .sex),
-            ("A sexual question or uncertainty I still think about is…", .sex),
-            ("A belief about sex I've had to rethink over time is…", .sex),
-            ("Something I don't fully understand about desire is…", .sex),
-            ("My sex life changed in a meaningful way after…", .sex),
-            ("An early experience that shaped how I think about sex was…", .sex),
-            ("The difference between emotional intimacy and physical intimacy feels like…", .sex),
-            ("Sex feels most meaningful to me when…", .sex),
-            ("Growing up, the message I got about sex was…", .sex),
-            ("What makes me feel most safe during intimacy is…", .sex),
-            ("What helps me fully relax and be present with you is…", .sex),
+            ("What does your heart need to hear from me right now?", .emotions, [
+                "How long have you been needing to hear that?",
+                "What would shift in you if I said it?",
+            ]),
+            ("What moment completely changed how you think about love?", .intimacy, [
+                "What were you believing about love before that moment?",
+                "How does it shape the way you love now?",
+            ]),
+            ("What about our future excites you and scares you at the same time?", .emotions, [
+                "Which feeling is stronger right now — the excitement or the fear?",
+                "What would help the excitement win?",
+            ]),
+            ("I think the idea of marriage, when it comes to intimacy, is…", .sex, [
+                "Where did that belief take shape for you?",
+                "How does that idea affect what you expect from a partner?",
+            ]),
+            ("During intimacy, everything else fades away when…", .sex, [
+                "What do you think creates that level of presence?",
+                "How often do you reach that state?",
+            ]),
+            ("A sexual question or uncertainty I still think about is…", .sex, [
+                "What makes that question hard to settle?",
+                "Who would you trust enough to explore it with?",
+            ]),
+            ("A belief about sex I've had to rethink over time is…", .sex, [
+                "What experience pushed you to rethink it?",
+                "What do you believe now in its place?",
+            ]),
+            ("Something I don't fully understand about desire is…", .sex, [
+                "What part of it feels the most confusing?",
+                "What would understanding it better give you?",
+            ]),
+            ("My sex life changed in a meaningful way after…", .sex, [
+                "What shifted inside you because of that experience?",
+                "How did it change what you look for in intimacy?",
+            ]),
+            ("An early experience that shaped how I think about sex was…", .sex, [
+                "How did that experience color the way you approach intimacy now?",
+                "Is there a part of it you're still working through?",
+            ]),
+            ("The difference between emotional intimacy and physical intimacy feels like…", .sex, [
+                "Which one do you reach for first when you need to feel close?",
+                "Has there been a moment where one surprised you by turning into the other?",
+            ]),
+            ("Sex feels most meaningful to me when…", .sex, [
+                "What makes the difference between meaningful and just physical?",
+                "How often do you feel that deeper meaning?",
+            ]),
+            ("Growing up, the message I got about sex was…", .sex, [
+                "How has that message stayed with you or been rewritten?",
+                "What message would you want to pass on instead?",
+            ]),
+            ("What makes me feel most safe during intimacy is…", .sex, [
+                "What does safety in that context actually feel like in your body?",
+                "What's the quickest way that safety can be broken?",
+            ]),
+            ("What helps me fully relax and be present with you is…", .sex, [
+                "What usually gets in the way of that presence?",
+                "How can I make that easier for you?",
+            ]),
         ], mode: .couples, intensity: .honest, depth: .deepDive)
     }
 
@@ -360,36 +622,126 @@ private extension PromptBank {
 
     static func couples_unfiltered_warmUp() -> [Prompt] {
         make([
-            ("What part of yourself have you been hiding from the people closest to you?", .emotions),
-            ("What's something about us that you've never quite figured out?", .communication),
-            ("How honest do you think we really are with each other?", .communication),
-            ("I feel most sensual when…", .sex),
-            ("I feel most attractive when…", .sex),
-            ("What's a thought about us you've never said out loud?", .intimacy),
-            ("What's something you need from this relationship that you're not getting?", .communication),
-            ("When have you felt the most misunderstood by me?", .conflict),
-            ("What's something about me that you've had to learn to accept?", .growth),
-            ("What's a version of yourself you only show to me?", .identity),
-            ("What scares you most about our future together?", .emotions),
-            ("What's a pattern in our relationship you think we should break?", .conflict),
-            ("What do you wish you could be more honest about with me?", .communication),
-            ("What's something I do that triggers something deeper in you?", .emotions),
-            ("When did you last question whether we were on the same page?", .communication),
-            ("What's something about love that nobody warned you about?", .growth),
-            ("What's a resentment you've been carrying that you haven't voiced?", .conflict),
-            ("What's the most vulnerable you've ever felt with me?", .intimacy),
-            ("What do you think our biggest blind spot as a couple is?", .growth),
-            ("What's a truth about yourself that you're afraid would change how I see you?", .emotions),
-            ("When have you sacrificed too much of yourself for this relationship?", .values),
-            ("What's a fight we had that actually changed something for the better?", .conflict),
-            ("What's something about my past that still sits with you?", .past),
-            ("What would you change about how we communicate when things get hard?", .communication),
-            ("What's an expectation you've placed on me that might not be fair?", .conflict),
-            ("When was the last time you felt completely alone even though we were together?", .emotions),
-            ("What's something you've forgiven me for that I don't know about?", .conflict),
-            ("What do you think we each avoid feeling the most?", .emotions),
-            ("What's a way you've changed since being with me that worries you?", .identity),
-            ("What's something about us that you'd be embarrassed for others to know?", .intimacy),
+            ("What part of yourself have you been hiding from the people closest to you?", .emotions, [
+                "What are you afraid would happen if they saw it?",
+                "How does hiding it affect the way you show up?",
+            ]),
+            ("What's something about us that you've never quite figured out?", .communication, [
+                "Does not understanding it bother you or have you made peace with it?",
+                "What opens up if you finally understand it?",
+            ]),
+            ("How honest do you think we really are with each other?", .communication, [
+                "Where do you think the gaps are?",
+                "What would full honesty between us actually look like?",
+            ]),
+            ("I feel most sensual when…", .sex, [
+                "What helps you settle into that feeling most naturally?",
+                "What tends to pull you away from it?",
+            ]),
+            ("I feel most attractive when…", .sex, [
+                "What is it about that moment that makes you feel seen that way?",
+                "How much of that feeling comes from you versus someone else's response?",
+            ]),
+            ("What's a thought about us you've never said out loud?", .intimacy, [
+                "What's kept you from voicing it until now?",
+                "What do you think I'd feel hearing it?",
+            ]),
+            ("What's something you need from this relationship that you're not getting?", .communication, [
+                "How long have you been sitting with that unmet need?",
+                "What would it look like if that need were fully met?",
+            ]),
+            ("When have you felt the most misunderstood by me?", .conflict, [
+                "What did you need me to see that I missed?",
+                "Did that moment change anything between us?",
+            ]),
+            ("What's something about me that you've had to learn to accept?", .growth, [
+                "Was the accepting gradual or did something shift it?",
+                "What did that acceptance cost you?",
+            ]),
+            ("What's a version of yourself you only show to me?", .identity, [
+                "What is it about us that makes that version feel safe?",
+                "Do you like that version of yourself?",
+            ]),
+            ("What scares you most about our future together?", .emotions, [
+                "Is that fear rooted in us or in something older?",
+                "What would help quiet that fear?",
+            ]),
+            ("What's a pattern in our relationship you think we should break?", .conflict, [
+                "How does that pattern usually start?",
+                "What do you think it would take for us to actually stop it?",
+            ]),
+            ("What do you wish you could be more honest about with me?", .communication, [
+                "What feels at risk if you say it?",
+                "What kind of response would make honesty feel safe?",
+            ]),
+            ("What's something I do that triggers something deeper in you?", .emotions, [
+                "What's the deeper thing it's actually touching?",
+                "Do you think I have any idea it lands that way?",
+            ]),
+            ("When did you last question whether we were on the same page?", .communication, [
+                "What made you doubt it?",
+                "Did you say something or keep it to yourself?",
+            ]),
+            ("What's something about love that nobody warned you about?", .growth, [
+                "How did finding that out change you?",
+                "What would you tell someone who's about to learn it?",
+            ]),
+            ("What's a resentment you've been carrying that you haven't voiced?", .conflict, [
+                "What's it been doing to you to hold onto it?",
+                "What would you need to feel safe letting it out?",
+            ]),
+            ("What's the most vulnerable you've ever felt with me?", .intimacy, [
+                "What was it about that moment that stripped your guard away?",
+                "Did that vulnerability bring us closer or leave you exposed?",
+            ]),
+            ("What do you think our biggest blind spot as a couple is?", .growth, [
+                "What would someone on the outside probably see that we can't?",
+                "What becomes possible if we finally face it?",
+            ]),
+            ("What's a truth about yourself that you're afraid would change how I see you?", .emotions, [
+                "What's the worst version of how you imagine I'd react?",
+                "What would it mean if I heard it and nothing changed?",
+            ]),
+            ("When have you sacrificed too much of yourself for this relationship?", .values, [
+                "Did you realize it was too much at the time or only after?",
+                "What part of yourself did you lose in the process?",
+            ]),
+            ("What's a fight we had that actually changed something for the better?", .conflict, [
+                "What broke through in that fight that couldn't have come out any other way?",
+                "How did it change the way you see conflict between us?",
+            ]),
+            ("What's something about my past that still sits with you?", .past, [
+                "What about it keeps pulling at you?",
+                "Have you made peace with it or is it still unresolved?",
+            ]),
+            ("What would you change about how we communicate when things get hard?", .communication, [
+                "What does our worst communication pattern look like?",
+                "What would the better version feel like in the moment?",
+            ]),
+            ("What's an expectation you've placed on me that might not be fair?", .conflict, [
+                "Where do you think that expectation comes from?",
+                "What would it mean to release it?",
+            ]),
+            ("When was the last time you felt completely alone even though we were together?", .emotions, [
+                "What was happening between us in that moment?",
+                "What would have made you feel less alone?",
+            ]),
+            ("What's something you've forgiven me for that I don't know about?", .conflict, [
+                "What did the forgiving cost you?",
+                "Is there a part of it that's still not fully resolved?",
+            ]),
+            ("What do you think we each avoid feeling the most?", .emotions, [
+                "How does that avoidance show up in the way we treat each other?",
+                "What would happen if we stopped avoiding it?",
+            ]),
+            ("What's a way you've changed since being with me that worries you?", .identity, [
+                "Is it a change you chose or one that happened to you?",
+                "What would the old version of you think?",
+            ]),
+            ("What's something about us that you'd be embarrassed for others to know?", .intimacy, [
+                "What does the embarrassment protect?",
+                "Would telling someone actually change anything?",
+            ]),
         ], mode: .couples, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -397,15 +749,42 @@ private extension PromptBank {
 
     static func couples_unfiltered_realTalk() -> [Prompt] {
         make([
-            ("What's something you've been pretending is fine when it really isn't?", .emotions),
-            ("When did you hurt someone without meaning to, and what happened after?", .conflict),
-            ("What makes you the hardest to live with — if you're being honest?", .conflict),
-            ("When did you last feel genuinely lost, and what was happening?", .emotions),
-            ("In what situations are you your own worst enemy?", .growth),
-            ("How do you tend to withdraw your love or attention when you're upset?", .conflict),
-            ("When was a time you admitted you were wrong — and how did that feel?", .conflict),
-            ("Something I've always been curious to explore sexually is…", .sex),
-            ("The word \u{201C}forbidden\u{201D} makes me think of…", .sex),
+            ("What's something you've been pretending is fine when it really isn't?", .emotions, [
+                "How long have you been holding that performance together?",
+                "What would happen if you stopped pretending?",
+            ]),
+            ("When did you hurt someone without meaning to, and what happened after?", .conflict, [
+                "Did you realize it right away or did it take time?",
+                "What did that teach you about the gap between intention and impact?",
+            ]),
+            ("What makes you the hardest to live with — if you're being honest?", .conflict, [
+                "How do you think that quality affects the people closest to you?",
+                "Have you tried to change it or accepted it as part of who you are?",
+            ]),
+            ("When did you last feel genuinely lost, and what was happening?", .emotions, [
+                "What did you reach for to try to find your footing?",
+                "Did anyone know how lost you were?",
+            ]),
+            ("In what situations are you your own worst enemy?", .growth, [
+                "What does your self-sabotage usually look like in those moments?",
+                "What do you think you're really trying to protect?",
+            ]),
+            ("How do you tend to withdraw your love or attention when you're upset?", .conflict, [
+                "Are you always aware you're doing it?",
+                "What would it take for you to stay present instead of pulling back?",
+            ]),
+            ("When was a time you admitted you were wrong — and how did that feel?", .conflict, [
+                "What made that admission so hard?",
+                "Did it change anything in the relationship?",
+            ]),
+            ("Something I've always been curious to explore sexually is…", .sex, [
+                "What draws you to that, and what holds you back?",
+                "What would you need to feel safe enough to bring it up?",
+            ]),
+            ("The word \u{201C}forbidden\u{201D} makes me think of…", .sex, [
+                "What is it about that edge that pulls you in?",
+                "How do you feel about having that thought?",
+            ]),
         ], mode: .couples, intensity: .unfiltered, depth: .realTalk)
     }
 
@@ -413,18 +792,54 @@ private extension PromptBank {
 
     static func couples_unfiltered_deepDive() -> [Prompt] {
         make([
-            ("What's something you used to dream about but have quietly given up on?", .emotions),
-            ("What would you give up everything for if you had to choose?", .values),
-            ("Is there someone you think of as the one who got away?", .intimacy),
-            ("What's the hardest lesson love has ever taught you?", .intimacy),
-            ("What's the heartbreak that hit you the hardest?", .emotions),
-            ("When was the last time you felt truly lonely, even if you weren't alone?", .emotions),
-            ("What would be something you could never forgive in a relationship?", .conflict),
-            ("If my partner had an affair, I think I would…", .sex),
-            ("One of the most awkward or uncomfortable moments I've had after intimacy was…", .sex),
-            ("A fantasy I have mixed feelings about is…", .sex),
-            ("Something I haven't been fully honest about in my sexual past is…", .sex),
-            ("A recurring fantasy I've had is…", .sex),
+            ("What's something you used to dream about but have quietly given up on?", .emotions, [
+                "When did you stop believing it was possible?",
+                "Is there a part of you that still wants it?",
+            ]),
+            ("What would you give up everything for if you had to choose?", .values, [
+                "What does that choice reveal about what you value most?",
+                "Has that answer changed over time?",
+            ]),
+            ("Is there someone you think of as the one who got away?", .intimacy, [
+                "What do you think you're really missing — the person or the possibility?",
+                "How does that memory affect the way you love now?",
+            ]),
+            ("What's the hardest lesson love has ever taught you?", .intimacy, [
+                "How did that lesson change what you need from a partner?",
+                "Are you still learning it, or have you made peace with it?",
+            ]),
+            ("What's the heartbreak that hit you the hardest?", .emotions, [
+                "What part of you did it break open?",
+                "How did it reshape the way you protect your heart?",
+            ]),
+            ("When was the last time you felt truly lonely, even if you weren't alone?", .emotions, [
+                "What was missing in that moment?",
+                "What would it take to not feel that way again?",
+            ]),
+            ("What would be something you could never forgive in a relationship?", .conflict, [
+                "What does that boundary protect in you?",
+                "Has anything ever come close to testing it?",
+            ]),
+            ("If my partner had an affair, I think I would…", .sex, [
+                "What does your gut reaction tell you about what you value most?",
+                "Do you think your actual response would match what you imagine?",
+            ]),
+            ("One of the most awkward or uncomfortable moments I've had after intimacy was…", .sex, [
+                "What made that moment land so uncomfortably?",
+                "Did it change anything about how you handle vulnerability after sex?",
+            ]),
+            ("A fantasy I have mixed feelings about is…", .sex, [
+                "What's the tension between the part that wants it and the part that resists?",
+                "What do you think the fantasy is really about underneath?",
+            ]),
+            ("Something I haven't been fully honest about in my sexual past is…", .sex, [
+                "What's kept you from sharing it until now?",
+                "What would it feel like to finally have someone know?",
+            ]),
+            ("A recurring fantasy I've had is…", .sex, [
+                "What do you think that fantasy is really reaching for?",
+                "How do you feel about the fact that it keeps coming back?",
+            ]),
         ], mode: .couples, intensity: .unfiltered, depth: .deepDive)
     }
 
@@ -432,36 +847,126 @@ private extension PromptBank {
 
     static func friends_light_warmUp() -> [Prompt] {
         make([
-            ("How do you wish people would describe you when they introduce you?", .identity),
-            ("What's a book you find yourself recommending to everyone?", .dailyLife),
-            ("Is there a contact in your phone you know you should probably delete?", .conflict),
-            ("If your life was a movie, who would you cast to play you?", .dailyLife),
-            ("What's the last time you got caught doing something you shouldn't have been doing?", .dailyLife),
-            ("What's the most embarrassing moment you can actually laugh about now?", .dailyLife),
-            ("What's the last truly generous thing you did for someone without being asked?", .appreciation),
-            ("What's a rule you secretly enjoy breaking?", .identity),
-            ("If you got fired tomorrow, what would it probably be for?", .dailyLife),
-            ("If you could be known for one thing, what would it be?", .values),
-            ("What's something you've always wondered if everyone secretly does too?", .identity),
-            ("What could you talk about for hours that most people wouldn't expect?", .values),
-            ("What would you happily do for a living if money didn't matter at all?", .dailyLife),
-            ("If you could start a completely different career tomorrow, what would you pick?", .dailyLife),
-            ("If you wrote a book about your life so far, what would you call it?", .values),
-            ("What brings out your competitive side more than anything else?", .identity),
-            ("At a party, where would someone most likely find you?", .dailyLife),
-            ("What do people consistently get wrong about you?", .communication),
-            ("What's something you pretend to know way more about than you actually do?", .identity),
-            ("What's the weirdest dream you've ever had?", .dailyLife),
-            ("What's a quality in your closest friend that you genuinely admire?", .appreciation),
-            ("When was the last time someone made your day without even trying?", .appreciation),
-            ("What's the most random thing on your bucket list?", .dailyLife),
-            ("What's a hill you will die on that nobody else seems to care about?", .values),
-            ("What's the best meal you've ever had and where was it?", .dailyLife),
-            ("What's something you're weirdly good at that has no practical use?", .identity),
-            ("What's the last thing you stayed up way too late doing?", .dailyLife),
-            ("What's a trend you absolutely refuse to get on board with?", .values),
-            ("What's the most thoughtful thing a friend has ever done for you?", .appreciation),
-            ("What's something you only do when nobody's watching?", .identity),
+            ("How do you wish people would describe you when they introduce you?", .identity, [
+                "What does that description say about what matters most to you?",
+                "How far off is that from how you think people actually see you?",
+            ]),
+            ("What's a book you find yourself recommending to everyone?", .dailyLife, [
+                "What about it hit you so hard?",
+                "What kind of person do you usually recommend it to?",
+            ]),
+            ("Is there a contact in your phone you know you should probably delete?", .conflict, [
+                "What keeps you from doing it?",
+                "What would deleting it actually mean for you?",
+            ]),
+            ("If your life was a movie, who would you cast to play you?", .dailyLife, [
+                "What is it about that person that captures your energy?",
+                "What part of you do you think they'd struggle to get right?",
+            ]),
+            ("What's the last time you got caught doing something you shouldn't have been doing?", .dailyLife, [
+                "How did you handle getting caught?",
+                "Would you do it again if you knew you wouldn't get caught?",
+            ]),
+            ("What's the most embarrassing moment you can actually laugh about now?", .dailyLife, [
+                "How long did it take before you could laugh about it?",
+                "What made it shift from embarrassing to funny?",
+            ]),
+            ("What's the last truly generous thing you did for someone without being asked?", .appreciation, [
+                "What moved you to do it?",
+                "Did they ever find out it was you?",
+            ]),
+            ("What's a rule you secretly enjoy breaking?", .identity, [
+                "What does breaking it give you?",
+                "Do you think anyone has noticed?",
+            ]),
+            ("If you got fired tomorrow, what would it probably be for?", .dailyLife, [
+                "Is that something you're proud of or trying to fix?",
+                "What does that say about how you operate?",
+            ]),
+            ("If you could be known for one thing, what would it be?", .values, [
+                "Why that above everything else?",
+                "Are you actively building toward that or is it more of a wish?",
+            ]),
+            ("What's something you've always wondered if everyone secretly does too?", .identity, [
+                "What would it mean to you if they did?",
+                "How would it feel if you were the only one?",
+            ]),
+            ("What could you talk about for hours that most people wouldn't expect?", .values, [
+                "How did that interest develop?",
+                "Who in your life actually knows about this side of you?",
+            ]),
+            ("What would you happily do for a living if money didn't matter at all?", .dailyLife, [
+                "What draws you to that over everything else?",
+                "What's stopping you from moving toward it even now?",
+            ]),
+            ("If you could start a completely different career tomorrow, what would you pick?", .dailyLife, [
+                "What need would that career satisfy that your current one doesn't?",
+                "What's the one thing holding you back from that leap?",
+            ]),
+            ("If you wrote a book about your life so far, what would you call it?", .values, [
+                "What chapter are you in right now?",
+                "What would the tone of the book be — funny, heavy, hopeful?",
+            ]),
+            ("What brings out your competitive side more than anything else?", .identity, [
+                "Where do you think that drive comes from?",
+                "Is your competitiveness something you like about yourself?",
+            ]),
+            ("At a party, where would someone most likely find you?", .dailyLife, [
+                "What does that spot say about your social energy?",
+                "Are you there by choice or by habit?",
+            ]),
+            ("What do people consistently get wrong about you?", .communication, [
+                "What do you think creates that misconception?",
+                "Does it bother you, or have you stopped correcting it?",
+            ]),
+            ("What's something you pretend to know way more about than you actually do?", .identity, [
+                "What made you start faking it?",
+                "Has anyone ever called you out?",
+            ]),
+            ("What's the weirdest dream you've ever had?", .dailyLife, [
+                "Did it linger with you after you woke up?",
+                "Do you think it meant something or was it just chaos?",
+            ]),
+            ("What's a quality in your closest friend that you genuinely admire?", .appreciation, [
+                "Is it a quality you see in yourself too?",
+                "Have you ever told them you admire that about them?",
+            ]),
+            ("When was the last time someone made your day without even trying?", .appreciation, [
+                "What did they do that landed so perfectly?",
+                "Did they know the effect they had?",
+            ]),
+            ("What's the most random thing on your bucket list?", .dailyLife, [
+                "Where did that idea come from?",
+                "What's been keeping you from doing it?",
+            ]),
+            ("What's a hill you will die on that nobody else seems to care about?", .values, [
+                "Why does that one matter so much to you?",
+                "Has defending it ever gotten you into trouble?",
+            ]),
+            ("What's the best meal you've ever had and where was it?", .dailyLife, [
+                "What made that meal so unforgettable?",
+                "Was it the food or the moment around it?",
+            ]),
+            ("What's something you're weirdly good at that has no practical use?", .identity, [
+                "How did you discover that talent?",
+                "Has it ever come in handy in an unexpected way?",
+            ]),
+            ("What's the last thing you stayed up way too late doing?", .dailyLife, [
+                "Was it worth the lost sleep?",
+                "What made it so hard to stop?",
+            ]),
+            ("What's a trend you absolutely refuse to get on board with?", .values, [
+                "What is it about that trend that rubs you the wrong way?",
+                "Do people give you a hard time about it?",
+            ]),
+            ("What's the most thoughtful thing a friend has ever done for you?", .appreciation, [
+                "What made it feel so meaningful?",
+                "How did it change the way you see that friendship?",
+            ]),
+            ("What's something you only do when nobody's watching?", .identity, [
+                "Why do you keep it private?",
+                "What would happen if someone caught you?",
+            ]),
         ], mode: .friends, intensity: .light, depth: .warmUp)
     }
 
@@ -469,9 +974,18 @@ private extension PromptBank {
 
     static func friends_light_realTalk() -> [Prompt] {
         make([
-            ("Who's someone who had a huge impact on your life without ever realizing it?", .appreciation),
-            ("When did you completely flip your perspective on something you used to believe?", .growth),
-            ("Who do you owe a long-overdue thank you?", .appreciation),
+            ("Who's someone who had a huge impact on your life without ever realizing it?", .appreciation, [
+                "What did they do that changed things for you?",
+                "Have you ever considered telling them?",
+            ]),
+            ("When did you completely flip your perspective on something you used to believe?", .growth, [
+                "What finally made it click?",
+                "How did that shift change the way you move through the world?",
+            ]),
+            ("Who do you owe a long-overdue thank you?", .appreciation, [
+                "What's been stopping you from saying it?",
+                "What would you want them to know?",
+            ]),
         ], mode: .friends, intensity: .light, depth: .realTalk)
     }
 
@@ -479,10 +993,22 @@ private extension PromptBank {
 
     static func friends_light_deepDive() -> [Prompt] {
         make([
-            ("How do you think we've rubbed off on each other over time?", .growth),
-            ("What do you think keeps our friendship going through everything?", .appreciation),
-            ("What's a value you think we share that really matters to you?", .values),
-            ("What's a moment where you felt like I really got you?", .intimacy),
+            ("How do you think we've rubbed off on each other over time?", .growth, [
+                "Is there something you picked up from me that surprised you?",
+                "What part of that influence are you most grateful for?",
+            ]),
+            ("What do you think keeps our friendship going through everything?", .appreciation, [
+                "Has there been a moment where that bond was tested?",
+                "What would you never want to lose about what we have?",
+            ]),
+            ("What's a value you think we share that really matters to you?", .values, [
+                "When did you first notice we shared that?",
+                "How does that shared value show up in the way we treat each other?",
+            ]),
+            ("What's a moment where you felt like I really got you?", .intimacy, [
+                "What had you been needing in that moment?",
+                "How did it change the way you see our friendship?",
+            ]),
         ], mode: .friends, intensity: .light, depth: .deepDive)
     }
 
@@ -490,36 +1016,126 @@ private extension PromptBank {
 
     static func friends_honest_warmUp() -> [Prompt] {
         make([
-            ("What's a story people tell about you that isn't quite right — but you never bother to correct?", .communication),
-            ("How do you honestly feel when a friend is always running late?", .conflict),
-            ("Who gets under your skin more than anyone, and why do you think that is?", .conflict),
-            ("What was the last lie you told, and why did you tell it?", .communication),
-            ("What are you the most judgmental about, even if you'd never admit it?", .values),
-            ("What's something you've always been a little bit embarrassed about?", .emotions),
-            ("What's a friendship you let fade that you sometimes regret?", .past),
-            ("What do you wish your friends understood about your life right now?", .communication),
-            ("When was the last time you felt left out by people you care about?", .emotions),
-            ("What's something you've noticed about yourself that you don't love?", .growth),
-            ("What's a compliment you received that caught you off guard?", .appreciation),
-            ("What's something you keep doing even though you know it's not great for you?", .growth),
-            ("What do you find hardest about maintaining friendships as you get older?", .communication),
-            ("What's a promise you made to yourself that you've actually kept?", .values),
-            ("When's the last time you felt genuinely jealous of a friend?", .emotions),
-            ("What's something you've outgrown but haven't let go of yet?", .growth),
-            ("What's a topic you avoid with certain friends and why?", .communication),
-            ("What's the hardest part about being honest with the people closest to you?", .communication),
-            ("What do you wish someone would just ask you about?", .emotions),
-            ("What's something you've been overthinking lately?", .emotions),
-            ("What's an opinion you hold that you know your friends would push back on?", .values),
-            ("When did a friend disappoint you in a way they probably don't know about?", .conflict),
-            ("What's a part of your personality that only comes out around certain people?", .identity),
-            ("What's a moment where you felt truly appreciated by a friend?", .appreciation),
-            ("What's something that's been harder than you've let on?", .emotions),
-            ("What do you think makes you a good friend, and where do you fall short?", .growth),
-            ("What's a conversation you had recently that left you thinking for days?", .communication),
-            ("What's something you pretend to be okay with but actually aren't?", .emotions),
-            ("What's a risk you wish you had the courage to take right now?", .growth),
-            ("When was the last time you really showed up for someone in a meaningful way?", .appreciation),
+            ("What's a story people tell about you that isn't quite right — but you never bother to correct?", .communication, [
+                "Why do you let it stand?",
+                "What would the real version sound like?",
+            ]),
+            ("How do you honestly feel when a friend is always running late?", .conflict, [
+                "What does it bring up in you beyond the inconvenience?",
+                "Have you ever said something about it?",
+            ]),
+            ("Who gets under your skin more than anyone, and why do you think that is?", .conflict, [
+                "What is it about them that gets to you specifically?",
+                "Do you think it says more about them or about you?",
+            ]),
+            ("What was the last lie you told, and why did you tell it?", .communication, [
+                "What were you trying to protect by lying?",
+                "Do you think the person believed you?",
+            ]),
+            ("What are you the most judgmental about, even if you'd never admit it?", .values, [
+                "Where do you think that judgment comes from?",
+                "Do you hold yourself to the same standard?",
+            ]),
+            ("What's something you've always been a little bit embarrassed about?", .emotions, [
+                "What makes that one stick with you?",
+                "Has anyone ever made you feel worse about it?",
+            ]),
+            ("What's a friendship you let fade that you sometimes regret?", .past, [
+                "What got in the way of keeping it alive?",
+                "What would you say to them if you reconnected?",
+            ]),
+            ("What do you wish your friends understood about your life right now?", .communication, [
+                "What's the biggest gap between how it looks and how it feels?",
+                "Why is that hard to explain?",
+            ]),
+            ("When was the last time you felt left out by people you care about?", .emotions, [
+                "What made that sting so much?",
+                "Did you say anything about it?",
+            ]),
+            ("What's something you've noticed about yourself that you don't love?", .growth, [
+                "Is it something you want to change or learn to accept?",
+                "When does it show up the most?",
+            ]),
+            ("What's a compliment you received that caught you off guard?", .appreciation, [
+                "Why do you think it surprised you?",
+                "Did it change how you see yourself at all?",
+            ]),
+            ("What's something you keep doing even though you know it's not great for you?", .growth, [
+                "What does that thing give you that keeps you coming back?",
+                "What would have to change for you to stop?",
+            ]),
+            ("What do you find hardest about maintaining friendships as you get older?", .communication, [
+                "What do you think has changed the most?",
+                "What would your ideal friendship look like at this stage?",
+            ]),
+            ("What's a promise you made to yourself that you've actually kept?", .values, [
+                "What made you stick with that one when so many others slip?",
+                "What does keeping it mean to you?",
+            ]),
+            ("When's the last time you felt genuinely jealous of a friend?", .emotions, [
+                "What was it about their situation that got to you?",
+                "What does that jealousy tell you about what you want?",
+            ]),
+            ("What's something you've outgrown but haven't let go of yet?", .growth, [
+                "What's keeping you attached to it?",
+                "What would letting go actually look like?",
+            ]),
+            ("What's a topic you avoid with certain friends and why?", .communication, [
+                "What are you afraid would happen if you brought it up?",
+                "Does avoiding it create distance between you?",
+            ]),
+            ("What's the hardest part about being honest with the people closest to you?", .communication, [
+                "What are you usually trying to protect — them or yourself?",
+                "When has honesty actually brought you closer?",
+            ]),
+            ("What do you wish someone would just ask you about?", .emotions, [
+                "Why do you think nobody has?",
+                "What would it mean to finally talk about it?",
+            ]),
+            ("What's something you've been overthinking lately?", .emotions, [
+                "What's the thought that keeps looping back?",
+                "What would it take to finally let it settle?",
+            ]),
+            ("What's an opinion you hold that you know your friends would push back on?", .values, [
+                "What makes you hold onto it anyway?",
+                "Have you ever tested it out loud?",
+            ]),
+            ("When did a friend disappoint you in a way they probably don't know about?", .conflict, [
+                "Why didn't you say anything?",
+                "Has it changed the way you see them?",
+            ]),
+            ("What's a part of your personality that only comes out around certain people?", .identity, [
+                "What is it about those people that brings it out?",
+                "Do you like that version of yourself?",
+            ]),
+            ("What's a moment where you felt truly appreciated by a friend?", .appreciation, [
+                "What did they do that made it feel real?",
+                "How often do you feel that way?",
+            ]),
+            ("What's something that's been harder than you've let on?", .emotions, [
+                "What have you been doing to hold it together?",
+                "What would help, even just a little?",
+            ]),
+            ("What do you think makes you a good friend, and where do you fall short?", .growth, [
+                "Do the people in your life see those strengths and weaknesses the same way?",
+                "What's one thing you'd like to get better at?",
+            ]),
+            ("What's a conversation you had recently that left you thinking for days?", .communication, [
+                "What was it about that conversation that stuck?",
+                "Did it change your mind about anything?",
+            ]),
+            ("What's something you pretend to be okay with but actually aren't?", .emotions, [
+                "How long have you been carrying that pretense?",
+                "What would happen if you dropped it?",
+            ]),
+            ("What's a risk you wish you had the courage to take right now?", .growth, [
+                "What's the worst thing that could actually happen?",
+                "What would taking it say about who you're becoming?",
+            ]),
+            ("When was the last time you really showed up for someone in a meaningful way?", .appreciation, [
+                "What made you step up in that moment?",
+                "How did it feel to be that person for them?",
+            ]),
         ], mode: .friends, intensity: .honest, depth: .warmUp)
     }
 
@@ -527,22 +1143,70 @@ private extension PromptBank {
 
     static func friends_honest_realTalk() -> [Prompt] {
         make([
-            ("When was a time you were meaner than the situation called for?", .conflict),
-            ("What version of yourself are you sometimes tempted to present that isn't quite real?", .identity),
-            ("What's a mistake you made once that you know you'll never repeat?", .growth),
-            ("Who challenges you the most in your life right now, and how do you deal with it?", .conflict),
-            ("Who intimidates you, and what do you think that says about you?", .identity),
-            ("What's a risk you took that ended up completely changing things?", .growth),
-            ("What's something only your closest friends know about you?", .intimacy),
-            ("What's a message you sent that you immediately wished you could take back?", .communication),
-            ("What's a challenge you've faced that you're proud of getting through?", .appreciation),
-            ("What's something you took credit for that you probably shouldn't have?", .conflict),
-            ("When was the last time you played a version of yourself that wasn't really you?", .identity),
-            ("When do you tell yourself it's not really lying?", .communication),
-            ("What's a moment from your past you wish everyone would just forget?", .past),
-            ("What's a story you tell about yourself that's not totally accurate?", .communication),
-            ("What's a way someone has shown up for you that you'll never forget?", .appreciation),
-            ("What's a lesson you had to learn the hard way more than once?", .growth),
+            ("When was a time you were meaner than the situation called for?", .conflict, [
+                "What was really going on underneath that reaction?",
+                "Did you ever make it right?",
+            ]),
+            ("What version of yourself are you sometimes tempted to present that isn't quite real?", .identity, [
+                "What do you get from putting that version forward?",
+                "What's the gap between that version and the real one?",
+            ]),
+            ("What's a mistake you made once that you know you'll never repeat?", .growth, [
+                "What did it cost you to learn that lesson?",
+                "How did it change the way you make decisions?",
+            ]),
+            ("Who challenges you the most in your life right now, and how do you deal with it?", .conflict, [
+                "What about them pushes your buttons?",
+                "Do you think the challenge is making you better or wearing you down?",
+            ]),
+            ("Who intimidates you, and what do you think that says about you?", .identity, [
+                "What quality of theirs triggers that feeling?",
+                "Is it something you want for yourself?",
+            ]),
+            ("What's a risk you took that ended up completely changing things?", .growth, [
+                "What gave you the push to take it?",
+                "Would you take it again knowing how it turned out?",
+            ]),
+            ("What's something only your closest friends know about you?", .intimacy, [
+                "Why do you keep that one in a smaller circle?",
+                "How would things feel different if more people knew?",
+            ]),
+            ("What's a message you sent that you immediately wished you could take back?", .communication, [
+                "What were you feeling when you hit send?",
+                "How did it land on the other end?",
+            ]),
+            ("What's a challenge you've faced that you're proud of getting through?", .appreciation, [
+                "What did you discover about yourself in the process?",
+                "Did anyone help you through it, or was it all you?",
+            ]),
+            ("What's something you took credit for that you probably shouldn't have?", .conflict, [
+                "Does it still sit with you?",
+                "Would you own up to it now if given the chance?",
+            ]),
+            ("When was the last time you played a version of yourself that wasn't really you?", .identity, [
+                "What did that situation require you to be?",
+                "How did it feel to come back to yourself after?",
+            ]),
+            ("When do you tell yourself it's not really lying?", .communication, [
+                "What makes that line feel blurry for you?",
+                "How do you decide when the truth is worth the discomfort?",
+            ]),
+            ("What's a moment from your past you wish everyone would just forget?", .past, [
+                "What about it still makes you cringe?",
+                "Do you think other people remember it as much as you do? Why?",
+            ]),
+            ("What's a story you tell about yourself that's not totally accurate?", .communication, [
+                "What did you change and why?",
+                "What would the honest version reveal about you?",
+            ]),
+            ("What's a way someone has shown up for you that you'll never forget?", .appreciation, [
+                "What made that moment different from other times people tried to help?",
+                "Did it change what you expect from the people around you?",
+            ]),
+            ("What's a lesson you had to learn the hard way more than once?", .growth, [
+                "What kept pulling you back into the same mistake?",
+                "What finally made it stick?",
+            ]),
         ], mode: .friends, intensity: .honest, depth: .realTalk)
     }
 
@@ -550,9 +1214,18 @@ private extension PromptBank {
 
     static func friends_honest_deepDive() -> [Prompt] {
         make([
-            ("What's a dream you've kept entirely to yourself?", .intimacy),
-            ("Who do you owe an apology that you haven't given yet?", .conflict),
-            ("Who's a friend you haven't shown up for the way you should have?", .conflict),
+            ("What's a dream you've kept entirely to yourself?", .intimacy, [
+                "What makes it feel too private or fragile to share?",
+                "What would it take for you to start chasing it?",
+            ]),
+            ("Who do you owe an apology that you haven't given yet?", .conflict, [
+                "What's been stopping you from offering it?",
+                "What do you think it would change — for them and for you?",
+            ]),
+            ("Who's a friend you haven't shown up for the way you should have?", .conflict, [
+                "What got in the way?",
+                "If you could go back to that moment, what would you do differently?",
+            ]),
         ], mode: .friends, intensity: .honest, depth: .deepDive)
     }
 
@@ -560,36 +1233,126 @@ private extension PromptBank {
 
     static func friends_unfiltered_warmUp() -> [Prompt] {
         make([
-            ("What's something you pretend doesn't bother you but absolutely does?", .emotions),
-            ("What do people get wrong about you the most?", .communication),
-            ("What opinion do you hold that most of your friends would disagree with?", .values),
-            ("What's the worst advice you've ever followed?", .growth),
-            ("What's a part of yourself you've had to fight to accept?", .identity),
-            ("What's something you've done that you'll never fully explain to anyone?", .past),
-            ("When have you been the villain in someone else's story?", .conflict),
-            ("What's a belief you held strongly that completely fell apart?", .values),
-            ("What's something about the way you were raised that you've had to unlearn?", .growth),
-            ("What's the loneliest you've ever felt in a room full of people?", .emotions),
-            ("What's a side of yourself that only comes out when you're angry?", .identity),
-            ("What's something you've said that you can never take back?", .conflict),
-            ("What's a truth about yourself that most people couldn't handle?", .identity),
-            ("When was the last time you seriously considered cutting someone off?", .conflict),
-            ("What's something you judge other people for that you're also guilty of?", .values),
-            ("What's the most selfish thing you've done that you don't regret?", .values),
-            ("What's a feeling you've been suppressing for way too long?", .emotions),
-            ("What's something you've never been able to forgive yourself for?", .emotions),
-            ("What do you wish people would stop pretending to care about?", .values),
-            ("What's a moment where you realized a friendship was one-sided?", .conflict),
-            ("What's something dark you've thought about that you'd never say out loud?", .emotions),
-            ("What's the most honest thing you've ever said to someone's face?", .communication),
-            ("What's an experience that hardened you in a way others don't see?", .past),
-            ("When did you last feel truly ashamed of yourself?", .emotions),
-            ("What's a secret you've kept from your closest friends?", .intimacy),
-            ("What's a way you've manipulated a situation that you're not proud of?", .conflict),
-            ("What's a double standard you hold that you know isn't fair?", .values),
-            ("What's something you lost respect for someone over?", .conflict),
-            ("When's the last time you cried and what set it off?", .emotions),
-            ("What's a question you're afraid someone might ask you?", .emotions),
+            ("What's something you pretend doesn't bother you but absolutely does?", .emotions, [
+                "What makes you keep pretending?",
+                "What might shift if you admitted it out loud?",
+            ]),
+            ("What do people get wrong about you the most?", .communication, [
+                "What do you think creates that impression?",
+                "Have you ever tried to correct it?",
+            ]),
+            ("What opinion do you hold that most of your friends would disagree with?", .values, [
+                "What makes you so sure you're right about it?",
+                "Have you ever tested it in conversation?",
+            ]),
+            ("What's the worst advice you've ever followed?", .growth, [
+                "What made you trust it at the time?",
+                "What did the fallout teach you?",
+            ]),
+            ("What's a part of yourself you've had to fight to accept?", .identity, [
+                "What made the acceptance so hard?",
+                "Are you fully there, or still working on it?",
+            ]),
+            ("What's something you've done that you'll never fully explain to anyone?", .past, [
+                "What would someone need to understand to make sense of it?",
+                "Does keeping it to yourself feel like protection or a burden?",
+            ]),
+            ("When have you been the villain in someone else's story?", .conflict, [
+                "Do you agree with their version of it?",
+                "What would your side of the story sound like?",
+            ]),
+            ("What's a belief you held strongly that completely fell apart?", .values, [
+                "What caused it to collapse?",
+                "What do you believe now in its place?",
+            ]),
+            ("What's something about the way you were raised that you've had to unlearn?", .growth, [
+                "When did you first realize it wasn't serving you?",
+                "What did you replace it with?",
+            ]),
+            ("What's the loneliest you've ever felt in a room full of people?", .emotions, [
+                "What was happening around you that made it worse?",
+                "What would have made you feel less alone?",
+            ]),
+            ("What's a side of yourself that only comes out when you're angry?", .identity, [
+                "Are you afraid of that side or do you trust it?",
+                "What does it usually look like when it shows up?",
+            ]),
+            ("What's something you've said that you can never take back?", .conflict, [
+                "Do you wish you could, or do you stand by it?",
+                "How did it change things between you and that person?",
+            ]),
+            ("What's a truth about yourself that most people couldn't handle?", .identity, [
+                "What makes you think they couldn't handle it?",
+                "Who in your life could?",
+            ]),
+            ("When was the last time you seriously considered cutting someone off?", .conflict, [
+                "What brought you to that edge?",
+                "Did you go through with it?",
+            ]),
+            ("What's something you judge other people for that you're also guilty of?", .values, [
+                "Why is it easier to see the flaw in others than in yourself?",
+                "What would change if you applied the same standard to yourself?",
+            ]),
+            ("What's the most selfish thing you've done that you don't regret?", .values, [
+                "What did putting yourself first give you?",
+                "Would you make the same choice again?",
+            ]),
+            ("What's a feeling you've been suppressing for way too long?", .emotions, [
+                "What are you afraid would happen if you let it surface?",
+                "What's it costing you to keep it down?",
+            ]),
+            ("What's something you've never been able to forgive yourself for?", .emotions, [
+                "What would forgiving yourself actually require?",
+                "Do you think you deserve that forgiveness?",
+            ]),
+            ("What do you wish people would stop pretending to care about?", .values, [
+                "What does the performance bother you about specifically?",
+                "What would genuine care look like instead?",
+            ]),
+            ("What's a moment where you realized a friendship was one-sided?", .conflict, [
+                "What made it suddenly clear?",
+                "What did you do with that realization?",
+            ]),
+            ("What's something dark you've thought about that you'd never say out loud?", .emotions, [
+                "What do you think that thought says about you?",
+                "Does having it scare you or do you accept it as part of being human?",
+            ]),
+            ("What's the most honest thing you've ever said to someone's face?", .communication, [
+                "How did they take it?",
+                "Would you say it again?",
+            ]),
+            ("What's an experience that hardened you in a way others don't see?", .past, [
+                "What part of you did it close off?",
+                "Do you see the hardening as protection or damage?",
+            ]),
+            ("When did you last feel truly ashamed of yourself?", .emotions, [
+                "What triggered the shame?",
+                "Have you been able to work through it?",
+            ]),
+            ("What's a secret you've kept from your closest friends?", .intimacy, [
+                "What would change in those friendships if they knew?",
+                "What's kept you from sharing it?",
+            ]),
+            ("What's a way you've manipulated a situation that you're not proud of?", .conflict, [
+                "What were you trying to get out of it?",
+                "Would you handle it differently now?",
+            ]),
+            ("What's a double standard you hold that you know isn't fair?", .values, [
+                "What makes it hard to let go of?",
+                "Has anyone ever called you on it?",
+            ]),
+            ("What's something you lost respect for someone over?", .conflict, [
+                "Was it one moment or a slow build?",
+                "Did you ever tell them?",
+            ]),
+            ("When's the last time you cried and what set it off?", .emotions, [
+                "Did you let yourself fully go there or try to hold it together?",
+                "What did the cry release in you?",
+            ]),
+            ("What's a question you're afraid someone might ask you?", .emotions, [
+                "What's the honest answer you'd have to give?",
+                "What makes that truth feel so dangerous?",
+            ]),
         ], mode: .friends, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -597,13 +1360,34 @@ private extension PromptBank {
 
     static func friends_unfiltered_realTalk() -> [Prompt] {
         make([
-            ("When's a time you should have admitted you were wrong but couldn't bring yourself to?", .conflict),
-            ("What's something you've never told anyone how you really feel about?", .emotions),
-            ("What's something you really hope certain people never find out about?", .intimacy),
-            ("Who was the last person who really pushed you past your breaking point?", .conflict),
-            ("What's a grudge you've been carrying longer than you probably should?", .conflict),
-            ("What's a relationship you damaged that you sometimes still think about?", .conflict),
-            ("What does loyalty actually mean to you when it gets tested?", .values),
+            ("When's a time you should have admitted you were wrong but couldn't bring yourself to?", .conflict, [
+                "What was at stake that made the admission feel impossible?",
+                "Do you think the other person knew you were wrong?",
+            ]),
+            ("What's something you've never told anyone how you really feel about?", .emotions, [
+                "What has keeping it inside done to you?",
+                "What would finally saying it change?",
+            ]),
+            ("What's something you really hope certain people never find out about?", .intimacy, [
+                "What are you most afraid they'd think?",
+                "Would the truth actually be as bad as you imagine?",
+            ]),
+            ("Who was the last person who really pushed you past your breaking point?", .conflict, [
+                "What did your breaking point look like?",
+                "How did you come back from it?",
+            ]),
+            ("What's a grudge you've been carrying longer than you probably should?", .conflict, [
+                "What would it take to finally set it down?",
+                "What is holding onto it giving you?",
+            ]),
+            ("What's a relationship you damaged that you sometimes still think about?", .conflict, [
+                "What do you think you would have done differently?",
+                "Do you think repair is still possible?",
+            ]),
+            ("What does loyalty actually mean to you when it gets tested?", .values, [
+                "When has your loyalty been tested the hardest?",
+                "Where do you draw the line between loyalty and self-respect?",
+            ]),
         ], mode: .friends, intensity: .unfiltered, depth: .realTalk)
     }
 
@@ -611,9 +1395,18 @@ private extension PromptBank {
 
     static func friends_unfiltered_deepDive() -> [Prompt] {
         make([
-            ("Is there a friendship you've outgrown but haven't walked away from yet?", .conflict),
-            ("What's a story you've told before but never the complete, honest version?", .intimacy),
-            ("When did someone break your trust in a way that changed how you operate?", .conflict),
+            ("Is there a friendship you've outgrown but haven't walked away from yet?", .conflict, [
+                "What's keeping you in it?",
+                "What would walking away actually cost you?",
+            ]),
+            ("What's a story you've told before but never the complete, honest version?", .intimacy, [
+                "What's the part you always leave out?",
+                "What would the full version reveal about you?",
+            ]),
+            ("When did someone break your trust in a way that changed how you operate?", .conflict, [
+                "What defense did you build because of it?",
+                "Has anyone since earned back the kind of trust you lost?",
+            ]),
         ], mode: .friends, intensity: .unfiltered, depth: .deepDive)
     }
 
@@ -621,36 +1414,126 @@ private extension PromptBank {
 
     static func family_light_warmUp() -> [Prompt] {
         make([
-            ("What's a value from your culture or background that really matters to you?", .values),
-            ("What's a moment from your younger years you can't believe you walked away from?", .past),
-            ("What's a story you know you've told way too many times?", .dailyLife),
-            ("What's a smell that instantly takes you back to a specific moment?", .past),
-            ("What's something you genuinely can't believe you got away with growing up?", .past),
-            ("What completely breaks your willpower every single time?", .dailyLife),
-            ("What's something you miss being able to do that you used to take for granted?", .past),
-            ("What do you wish you could still get away with?", .past),
-            ("What's your most irrational fear — the one that makes no logical sense?", .emotions),
-            ("What's the best prank you've ever managed to pull off?", .dailyLife),
-            ("What's a totally normal thing that makes you weirdly self-conscious?", .dailyLife),
-            ("What's the most uncomfortable gathering you've ever had to sit through?", .dailyLife),
-            ("What did you used to daydream about for hours as a kid?", .past),
-            ("What's the last thing you saw or read that you definitely weren't supposed to?", .dailyLife),
-            ("What's the most meaningful gift anyone has ever given you?", .appreciation),
-            ("What makes you the proudest about your family?", .appreciation),
-            ("What's a guilty pleasure you will always defend?", .dailyLife),
-            ("What's a family recipe or tradition you never want to lose?", .values),
-            ("What's the funniest thing that ever happened at a family gathering?", .dailyLife),
-            ("What's something a family member taught you that you still use today?", .appreciation),
-            ("What's a nickname from your childhood and how did you get it?", .past),
-            ("What's a family trip or vacation you'll never forget?", .past),
-            ("What did you get in trouble for the most as a kid?", .past),
-            ("What's a song or movie that always reminds you of your family?", .appreciation),
-            ("What's something your family is surprisingly competitive about?", .dailyLife),
-            ("What's a family joke that an outsider would never understand?", .dailyLife),
-            ("What's a skill you picked up from watching a family member?", .growth),
-            ("What's the best piece of advice a family member ever gave you?", .values),
-            ("What holiday tradition means the most to you and why?", .values),
-            ("Who in your family always knows how to make you feel better?", .appreciation),
+            ("What's a value from your culture or background that really matters to you?", .values, [
+                "How do you try to live that value out day to day?",
+                "Is it something you want to pass on?",
+            ]),
+            ("What's a moment from your younger years you can't believe you walked away from?", .past, [
+                "What do you think kept you safe?",
+                "How did it change the risks you take now?",
+            ]),
+            ("What's a story you know you've told way too many times?", .dailyLife, [
+                "What is it about that story that keeps pulling you back?",
+                "Does anyone in your life finish it for you at this point?",
+            ]),
+            ("What's a smell that instantly takes you back to a specific moment?", .past, [
+                "What's the memory tied to it?",
+                "How does it make you feel when it hits you unexpectedly?",
+            ]),
+            ("What's something you genuinely can't believe you got away with growing up?", .past, [
+                "Would you be proud or horrified if your kids did the same?",
+                "Who else knows about it?",
+            ]),
+            ("What completely breaks your willpower every single time?", .dailyLife, [
+                "What is it about that thing that makes you cave?",
+                "Have you ever successfully resisted, and how?",
+            ]),
+            ("What's something you miss being able to do that you used to take for granted?", .past, [
+                "When did you stop being able to do it?",
+                "What would it mean to get it back?",
+            ]),
+            ("What do you wish you could still get away with?", .past, [
+                "What made it possible back then?",
+                "What changed?",
+            ]),
+            ("What's your most irrational fear — the one that makes no logical sense?", .emotions, [
+                "How do you deal with it when it comes up?",
+                "Do you have any idea where it started?",
+            ]),
+            ("What's the best prank you've ever managed to pull off?", .dailyLife, [
+                "How did the person react?",
+                "Did it become a legendary family story?",
+            ]),
+            ("What's a totally normal thing that makes you weirdly self-conscious?", .dailyLife, [
+                "When did you first notice it bothered you?",
+                "Do other people pick up on it?",
+            ]),
+            ("What's the most uncomfortable gathering you've ever had to sit through?", .dailyLife, [
+                "What made it so painful?",
+                "How did you survive it?",
+            ]),
+            ("What did you used to daydream about for hours as a kid?", .past, [
+                "Is any part of that daydream still alive in you?",
+                "What does it say about what you wanted most?",
+            ]),
+            ("What's the last thing you saw or read that you definitely weren't supposed to?", .dailyLife, [
+                "How did it affect you?",
+                "Did you tell anyone about it?",
+            ]),
+            ("What's the most meaningful gift anyone has ever given you?", .appreciation, [
+                "What made it so special?",
+                "Do you still have it?",
+            ]),
+            ("What makes you the proudest about your family?", .appreciation, [
+                "Is that something your family knows you feel?",
+                "What do you think built that quality?",
+            ]),
+            ("What's a guilty pleasure you will always defend?", .dailyLife, [
+                "Why does it bring you so much joy?",
+                "Who gives you the hardest time about it?",
+            ]),
+            ("What's a family recipe or tradition you never want to lose?", .values, [
+                "What memory is attached to it?",
+                "Are you the one keeping it alive?",
+            ]),
+            ("What's the funniest thing that ever happened at a family gathering?", .dailyLife, [
+                "Who was at the center of it?",
+                "Does it still come up at every gathering?",
+            ]),
+            ("What's something a family member taught you that you still use today?", .appreciation, [
+                "Were they teaching you on purpose or was it just by example?",
+                "Have you ever thanked them for it?",
+            ]),
+            ("What's a nickname from your childhood and how did you get it?", .past, [
+                "Do you love it or wish it would die?",
+                "Does anyone still call you that?",
+            ]),
+            ("What's a family trip or vacation you'll never forget?", .past, [
+                "What made it so memorable — something that went right or hilariously wrong?",
+                "Who do you associate that trip with most?",
+            ]),
+            ("What did you get in trouble for the most as a kid?", .past, [
+                "Were you actually guilty most of the time?",
+                "Do you see any of that same behavior in yourself now?",
+            ]),
+            ("What's a song or movie that always reminds you of your family?", .appreciation, [
+                "What feeling does it bring up?",
+                "Is it a happy association or a complicated one?",
+            ]),
+            ("What's something your family is surprisingly competitive about?", .dailyLife, [
+                "Who's the worst competitor in the family?",
+                "Has it ever gotten out of hand?",
+            ]),
+            ("What's a family joke that an outsider would never understand?", .dailyLife, [
+                "What's the story behind it?",
+                "Who started it?",
+            ]),
+            ("What's a skill you picked up from watching a family member?", .growth, [
+                "Did they know you were learning from them?",
+                "How has that skill shaped your life?",
+            ]),
+            ("What's the best piece of advice a family member ever gave you?", .values, [
+                "When did you first realize they were right?",
+                "Has it held up over time?",
+            ]),
+            ("What holiday tradition means the most to you and why?", .values, [
+                "What would it feel like if that tradition stopped?",
+                "What does it represent to you beyond the tradition itself?",
+            ]),
+            ("Who in your family always knows how to make you feel better?", .appreciation, [
+                "What do they do that works so well?",
+                "Do they know they have that power?",
+            ]),
         ], mode: .family, intensity: .light, depth: .warmUp)
     }
 
@@ -658,11 +1541,26 @@ private extension PromptBank {
 
     static func family_light_realTalk() -> [Prompt] {
         make([
-            ("What's a story about you that you'd love to see passed down in your family?", .values),
-            ("What's one day in your life you know you'll never forget?", .past),
-            ("How did you see the world when you were young, and when did that change?", .past),
-            ("What's the kindest thing anyone has ever done for you?", .appreciation),
-            ("What's something your family does that you didn't appreciate until you were older?", .appreciation),
+            ("What's a story about you that you'd love to see passed down in your family?", .values, [
+                "What does that story capture about who you are?",
+                "Who would you want to be the one telling it?",
+            ]),
+            ("What's one day in your life you know you'll never forget?", .past, [
+                "What made that day burn itself into your memory?",
+                "How did it change you?",
+            ]),
+            ("How did you see the world when you were young, and when did that change?", .past, [
+                "What experience was the turning point?",
+                "Do you miss seeing things that way?",
+            ]),
+            ("What's the kindest thing anyone has ever done for you?", .appreciation, [
+                "What made it feel so deeply kind?",
+                "Did it change what you believe people are capable of?",
+            ]),
+            ("What's something your family does that you didn't appreciate until you were older?", .appreciation, [
+                "What made you finally see it differently?",
+                "Have you told them you appreciate it now?",
+            ]),
         ], mode: .family, intensity: .light, depth: .realTalk)
     }
 
@@ -670,10 +1568,22 @@ private extension PromptBank {
 
     static func family_light_deepDive() -> [Prompt] {
         make([
-            ("How has your idea of what family means changed over the years?", .values),
-            ("What do you hope the next generation picks up from how we are?", .values),
-            ("What moment brought us closer than anything else?", .intimacy),
-            ("What's your favorite thing about being part of this family?", .appreciation),
+            ("How has your idea of what family means changed over the years?", .values, [
+                "What experience shifted it the most?",
+                "What does family mean to you now that it didn't before?",
+            ]),
+            ("What do you hope the next generation picks up from how we are?", .values, [
+                "What's the one thing you'd want them to carry forward?",
+                "What would you hope they leave behind?",
+            ]),
+            ("What moment brought us closer than anything else?", .intimacy, [
+                "What was it about that moment that broke through?",
+                "How did things feel different after?",
+            ]),
+            ("What's your favorite thing about being part of this family?", .appreciation, [
+                "When do you feel that the strongest?",
+                "Is there anything you'd add to make it even better?",
+            ]),
         ], mode: .family, intensity: .light, depth: .deepDive)
     }
 
@@ -681,36 +1591,126 @@ private extension PromptBank {
 
     static func family_honest_warmUp() -> [Prompt] {
         make([
-            ("What feelings come up for you around family gatherings?", .emotions),
-            ("What's something you think this family avoids talking about?", .communication),
-            ("What's something that's changed in this family that you're still adjusting to?", .emotions),
-            ("What's a family expectation you've struggled to live up to?", .values),
-            ("What's something you wish you had said to a family member sooner?", .communication),
-            ("When did you first realize your family wasn't like everyone else's?", .past),
-            ("What's a way your family shows love that took you a while to recognize?", .appreciation),
-            ("What role do you play in your family and how do you feel about it?", .identity),
-            ("What's something you've inherited from your parents — a habit or trait — that surprises you?", .identity),
-            ("What's a family memory that still makes you emotional?", .emotions),
-            ("What do you wish your parents had done differently?", .past),
-            ("What's a sacrifice a family member made for you that you think about often?", .appreciation),
-            ("What's something about your upbringing you didn't question until you were older?", .growth),
-            ("How has your relationship with a family member changed over the years?", .growth),
-            ("What's the most important thing your family taught you about trust?", .values),
-            ("What's a misunderstanding in your family that was never properly cleared up?", .conflict),
-            ("What do you think your family worries about most when it comes to you?", .emotions),
-            ("What's a moment where your family really came together?", .appreciation),
-            ("What's something about your family dynamic that outsiders wouldn't understand?", .communication),
-            ("When did you feel the most supported by your family?", .appreciation),
-            ("What's a conversation you keep having with family that never goes anywhere?", .conflict),
-            ("What's something you appreciate about your family that you rarely say?", .appreciation),
-            ("What's a lesson your family taught you through their mistakes?", .growth),
-            ("What's a way you've tried to break a family pattern?", .growth),
-            ("What emotion do you associate most with your childhood home?", .emotions),
-            ("What's something you've forgiven a family member for that was really hard?", .conflict),
-            ("What do you think your family's greatest strength is?", .appreciation),
-            ("What's a story about your parents' early life that changed how you see them?", .past),
-            ("What's something your family doesn't talk about but probably should?", .communication),
-            ("When have you felt the proudest to be part of your family?", .appreciation),
+            ("What feelings come up for you around family gatherings?", .emotions, [
+                "Is it more anticipation, dread, or something in between?",
+                "How do you usually cope with whatever comes up?",
+            ]),
+            ("What's something you think this family avoids talking about?", .communication, [
+                "What do you think would happen if someone finally brought it up?",
+                "How does the silence around it affect everyone?",
+            ]),
+            ("What's something that's changed in this family that you're still adjusting to?", .emotions, [
+                "What part of the change has been hardest?",
+                "What would help you adjust?",
+            ]),
+            ("What's a family expectation you've struggled to live up to?", .values, [
+                "Do you want to meet that expectation, or let it go?",
+                "What pressure does it put on you?",
+            ]),
+            ("What's something you wish you had said to a family member sooner?", .communication, [
+                "What stopped you from saying it when it mattered?",
+                "Is there still time?",
+            ]),
+            ("When did you first realize your family wasn't like everyone else's?", .past, [
+                "How did that realization hit you?",
+                "Did it change the way you felt about your family?",
+            ]),
+            ("What's a way your family shows love that took you a while to recognize?", .appreciation, [
+                "What did you think it was before you understood it as love?",
+                "How do you feel about it now?",
+            ]),
+            ("What role do you play in your family and how do you feel about it?", .identity, [
+                "Did you choose that role or did it choose you?",
+                "What would happen if you stopped playing it?",
+            ]),
+            ("What's something you've inherited from your parents — a habit or trait — that surprises you?", .identity, [
+                "When did you first notice it in yourself?",
+                "Is it something you want to keep or let go of?",
+            ]),
+            ("What's a family memory that still makes you emotional?", .emotions, [
+                "What about it still gets to you?",
+                "Who else in your family shares that memory?",
+            ]),
+            ("What do you wish your parents had done differently?", .past, [
+                "How do you think it would have changed you?",
+                "Have you been able to talk to them about it?",
+            ]),
+            ("What's a sacrifice a family member made for you that you think about often?", .appreciation, [
+                "Do they know how much it meant to you?",
+                "How did it shape the way you show up for others?",
+            ]),
+            ("What's something about your upbringing you didn't question until you were older?", .growth, [
+                "What made you start questioning it?",
+                "How did the new perspective change you?",
+            ]),
+            ("How has your relationship with a family member changed over the years?", .growth, [
+                "What caused the biggest shift?",
+                "Is the current version better or just different?",
+            ]),
+            ("What's the most important thing your family taught you about trust?", .values, [
+                "Was it taught through example or through a lesson learned the hard way?",
+                "How does that understanding show up in your relationships now?",
+            ]),
+            ("What's a misunderstanding in your family that was never properly cleared up?", .conflict, [
+                "Does it still affect how you relate to each other?",
+                "What would it take to finally clear the air?",
+            ]),
+            ("What do you think your family worries about most when it comes to you?", .emotions, [
+                "Is their worry justified?",
+                "How do you feel knowing they carry that concern?",
+            ]),
+            ("What's a moment where your family really came together?", .appreciation, [
+                "What brought everyone together?",
+                "What did you learn about your family in that moment?",
+            ]),
+            ("What's something about your family dynamic that outsiders wouldn't understand?", .communication, [
+                "Does it work for you, or do you wish it were different?",
+                "What would you want someone outside to know?",
+            ]),
+            ("When did you feel the most supported by your family?", .appreciation, [
+                "What did that support look like?",
+                "Did it change what you expect from them going forward?",
+            ]),
+            ("What's a conversation you keep having with family that never goes anywhere?", .conflict, [
+                "Why do you think it keeps stalling?",
+                "What would a breakthrough actually look like?",
+            ]),
+            ("What's something you appreciate about your family that you rarely say?", .appreciation, [
+                "What makes it hard to say out loud?",
+                "What do you think it would mean to them to hear it?",
+            ]),
+            ("What's a lesson your family taught you through their mistakes?", .growth, [
+                "How did watching that mistake affect you growing up?",
+                "Has it changed the way you handle similar situations?",
+            ]),
+            ("What's a way you've tried to break a family pattern?", .growth, [
+                "How has that effort gone?",
+                "What makes the pattern so hard to break?",
+            ]),
+            ("What emotion do you associate most with your childhood home?", .emotions, [
+                "Is that emotion something you carry with you still?",
+                "How does it color the way you think about home now?",
+            ]),
+            ("What's something you've forgiven a family member for that was really hard?", .conflict, [
+                "What did forgiving them cost you?",
+                "Did the forgiveness change the relationship?",
+            ]),
+            ("What do you think your family's greatest strength is?", .appreciation, [
+                "When does that strength show up the most?",
+                "How do you contribute to it?",
+            ]),
+            ("What's a story about your parents' early life that changed how you see them?", .past, [
+                "What did it help you understand about who they are?",
+                "Did it make you feel closer to them or more complicated about them?",
+            ]),
+            ("What's something your family doesn't talk about but probably should?", .communication, [
+                "What keeps the silence going?",
+                "Who do you think would need to go first?",
+            ]),
+            ("When have you felt the proudest to be part of your family?", .appreciation, [
+                "What sparked that pride?",
+                "Do you think your family knows you feel that way?",
+            ]),
         ], mode: .family, intensity: .honest, depth: .warmUp)
     }
 
@@ -718,14 +1718,38 @@ private extension PromptBank {
 
     static func family_honest_realTalk() -> [Prompt] {
         make([
-            ("What's a conversation you know you need to have with your parents?", .communication),
-            ("What's a decision someone else made that ended up changing the course of your life?", .past),
-            ("Who really holds the power in your family, and how does that affect everyone?", .communication),
-            ("What about being a parent — or the idea of it — genuinely worries you?", .emotions),
-            ("What's something from your childhood that you later realized wasn't everyone's normal?", .past),
-            ("What's something about your background you wish more people took the time to understand?", .values),
-            ("What comes up for you when you see a photo of yourself as a kid?", .past),
-            ("What's something you did that you refuse to apologize for?", .values),
+            ("What's a conversation you know you need to have with your parents?", .communication, [
+                "What's been holding it back?",
+                "How do you imagine it going?",
+            ]),
+            ("What's a decision someone else made that ended up changing the course of your life?", .past, [
+                "Did you have any say in it at the time?",
+                "How do you feel about it now — grateful, resentful, or somewhere in between?",
+            ]),
+            ("Who really holds the power in your family, and how does that affect everyone?", .communication, [
+                "Is that power dynamic acknowledged or unspoken?",
+                "How has it shaped your own relationship with authority?",
+            ]),
+            ("What about being a parent — or the idea of it — genuinely worries you?", .emotions, [
+                "Where do you think that worry comes from?",
+                "What pattern are you most afraid of repeating?",
+            ]),
+            ("What's something from your childhood that you later realized wasn't everyone's normal?", .past, [
+                "How did that realization land?",
+                "Has it changed the way you see your upbringing?",
+            ]),
+            ("What's something about your background you wish more people took the time to understand?", .values, [
+                "How would your experience change if they really got it?",
+                "What's the most common misunderstanding?",
+            ]),
+            ("What comes up for you when you see a photo of yourself as a kid?", .past, [
+                "What do you feel looking at that version of yourself?",
+                "What would you want that kid to know?",
+            ]),
+            ("What's something you did that you refuse to apologize for?", .values, [
+                "What principle are you standing on?",
+                "Does anyone in your life still hold it against you?",
+            ]),
         ], mode: .family, intensity: .honest, depth: .realTalk)
     }
 
@@ -733,12 +1757,30 @@ private extension PromptBank {
 
     static func family_honest_deepDive() -> [Prompt] {
         make([
-            ("What do you wish someone had told you when you were growing up?", .past),
-            ("What's an experience that shaped who you are that almost nobody knows about?", .past),
-            ("What did your parents teach you about love — whether they meant to or not?", .intimacy),
-            ("Who taught you the most about what love actually looks like?", .intimacy),
-            ("If you could change one thing about the way you were raised, what would it be?", .past),
-            ("What would you go back and whisper to your younger self?", .past),
+            ("What do you wish someone had told you when you were growing up?", .past, [
+                "How would hearing it have changed things for you?",
+                "Who do you wish had been the one to say it?",
+            ]),
+            ("What's an experience that shaped who you are that almost nobody knows about?", .past, [
+                "Why have you kept it so private?",
+                "What would sharing it mean for you?",
+            ]),
+            ("What did your parents teach you about love — whether they meant to or not?", .intimacy, [
+                "Was it a lesson you had to unlearn or one you're grateful for?",
+                "How does it show up in your relationships now?",
+            ]),
+            ("Who taught you the most about what love actually looks like?", .intimacy, [
+                "What did they do that made the lesson stick?",
+                "Did they know they were teaching you?",
+            ]),
+            ("If you could change one thing about the way you were raised, what would it be?", .past, [
+                "How do you think that one change would have rippled through your life?",
+                "Have you been able to talk to your parents about it?",
+            ]),
+            ("What would you go back and whisper to your younger self?", .past, [
+                "What's the one thing that kid needed to hear most?",
+                "Do you think they would have listened?",
+            ]),
         ], mode: .family, intensity: .honest, depth: .deepDive)
     }
 
@@ -746,36 +1788,126 @@ private extension PromptBank {
 
     static func family_unfiltered_warmUp() -> [Prompt] {
         make([
-            ("What role do you play in your family, and how did that happen?", .identity),
-            ("What conversation are you dreading that you know needs to happen?", .conflict),
-            ("What would change if everyone in this family said what they actually meant?", .communication),
-            ("What's a family secret that shaped you more than anyone realizes?", .past),
-            ("What's the biggest lie your family tells itself?", .communication),
-            ("What's something about your childhood you've never fully processed?", .emotions),
-            ("What's a wound from your family that still hasn't healed?", .emotions),
-            ("When did you stop trying to earn a family member's approval?", .growth),
-            ("What's something you resent about how responsibilities are divided in your family?", .conflict),
-            ("What's a part of your family history that feels heavy to carry?", .past),
-            ("What's something a family member did that you've never been able to fully forgive?", .conflict),
-            ("What do you wish your parents really knew about your life right now?", .communication),
-            ("What's a way your family made you feel small without realizing it?", .emotions),
-            ("What's a toxic pattern in your family that you're trying not to repeat?", .growth),
-            ("What's the hardest thing about loving someone in your family?", .emotions),
-            ("What's a part of your identity that your family still doesn't fully accept?", .identity),
-            ("What would your younger self think about your relationship with your family now?", .past),
-            ("What's a boundary with family that you had to fight to set?", .conflict),
-            ("What's something you've never confronted a family member about but probably should?", .communication),
-            ("What's a way your family dealt with conflict that you've had to unlearn?", .conflict),
-            ("What's the most painful thing a family member has ever said to you?", .emotions),
-            ("When have you felt like the black sheep of your family?", .identity),
-            ("What's something about your parents' relationship that affected how you see love?", .intimacy),
-            ("What's an unfair expectation that was placed on you growing up?", .values),
-            ("What's a truth about your family that nobody outside would believe?", .communication),
-            ("What do you carry from your family that you wish you could put down?", .emotions),
-            ("What's a sacrifice you made for your family that went unnoticed?", .appreciation),
-            ("What's something you swore you'd never do as a parent that you catch yourself doing?", .growth),
-            ("When did you first realize you were repeating a family pattern?", .growth),
-            ("What's the thing your family is most in denial about?", .communication),
+            ("What role do you play in your family, and how did that happen?", .identity, [
+                "Is it a role you want, or one that was assigned to you?",
+                "What would that free you to be?",
+            ]),
+            ("What conversation are you dreading that you know needs to happen?", .conflict, [
+                "What's the worst outcome you're imagining?",
+                "What would waiting any longer cost you?",
+            ]),
+            ("What would change if everyone in this family said what they actually meant?", .communication, [
+                "Would it bring you closer or blow things apart?",
+                "Who has the most they're holding back?",
+            ]),
+            ("What's a family secret that shaped you more than anyone realizes?", .past, [
+                "How did you find out about it?",
+                "What did carrying that knowledge do to you?",
+            ]),
+            ("What's the biggest lie your family tells itself?", .communication, [
+                "Who benefits from keeping that lie alive?",
+                "What would the truth demand from everyone?",
+            ]),
+            ("What's something about your childhood you've never fully processed?", .emotions, [
+                "What happens when it surfaces?",
+                "What do you think processing it would require?",
+            ]),
+            ("What's a wound from your family that still hasn't healed?", .emotions, [
+                "What keeps it from healing?",
+                "What would healing actually look like for you?",
+            ]),
+            ("When did you stop trying to earn a family member's approval?", .growth, [
+                "What was the final straw?",
+                "How did letting go of it change you?",
+            ]),
+            ("What's something you resent about how responsibilities are divided in your family?", .conflict, [
+                "Have you ever brought it up?",
+                "What would fair actually look like to you?",
+            ]),
+            ("What's a part of your family history that feels heavy to carry?", .past, [
+                "Do you feel responsible for that weight?",
+                "Who else in the family carries it with you?",
+            ]),
+            ("What's something a family member did that you've never been able to fully forgive?", .conflict, [
+                "What would forgiveness require from you?",
+                "What keeps the wound open?",
+            ]),
+            ("What do you wish your parents really knew about your life right now?", .communication, [
+                "What's stopped you from telling them?",
+                "How do you think they'd react?",
+            ]),
+            ("What's a way your family made you feel small without realizing it?", .emotions, [
+                "Does it still happen?",
+                "How has that feeling shaped the way you see yourself?",
+            ]),
+            ("What's a toxic pattern in your family that you're trying not to repeat?", .growth, [
+                "When do you catch yourself falling into it?",
+                "What's your alternative look like?",
+            ]),
+            ("What's the hardest thing about loving someone in your family?", .emotions, [
+                "What makes the love complicated?",
+                "Is the difficulty worth it?",
+            ]),
+            ("What's a part of your identity that your family still doesn't fully accept?", .identity, [
+                "How does their lack of acceptance affect you day to day?",
+                "Have you stopped trying to get them to see it?",
+            ]),
+            ("What would your younger self think about your relationship with your family now?", .past, [
+                "Would they be relieved, confused, or heartbroken?",
+                "What would you want to explain to them?",
+            ]),
+            ("What's a boundary with family that you had to fight to set?", .conflict, [
+                "What did it cost you to hold that line?",
+                "Has it been respected since?",
+            ]),
+            ("What's something you've never confronted a family member about but probably should?", .communication, [
+                "What's held you back?",
+                "What would you say if you finally did?",
+            ]),
+            ("What's a way your family dealt with conflict that you've had to unlearn?", .conflict, [
+                "What did you replace it with?",
+                "Was the unlearning gradual or forced by a specific moment?",
+            ]),
+            ("What's the most painful thing a family member has ever said to you?", .emotions, [
+                "Do you think they knew how much it hurt?",
+                "How did it change the way you relate to them?",
+            ]),
+            ("When have you felt like the black sheep of your family?", .identity, [
+                "Was it something you did or just who you are?",
+                "Have you made peace with that outsider feeling?",
+            ]),
+            ("What's something about your parents' relationship that affected how you see love?", .intimacy, [
+                "Was it something you wanted to replicate or avoid?",
+                "How does it show up in your own relationships?",
+            ]),
+            ("What's an unfair expectation that was placed on you growing up?", .values, [
+                "Who put it there?",
+                "Have you been able to let it go, or does it still drive you?",
+            ]),
+            ("What's a truth about your family that nobody outside would believe?", .communication, [
+                "What would someone need to see to understand?",
+                "How do you hold that truth and the public version at the same time?",
+            ]),
+            ("What do you carry from your family that you wish you could put down?", .emotions, [
+                "What keeps you holding onto it?",
+                "What would your life look like without that weight?",
+            ]),
+            ("What's a sacrifice you made for your family that went unnoticed?", .appreciation, [
+                "How did it feel to give that without recognition?",
+                "Would you do it again?",
+            ]),
+            ("What's something you swore you'd never do as a parent that you catch yourself doing?", .growth, [
+                "How does it feel when you notice it?",
+                "What are you trying to do differently in spite of it?",
+            ]),
+            ("When did you first realize you were repeating a family pattern?", .growth, [
+                "What tipped you off?",
+                "Have you been able to interrupt it?",
+            ]),
+            ("What's the thing your family is most in denial about?", .communication, [
+                "What would acknowledging it require from everyone?",
+                "Do you think anyone else in the family sees it too?",
+            ]),
         ], mode: .family, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -783,10 +1915,22 @@ private extension PromptBank {
 
     static func family_unfiltered_realTalk() -> [Prompt] {
         make([
-            ("What subjects are the hardest to bring up in your family?", .communication),
-            ("What's a topic that's completely off-limits in your family?", .communication),
-            ("What's something you hope your kids — or future kids — never learn about you?", .past),
-            ("What's a question you've always wanted to ask your parents but never have?", .communication),
+            ("What subjects are the hardest to bring up in your family?", .communication, [
+                "What makes those topics feel off-limits?",
+                "What do you think would happen if you went there anyway?",
+            ]),
+            ("What's a topic that's completely off-limits in your family?", .communication, [
+                "Who enforces that boundary?",
+                "What do you think the silence is protecting?",
+            ]),
+            ("What's something you hope your kids — or future kids — never learn about you?", .past, [
+                "What are you afraid it would change about how they see you?",
+                "Is it something you've made peace with yourself?",
+            ]),
+            ("What's a question you've always wanted to ask your parents but never have?", .communication, [
+                "What are you afraid the answer might be?",
+                "What would it change if you finally asked?",
+            ]),
         ], mode: .family, intensity: .unfiltered, depth: .realTalk)
     }
 
@@ -794,13 +1938,34 @@ private extension PromptBank {
 
     static func family_unfiltered_deepDive() -> [Prompt] {
         make([
-            ("What's something that was taken from you — not necessarily a physical thing?", .past),
-            ("Whose loss are you the most afraid of?", .emotions),
-            ("Who are you most afraid of losing in your life?", .emotions),
-            ("What trait of your parents are you most afraid of seeing in yourself?", .past),
-            ("How has your experience with loss or death shaped the way you live?", .past),
-            ("What's something you've never told your parents?", .communication),
-            ("What's a conversation from your past you wish you could have one more time?", .communication),
+            ("What's something that was taken from you — not necessarily a physical thing?", .past, [
+                "How did losing that shape who you became?",
+                "Do you think you'll ever get it back in some form?",
+            ]),
+            ("Whose loss are you the most afraid of?", .emotions, [
+                "What would that loss take from your world?",
+                "Does the fear of it change how you love them now?",
+            ]),
+            ("Who are you most afraid of losing in your life?", .emotions, [
+                "What makes that person irreplaceable to you?",
+                "How does that fear affect the way you hold onto them?",
+            ]),
+            ("What trait of your parents are you most afraid of seeing in yourself?", .past, [
+                "When do you catch glimpses of it?",
+                "What do you do when you see it surface?",
+            ]),
+            ("How has your experience with loss or death shaped the way you live?", .past, [
+                "What did loss teach you that nothing else could?",
+                "Has it made you hold tighter or let go more?",
+            ]),
+            ("What's something you've never told your parents?", .communication, [
+                "What would it mean for them to finally know?",
+                "What's kept you from saying it all this time?",
+            ]),
+            ("What's a conversation from your past you wish you could have one more time?", .communication, [
+                "What would you say differently?",
+                "What do you wish you had heard?",
+            ]),
         ], mode: .family, intensity: .unfiltered, depth: .deepDive)
     }
 
@@ -808,36 +1973,126 @@ private extension PromptBank {
 
     static func solo_light_warmUp() -> [Prompt] {
         make([
-            ("What do you spend too much time doing that you probably shouldn't?", .dailyLife),
-            ("What are you feeling genuinely proud of right now?", .appreciation),
-            ("What keeps showing up in your dreams lately?", .emotions),
-            ("What have you been quietly getting better at without anyone noticing?", .appreciation),
-            ("What do you do when you're completely alone and nobody can see?", .dailyLife),
-            ("What do you catch yourself complaining about the most?", .dailyLife),
-            ("What's something you used to know how to do but have completely lost?", .past),
-            ("What's a small win you had recently that you didn't celebrate enough?", .appreciation),
-            ("What's the last thing that genuinely surprised you about yourself?", .identity),
-            ("What's a comfort food that always makes everything a little better?", .dailyLife),
-            ("What's a place that always makes you feel calm?", .emotions),
-            ("What's something you're looking forward to right now?", .dailyLife),
-            ("What would you do with an entire day with zero obligations?", .dailyLife),
-            ("What's something you've been meaning to get back into?", .growth),
-            ("What's the best compliment you've ever received?", .appreciation),
-            ("What's a simple pleasure that never gets old for you?", .dailyLife),
-            ("What's something you're grateful for that you rarely think about?", .appreciation),
-            ("What's a skill you picked up that changed your daily life?", .growth),
-            ("What's your go-to way to recharge when you're running on empty?", .dailyLife),
-            ("What's the last thing you learned that genuinely excited you?", .growth),
-            ("What's a childhood memory that always makes you smile?", .past),
-            ("What's something about your morning routine that sets the tone for your day?", .dailyLife),
-            ("What's a personal rule you live by that most people don't know about?", .values),
-            ("What's something you've gotten more patient about as you've gotten older?", .growth),
-            ("What's a song that always puts you in a good mood?", .emotions),
-            ("What's the last thing you did that felt truly spontaneous?", .dailyLife),
-            ("What's a quality about yourself that you've come to appreciate?", .appreciation),
-            ("What's something you collect — physically or mentally?", .identity),
-            ("What's a place you've been that left a lasting impression on you?", .past),
-            ("What's something you do purely for the joy of it, with no goal attached?", .dailyLife),
+            ("What do you spend too much time doing that you probably shouldn't?", .dailyLife, [
+                "What does it give you that keeps you coming back?",
+                "What would you do with that time if you reclaimed it?",
+            ]),
+            ("What are you feeling genuinely proud of right now?", .appreciation, [
+                "What did it take to get there?",
+                "Have you let yourself fully enjoy it?",
+            ]),
+            ("What keeps showing up in your dreams lately?", .emotions, [
+                "Do you think it's trying to tell you something?",
+                "How does it leave you feeling when you wake up?",
+            ]),
+            ("What have you been quietly getting better at without anyone noticing?", .appreciation, [
+                "What's been driving that quiet improvement?",
+                "Does it matter to you whether people notice?",
+            ]),
+            ("What do you do when you're completely alone and nobody can see?", .dailyLife, [
+                "What does that behavior say about who you really are?",
+                "Is it something you enjoy or just a habit?",
+            ]),
+            ("What do you catch yourself complaining about the most?", .dailyLife, [
+                "What's underneath the complaint?",
+                "Is it something you can change, or do you just need to vent?",
+            ]),
+            ("What's something you used to know how to do but have completely lost?", .past, [
+                "Do you miss it?",
+                "What would it take to get it back?",
+            ]),
+            ("What's a small win you had recently that you didn't celebrate enough?", .appreciation, [
+                "Why did you let it pass without acknowledgment?",
+                "What would celebrating it have felt like?",
+            ]),
+            ("What's the last thing that genuinely surprised you about yourself?", .identity, [
+                "Was it a good surprise or an unsettling one?",
+                "What do you think it reveals about where you're headed?",
+            ]),
+            ("What's a comfort food that always makes everything a little better?", .dailyLife, [
+                "What's the memory or feeling attached to it?",
+                "Is it the taste or the ritual that comforts you?",
+            ]),
+            ("What's a place that always makes you feel calm?", .emotions, [
+                "What is it about that place that settles you?",
+                "When was the last time you went there?",
+            ]),
+            ("What's something you're looking forward to right now?", .dailyLife, [
+                "What about it excites you the most?",
+                "How does having something to look forward to change your mood?",
+            ]),
+            ("What would you do with an entire day with zero obligations?", .dailyLife, [
+                "Would you plan it or let it unfold?",
+                "What does your ideal version of that day say about what you need?",
+            ]),
+            ("What's something you've been meaning to get back into?", .growth, [
+                "What pulled you away from it in the first place?",
+                "What would it give you to pick it up again?",
+            ]),
+            ("What's the best compliment you've ever received?", .appreciation, [
+                "Why did that one land so deeply?",
+                "Do you believe it about yourself?",
+            ]),
+            ("What's a simple pleasure that never gets old for you?", .dailyLife, [
+                "What makes it feel fresh every time?",
+                "When did you first discover how much it means to you?",
+            ]),
+            ("What's something you're grateful for that you rarely think about?", .appreciation, [
+                "What would your life look like without it?",
+                "Why do you think it's so easy to overlook?",
+            ]),
+            ("What's a skill you picked up that changed your daily life?", .growth, [
+                "How did you come to learn it?",
+                "What difference does it make on a regular day?",
+            ]),
+            ("What's your go-to way to recharge when you're running on empty?", .dailyLife, [
+                "Does it actually restore you, or just distract you?",
+                "How do you know when you've hit empty?",
+            ]),
+            ("What's the last thing you learned that genuinely excited you?", .growth, [
+                "What about it sparked that excitement?",
+                "Have you done anything with it since?",
+            ]),
+            ("What's a childhood memory that always makes you smile?", .past, [
+                "What about it still feels so warm?",
+                "Who's in that memory with you?",
+            ]),
+            ("What's something about your morning routine that sets the tone for your day?", .dailyLife, [
+                "What happens to your day when you skip it?",
+                "How did it become a ritual for you?",
+            ]),
+            ("What's a personal rule you live by that most people don't know about?", .values, [
+                "Where did that rule come from?",
+                "Has it ever been tested?",
+            ]),
+            ("What's something you've gotten more patient about as you've gotten older?", .growth, [
+                "What taught you that patience?",
+                "Is there something you're still impatient about?",
+            ]),
+            ("What's a song that always puts you in a good mood?", .emotions, [
+                "What memory or feeling does it tap into?",
+                "When do you reach for it most?",
+            ]),
+            ("What's the last thing you did that felt truly spontaneous?", .dailyLife, [
+                "What pushed you to just go for it?",
+                "How did it feel compared to your usual planned approach?",
+            ]),
+            ("What's a quality about yourself that you've come to appreciate?", .appreciation, [
+                "Did you always see it as a strength, or did that take time?",
+                "How does that quality show up in your daily life?",
+            ]),
+            ("What's something you collect — physically or mentally?", .identity, [
+                "What draws you to collecting it?",
+                "What does the collection mean to you?",
+            ]),
+            ("What's a place you've been that left a lasting impression on you?", .past, [
+                "What made it hit so hard?",
+                "Do you want to go back, or is the memory enough?",
+            ]),
+            ("What's something you do purely for the joy of it, with no goal attached?", .dailyLife, [
+                "How did you find that thing?",
+                "What does it give you that goal-driven things don't?",
+            ]),
         ], mode: .soloReflection, intensity: .light, depth: .warmUp)
     }
 
@@ -845,11 +2100,30 @@ private extension PromptBank {
 
     static func solo_light_realTalk() -> [Prompt] {
         make([
-            ("What do you hope people remember about you?", .values),
-            ("When was the last time you felt completely and totally free?", .emotions),
-            ("What's something you lost that you still think about?", .past),
-            ("When was the last time you felt like everything was going your way?", .emotions),
-            ("What's something you used to care deeply about that barely matters to you now?", .growth),
+            ("What do you hope people remember about you?", .values, [
+                "Are you living in a way that builds toward that?",
+                "What would you need to change to get closer to it?",
+            ]),
+            ("When was the last time you felt completely and totally free?", .emotions, [
+                "What created that feeling?",
+                "How often do you give yourself permission to feel that way?",
+            ]),
+            ("What's something you lost that you still think about?", .past, [
+                "What did that loss teach you about what matters?",
+                "Have you found anything that fills that space?",
+            ]),
+            ("When was the last time you felt like everything was going your way?", .emotions, [
+                "What was different about that stretch?",
+                "What do you think made it possible?",
+            ]),
+            ("What's something you used to care deeply about that barely matters to you now?", .growth, [
+                "What caused the shift?",
+                "Do you see letting go of it as growth or loss?",
+            ]),
+            ("What's something you've started to see more realistically over time?", .growth, [
+                "What helped you begin to see it differently?",
+                "Do you feel better or worse having that clearer view?",
+            ]),
         ], mode: .soloReflection, intensity: .light, depth: .realTalk)
     }
 
@@ -857,10 +2131,22 @@ private extension PromptBank {
 
     static func solo_light_deepDive() -> [Prompt] {
         make([
-            ("What does a good life actually look like to you — not what anyone told you it should be?", .values),
-            ("What's a belief that's shaped who you are more than anything?", .values),
-            ("What's something you've built — a habit, a relationship, a mindset — that you're really proud of?", .growth),
-            ("What's a part of your life that feels exactly right?", .appreciation),
+            ("What does a good life actually look like to you — not what anyone told you it should be?", .values, [
+                "How close are you to living that version?",
+                "What's the biggest gap between where you are and where you want to be?",
+            ]),
+            ("What's a belief that's shaped who you are more than anything?", .values, [
+                "Where did that belief take root?",
+                "Has it ever been challenged?",
+            ]),
+            ("What's something you've built — a habit, a relationship, a mindset — that you're really proud of?", .growth, [
+                "What did it take to build it?",
+                "What does it give you that you didn't have before?",
+            ]),
+            ("What's a part of your life that feels exactly right?", .appreciation, [
+                "What makes it feel so aligned?",
+                "How did you get it to that place?",
+            ]),
         ], mode: .soloReflection, intensity: .light, depth: .deepDive)
     }
 
@@ -868,36 +2154,126 @@ private extension PromptBank {
 
     static func solo_honest_warmUp() -> [Prompt] {
         make([
-            ("When you look in the mirror, what's the first thing that comes to mind?", .emotions),
-            ("What's a bad habit you've tried to break but keep coming back to?", .growth),
-            ("What do you waste the most mental energy worrying about?", .emotions),
-            ("What do you find surprisingly hard to say yes to?", .communication),
-            ("What's a part of your life that doesn't match who you thought you'd be by now?", .identity),
-            ("What's something you keep putting off that's actually important to you?", .growth),
-            ("What emotion do you have the hardest time sitting with?", .emotions),
-            ("What's a standard you hold yourself to that might be too high?", .values),
-            ("What's something you've been telling yourself that might not be true?", .growth),
-            ("What's a relationship in your life that needs more attention?", .intimacy),
-            ("What's something you're carrying that you haven't shared with anyone?", .emotions),
-            ("What do you think people assume about you that's wrong?", .identity),
-            ("What's a decision you made recently that you're still second-guessing?", .emotions),
-            ("What's something you need to hear right now but nobody's saying?", .emotions),
-            ("What's an area of your life where you've been coasting?", .growth),
-            ("What's a fear that's been quietly influencing your choices?", .emotions),
-            ("What would change in your life if you stopped people-pleasing?", .growth),
-            ("What's something you used to be sure about that you're not sure about anymore?", .values),
-            ("What do you think your biggest distraction in life is right now?", .dailyLife),
-            ("What's a part of your personality you've been hiding lately?", .identity),
-            ("What's a compliment you struggle to accept about yourself?", .identity),
-            ("What's something you need to forgive yourself for?", .emotions),
-            ("When was the last time you were truly honest with yourself about something uncomfortable?", .growth),
-            ("What's a boundary you need to set but haven't?", .communication),
-            ("What's the gap between how you present yourself and how you actually feel?", .identity),
-            ("What motivates you more — fear of failure or desire for something better?", .values),
-            ("What's something about your current life that your younger self would find confusing?", .past),
-            ("What's a way you've grown in the last year that you haven't acknowledged?", .growth),
-            ("What's something you keep avoiding because it would mean real change?", .growth),
-            ("What would you do differently if you truly believed you deserved it?", .values),
+            ("When you look in the mirror, what's the first thing that comes to mind?", .emotions, [
+                "Is that thought kind or critical?",
+                "Has the voice in your head always said that?",
+            ]),
+            ("What's a bad habit you've tried to break but keep coming back to?", .growth, [
+                "What does the habit give you that makes it so sticky?",
+                "What would breaking it actually require from you?",
+            ]),
+            ("What do you waste the most mental energy worrying about?", .emotions, [
+                "How much of that worry has ever come true?",
+                "What would you think about if you could stop?",
+            ]),
+            ("What do you find surprisingly hard to say yes to?", .communication, [
+                "What's underneath that hesitation?",
+                "What are you protecting by holding back?",
+            ]),
+            ("What's a part of your life that doesn't match who you thought you'd be by now?", .identity, [
+                "Does that gap feel motivating or discouraging?",
+                "What would closing it require?",
+            ]),
+            ("What's something you keep putting off that's actually important to you?", .growth, [
+                "What's the real reason you keep delaying?",
+                "What would it feel like to finally do it?",
+            ]),
+            ("What emotion do you have the hardest time sitting with?", .emotions, [
+                "What do you usually do to escape it?",
+                "What do you think it's trying to tell you?",
+            ]),
+            ("What's a standard you hold yourself to that might be too high?", .values, [
+                "Where did that standard come from?",
+                "What would ease up in your life if you lowered it?",
+            ]),
+            ("What's something you've been telling yourself that might not be true?", .growth, [
+                "How long have you been repeating that story?",
+                "What would change if you let it go?",
+            ]),
+            ("What's a relationship in your life that needs more attention?", .intimacy, [
+                "What's been getting in the way?",
+                "What would showing up more look like?",
+            ]),
+            ("What's something you're carrying that you haven't shared with anyone?", .emotions, [
+                "What would it take for you to share it?",
+                "How is carrying it alone affecting you?",
+            ]),
+            ("What do you think people assume about you that's wrong?", .identity, [
+                "What creates that false impression?",
+                "Does it bother you enough to correct it?",
+            ]),
+            ("What's a decision you made recently that you're still second-guessing?", .emotions, [
+                "What's the version of events where you made the right call?",
+                "What would put the second-guessing to rest?",
+            ]),
+            ("What's something you need to hear right now but nobody's saying?", .emotions, [
+                "Why do you think no one has said it?",
+                "Can you say it to yourself and have it count?",
+            ]),
+            ("What's an area of your life where you've been coasting?", .growth, [
+                "What would it look like if you started trying again?",
+                "What let you start coasting in the first place?",
+            ]),
+            ("What's a fear that's been quietly influencing your choices?", .emotions, [
+                "How many decisions has it shaped without you realizing?",
+                "What would you choose if that fear weren't there?",
+            ]),
+            ("What would change in your life if you stopped people-pleasing?", .growth, [
+                "Who would you disappoint first?",
+                "What would you gain by being honest instead?",
+            ]),
+            ("What's something you used to be sure about that you're not sure about anymore?", .values, [
+                "What made the certainty crack?",
+                "Is the uncertainty uncomfortable or freeing?",
+            ]),
+            ("What do you think your biggest distraction in life is right now?", .dailyLife, [
+                "What is it distracting you from?",
+                "What would you have to face without it?",
+            ]),
+            ("What's a part of your personality you've been hiding lately?", .identity, [
+                "What made you decide to tuck it away?",
+                "Do you miss that part of yourself?",
+            ]),
+            ("What's a compliment you struggle to accept about yourself?", .identity, [
+                "Why is it so hard to let in?",
+                "What would it mean if you believed it?",
+            ]),
+            ("What's something you need to forgive yourself for?", .emotions, [
+                "What's been standing in the way of that forgiveness?",
+                "What would letting it go free you to do?",
+            ]),
+            ("When was the last time you were truly honest with yourself about something uncomfortable?", .growth, [
+                "What did you admit?",
+                "How did it feel once you stopped avoiding it?",
+            ]),
+            ("What's a boundary you need to set but haven't?", .communication, [
+                "What's been holding you back from drawing that line?",
+                "What would change once it's in place?",
+            ]),
+            ("What's the gap between how you present yourself and how you actually feel?", .identity, [
+                "Who in your life sees closest to the real version?",
+                "What would it take to close that gap?",
+            ]),
+            ("What motivates you more — fear of failure or desire for something better?", .values, [
+                "How does that motivator shape the way you take risks?",
+                "Which one do you wish drove you more?",
+            ]),
+            ("What's something about your current life that your younger self would find confusing?", .past, [
+                "What would you explain to them about how you got here?",
+                "Would they be proud or concerned?",
+            ]),
+            ("What's a way you've grown in the last year that you haven't acknowledged?", .growth, [
+                "Why is it so hard to give yourself credit?",
+                "What does that growth mean for who you're becoming?",
+            ]),
+            ("What's something you keep avoiding because it would mean real change?", .growth, [
+                "What's the change you're most afraid of?",
+                "What would life look like on the other side of it?",
+            ]),
+            ("What would you change about yourself if you had a magic wand to make it happen?", .values, [
+                "Name three reasons why you would make that change?",
+                "How would your life change if you made the change?",
+            ]),
         ], mode: .soloReflection, intensity: .honest, depth: .warmUp)
     }
 
@@ -905,17 +2281,58 @@ private extension PromptBank {
 
     static func solo_honest_realTalk() -> [Prompt] {
         make([
-            ("What's a blind spot you're slowly starting to see in yourself?", .growth),
-            ("What's a decision you keep avoiding even though you know it matters?", .growth),
-            ("How does it feel when you're the one holding the power in a situation?", .values),
-            ("What's one thing about yourself you know you need to change?", .growth),
-            ("What's something in your life that nobody truly understands your relationship with?", .identity),
-            ("When are you most proud of having stood up for yourself?", .growth),
-            ("What's something you've been holding onto way longer than you need to?", .past),
-            ("When was the last time you bent the rules in a way that still sits with you?", .conflict),
-            ("What kind of people make you feel the most envious, and why?", .emotions),
-            ("What's something you finally feel clear about after a long stretch of confusion?", .growth),
-            ("What's a boundary you've set recently that felt like real progress?", .growth),
+            ("What's a blind spot you're slowly starting to see in yourself?", .growth, [
+                "What helped you start to notice it?",
+                "How has recognizing it changed anything in your life?",
+            ]),
+            ("What's a decision you keep avoiding even though you know it matters?", .growth, [
+                "What makes the avoidance feel safer than deciding?",
+                "What's the cost of continuing to delay?",
+            ]),
+            ("How does it feel when you're the one holding the power in a situation?", .values, [
+                "Are you comfortable with power, or does it make you uneasy?",
+                "How do you handle the responsibility that comes with it?",
+            ]),
+            ("What's one thing about yourself you know you need to change?", .growth, [
+                "What has that thing cost you already?",
+                "What would be different once you made the change?",
+            ]),
+            ("What's something in your life that nobody truly understands your relationship with?", .identity, [
+                "What would someone need to know to get it?",
+                "Does the misunderstanding bother you or have you accepted it?",
+            ]),
+            ("When are you most proud of having stood up for yourself?", .growth, [
+                "What gave you the courage to do it?",
+                "How did it change what you expect from yourself?",
+            ]),
+            ("What's something you've been holding onto way longer than you need to?", .past, [
+                "What would happen if you finally let it go?",
+                "What does holding on give you?",
+            ]),
+            ("When was the last time you bent the rules in a way that still sits with you?", .conflict, [
+                "Do you feel guilty about it or justified?",
+                "Would you do it again?",
+            ]),
+            ("What kind of people make you feel the most envious, and why?", .emotions, [
+                "What does the envy reveal about what you want?",
+                "Is it something you could actually pursue?",
+            ]),
+            ("What's something you finally feel clear about after a long stretch of confusion?", .growth, [
+                "What brought the clarity?",
+                "How does it feel to be on the other side of it?",
+            ]),
+            ("What's a boundary you've set recently that felt like real progress?", .growth, [
+                "What made you finally draw the line?",
+                "How has life been different since?",
+            ]),
+            ("When did you start to feel that perfect justice might not exist?", .growth, [
+                "What experience made that idea feel less real?",
+                "How has that changed the way you see fairness or people?",
+            ]),
+            ("What's something you once believed would always work out, but now aren't so sure about?", .emotions, [
+                "What caused that belief to shift?",
+                "How do you feel holding that uncertainty now?",
+            ]),
         ], mode: .soloReflection, intensity: .honest, depth: .realTalk)
     }
 
@@ -923,9 +2340,18 @@ private extension PromptBank {
 
     static func solo_honest_deepDive() -> [Prompt] {
         make([
-            ("What would you give anything to have a second chance at?", .past),
-            ("What do you know you need to let go of but can't seem to release?", .growth),
-            ("What's the gap between who you are and who you want to be — and what lives in that gap?", .growth),
+            ("What would you give anything to have a second chance at?", .past, [
+                "What would you do differently this time?",
+                "What has not getting that chance taught you about your choices in life?",
+            ]),
+            ("What do you know you need to let go of but can't seem to release?", .growth, [
+                "What would your life look like without it?",
+                "What keeps your grip so tight?",
+            ]),
+            ("What's the gap between who you are and who you want to be — and what lives in that gap?", .growth, [
+                "What fills that space right now — fear, habit, or something else?",
+                "What's the first step changing this and and moving a step towards who you want to be?",
+            ]),
         ], mode: .soloReflection, intensity: .honest, depth: .deepDive)
     }
 
@@ -933,36 +2359,126 @@ private extension PromptBank {
 
     static func solo_unfiltered_warmUp() -> [Prompt] {
         make([
-            ("What do you have a complicated relationship with that's hard to explain?", .emotions),
-            ("When are you most tempted to break your own rules?", .values),
-            ("What's a feeling you've been swallowing instead of expressing?", .emotions),
-            ("What's the ugliest thought you've had about yourself recently?", .emotions),
-            ("What's a part of your past you'd erase if you could?", .past),
-            ("What's a way you self-sabotage that you're fully aware of?", .growth),
-            ("What's a truth about your life that you dress up when you talk about it?", .identity),
-            ("What's something you pretend to have figured out but really haven't?", .identity),
-            ("What's a coping mechanism you rely on that isn't actually healthy?", .growth),
-            ("What would people think if they could see your internal monologue?", .emotions),
-            ("What's the most painful thing you've realized about yourself?", .growth),
-            ("What's a desire you have that you feel ashamed of?", .emotions),
-            ("What's a version of yourself you've buried that sometimes still surfaces?", .identity),
-            ("What's the hardest thing about being you that nobody sees?", .emotions),
-            ("What's a promise you've broken to yourself more than once?", .values),
-            ("What's a relationship you stayed in too long and why?", .past),
-            ("What's something you're afraid to want because you might not get it?", .emotions),
-            ("What do you think your life would look like if you stopped performing for others?", .identity),
-            ("What's a memory that still makes you feel shame when it surfaces?", .past),
-            ("What's the most honest thing you could say about where you are in life right now?", .growth),
-            ("What's something you need that you've convinced yourself you don't?", .emotions),
-            ("What keeps you up at night that you've never told anyone?", .emotions),
-            ("What's a pattern in your relationships that you can't seem to break?", .growth),
-            ("What's the thing you're most afraid of other people finding out about you?", .identity),
-            ("What's a feeling you've numbed yourself to that you know you need to face?", .emotions),
-            ("What's a part of your story you've rewritten to make it easier to tell?", .past),
-            ("When was the last time you felt completely disgusted with yourself?", .emotions),
-            ("What's a sacrifice you made that nobody ever thanked you for?", .appreciation),
-            ("What would you confess if there were truly no consequences?", .values),
-            ("What's a wound you keep reopening because you haven't fully dealt with it?", .emotions),
+            ("What do you have a complicated relationship with that's hard to explain?", .emotions, [
+                "What makes it so hard to put into words?",
+                "Does the complication bother you, or have you accepted it?",
+            ]),
+            ("When are you most tempted to break your own rules?", .values, [
+                "What does giving in usually cost you?",
+                "Is the temptation about the thing itself or the rebellion?",
+            ]),
+            ("What's a feeling you've been swallowing instead of expressing?", .emotions, [
+                "What are you afraid would happen if you let it out?",
+                "How is holding it in affecting you?",
+            ]),
+            ("What's the ugliest thought you've had about yourself recently?", .emotions, [
+                "Where do you think that thought came from?",
+                "Do you believe it, or can you see it as just a thought that passed through?",
+            ]),
+            ("What's a part of your past you'd erase if you could?", .past, [
+                "What would be different about you without that experience?",
+                "Is there any part of it that made you who you are in a way you value?",
+            ]),
+            ("What's a way you self-sabotage that you're fully aware of?", .growth, [
+                "What do you think you're trying to avoid by doing it?",
+                "What would it take to stop the cycle?",
+            ]),
+            ("What's a truth about your life that you dress up when you talk about it?", .identity, [
+                "What's the undressed version?",
+                "Why does the real version feel too vulnerable to share?",
+            ]),
+            ("What's something you pretend to have figured out but really haven't?", .identity, [
+                "What would it mean to admit you're still lost on it?",
+                "Who would you go to for help if you could?",
+            ]),
+            ("What's a coping mechanism you rely on that isn't actually healthy?", .growth, [
+                "What does it numb or avoid?",
+                "What is a healthier replacement and what would it do for you?",
+            ]),
+            ("What would people think if they could see your internal monologue?", .emotions, [
+                "Would they be surprised, concerned, or relieved?",
+                "Is there a gap between what you think and what you show?",
+            ]),
+            ("What's the most painful thing you've realized about yourself?", .growth, [
+                "How did that realization land?",
+                "What have you done with that knowledge?",
+            ]),
+            ("What's a desire you have that you feel ashamed of?", .emotions, [
+                "Where does the shame come from — you or someone else's voice?",
+                "What would it feel like to want it without the guilt?",
+            ]),
+            ("What's a version of yourself you've buried that sometimes still surfaces?", .identity, [
+                "When does it tend to come back?",
+                "Is it a version you miss or one you're trying to outgrow?",
+            ]),
+            ("What's the hardest thing about being you that nobody sees?", .emotions, [
+                "What would it mean for someone to finally see it?",
+                "How do you carry that alone?",
+            ]),
+            ("What's a promise you've broken to yourself more than once?", .values, [
+                "What gets in the way every time?",
+                "What would it take to finally keep it?",
+            ]),
+            ("What's a relationship you stayed in too long and why?", .past, [
+                "What kept you there past the expiration?",
+                "What did leaving — or not leaving — teach you?",
+            ]),
+            ("What's something you're afraid to want because you might not get it?", .emotions, [
+                "What would it cost you to want it fully?",
+                "What's worse — not getting it, or never trying?",
+            ]),
+            ("What do you think your life would look like if you stopped performing for others?", .identity, [
+                "Who would you lose?",
+                "Who would you finally attract?",
+            ]),
+            ("What's a memory that still makes you feel shame when it surfaces?", .past, [
+                "What exactly triggers the shame?",
+                "Have you been able to talk to anyone about it?",
+            ]),
+            ("What's the most honest thing you could say about where you are in life right now?", .growth, [
+                "How does that honesty feel?",
+                "What would you change first if you could?",
+            ]),
+            ("What's something you need that you've convinced yourself you don't?", .emotions, [
+                "When did you start telling yourself you didn't need it?",
+                "What would admitting the need change for you?",
+            ]),
+            ("What keeps you up at night that you've never told anyone?", .emotions, [
+                "What makes it feel too heavy to share?",
+                "What would you need from someone to feel safe telling them?",
+            ]),
+            ("What's a pattern in your relationships that you can't seem to break?", .growth, [
+                "When did you first notice it repeating?",
+                "What do you think it's trying to resolve?",
+            ]),
+            ("What's the thing you're most afraid of other people finding out about you?", .identity, [
+                "Does it really matter if others know?",
+                "What's the worst thing that could happen and how would you prepare for it?",
+            ]),
+            ("What's something you've numbed yourself to that you know you need to eventually face?", .emotions, [
+                "How are you avoiding it?",
+                "What do you think would happen if you addressed it?",
+            ]),
+            ("What's a part of your story you've rewritten to make it easier to tell?", .past, [
+                "What did you leave out and why?",
+                "What would the unedited version reveal about you or expect others to accept?",
+            ]),
+            ("When was the last time you felt completely happy with yourself?", .emotions, [
+                "Why did it make you feel that way?",
+                "What would you need to do to feel it more often?",
+            ]),
+            ("What's a sacrifice you made that nobody ever thanked you for?", .appreciation, [
+                "Did it help the relationship or damage it?",
+                "Would you do it again knowing no one would noticed?",
+            ]),
+            ("Do you think that confession of wrongs is necessary for you to move forward?", .values, [
+                "Who does the confession actually help and why?",
+                "Is there a social prupose to the confession of worngs."
+            ]),
+            ("Do you have a wound in your heart that never fully heals?", .emotions, [
+                "Is this something you can change or do you need help from others? Who?",
+                "What would healing actually require and what would be the benefits?",
+            ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .warmUp)
     }
 
@@ -970,12 +2486,34 @@ private extension PromptBank {
 
     static func solo_unfiltered_realTalk() -> [Prompt] {
         make([
-            ("What's something you wish you'd never had to see?", .past),
-            ("When was the last time you felt like a total fraud?", .identity),
-            ("How would you honestly describe your relationship with your body?", .identity),
-            ("When did you last seriously doubt yourself, and what triggered it?", .growth),
-            ("What have you been faking lately that you wish you could just stop?", .growth),
-            ("What's a lie you told once that you still think about?", .conflict),
+            ("What's something you wish you'd never had to see?", .past, [
+                "How did seeing it change you?",
+                "Have you been able to process it?",
+            ]),
+            ("When was the last time you felt like a total fraud?", .identity, [
+                "What situation brought that feeling on?",
+                "Do you think others see through it, or is it all internal?",
+            ]),
+            ("How would you honestly describe your relationship with your body?", .identity, [
+                "When is that relationship at its hardest?",
+                "What would a healthier version of it look like?",
+            ]),
+            ("When did you last seriously doubt yourself, and what triggered it?", .growth, [
+                "How did you move through the doubt?",
+                "Did it reveal something real or was it just noise?",
+            ]),
+            ("What have you been faking lately that you wish you could just stop?", .growth, [
+                "Who are you performing for?",
+                "What would dropping the act actually cost you?",
+            ]),
+            ("What's a lie you told once that you still think about?", .conflict, [
+                "Why does it still have a hold on you?",
+                "What would making it right look like now?",
+            ]),
+            ("When did you first realize that you will one day die?", .emotions, [
+                "How old were you, and what made that realization land?",
+                "Does that awareness change how you think about your life now?",
+            ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .realTalk)
     }
 
@@ -983,21 +2521,66 @@ private extension PromptBank {
 
     static func solo_unfiltered_deepDive() -> [Prompt] {
         make([
-            ("What's something you've been putting off being honest with yourself about?", .identity),
-            ("Is there a relationship in your life that you know has run its course?", .conflict),
-            ("What's a part of yourself that you know you need to outgrow?", .growth),
-            ("What's something you still carry guilt about?", .emotions),
-            ("What's a belief you hold deeply but have never actually said out loud?", .values),
-            ("What's something that hurt you that you never talked to anyone about?", .emotions),
-            ("If you could erase one memory completely, which would you choose?", .past),
-            ("What's the worst thing you've done to someone that still weighs on you?", .conflict),
-            ("When have you felt the most humiliated in your life?", .emotions),
-            ("If you got to choose how your life story ends, what would it look like?", .values),
-            ("How did being treated badly by someone shape the way you see yourself?", .past),
-            ("What's something that happened that permanently changed who you are?", .past),
-            ("When was a time you felt rejected that really stung?", .emotions),
-            ("What's something you wish you could finally get closure on?", .emotions),
-            ("What principle would you never compromise on, no matter what?", .values),
+            ("What's something you've been putting off being honest with yourself about?", .identity, [
+                "What would the honest version sound like if you said it out loud?",
+                "What are you afraid will shift once you admit it?",
+            ]),
+            ("Is there a relationship in your life that you know has run its course?", .conflict, [
+                "What's keeping you from walking away?",
+                "What would you grieve if you let it go?",
+            ]),
+            ("What's a part of yourself that you know you need to outgrow?", .growth, [
+                "What's that part been protecting you from?",
+                "Who would you become without it?",
+            ]),
+            ("What's something you still carry guilt about?", .emotions, [
+                "What would it take to finally put it down?",
+                "Do you think you've earned forgiveness, even if you haven't given it to yourself?",
+            ]),
+            ("What's a belief you hold deeply but have never actually said out loud?", .values, [
+                "What makes it feel too risky to share?",
+                "What would it mean to own it publicly?",
+            ]),
+            ("What's something that hurt you that you never talked to anyone about?", .emotions, [
+                "What kept you silent?",
+                "What would you need from someone to feel safe opening up about it?",
+            ]),
+            ("If you could erase one memory completely, which would you choose?", .past, [
+                "What would life feel like without it?",
+                "Is there anything that memory gave you that you'd lose too?",
+            ]),
+            ("What's the worst thing you've done to someone that still weighs on you?", .conflict, [
+                "Have you tried to make it right?",
+                "What would you say to them now?",
+            ]),
+            ("When have you felt the most humiliated in your life?", .emotions, [
+                "How did that experience shape the way you protect yourself?",
+                "Have you healed from it, or does it still sting?",
+            ]),
+            ("If you got to choose how your life story ends, what would it look like?", .values, [
+                "What would the last chapter be about?",
+                "Are you living in a way that moves toward that ending?",
+            ]),
+            ("How did being treated badly by someone shape the way you see yourself?", .past, [
+                "Do you still carry their version of you?",
+                "What would it take to replace it with your own?",
+            ]),
+            ("What's something that happened that permanently changed who you are?", .past, [
+                "Was the change something you chose or something that happened to you?",
+                "Do you recognize yourself on both sides of it?",
+            ]),
+            ("When was a time you felt rejected that really stung?", .emotions, [
+                "What did the rejection make you believe about yourself?",
+                "Have you been able to separate the rejection from your worth?",
+            ]),
+            ("What's something you wish you could finally get closure on?", .emotions, [
+                "What would closure actually look like for you?",
+                "Is it something someone else needs to give you, or something you give yourself?",
+            ]),
+            ("What principle would you never compromise on, no matter what?", .values, [
+                "When has that principle been tested the hardest?",
+                "What does it protect in you that nothing else can?",
+            ]),
         ], mode: .soloReflection, intensity: .unfiltered, depth: .deepDive)
     }
 }

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -100,41 +100,139 @@ private extension PromptBank {
         entries.map { Prompt(text: $0.0, mode: mode, intensity: intensity, depthLevel: depth, topic: $0.1, followUps: defaultFollowUps) }
     }
 
+    /// Overload that accepts per-prompt follow-up strings instead of using the global defaults.
+    static func make(_ entries: [(String, Topic, [String])], mode: Mode, intensity: Intensity, depth: DepthLevel) -> [Prompt] {
+        entries.map { Prompt(text: $0.0, mode: mode, intensity: intensity, depthLevel: depth, topic: $0.1, followUps: $0.2.map { FollowUp(text: $0) }) }
+    }
+
     // MARK: - Couples · Light · Warm Up
 
     static func couples_light_warmUp() -> [Prompt] {
         make([
-            ("If you could know one thing about your future, what would you want to find out?", .dailyLife),
-            ("What's something you're unreasonably stubborn about?", .identity),
-            ("What's something you know you're completely irrational about?", .identity),
-            ("What's a tiny personal preference you feel surprisingly passionate about?", .dailyLife),
-            ("What do you spend way too much money on without any regret?", .dailyLife),
-            ("What do you know you make a bigger deal about than you should?", .communication),
-            ("What would you love to be able to spend more freely on?", .dailyLife),
-            ("Are you more of a host or a guest — and what does that say about you?", .dailyLife),
-            ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife),
-            ("What's your go-to midnight snack raid?", .dailyLife),
-            ("Who or what have you been quietly fascinated by lately?", .intimacy),
-            ("What's the most disastrous date you've ever been on?", .dailyLife),
-            ("What's your favorite real love story — yours or someone else's?", .intimacy),
-            ("What do you need most from me when you're not feeling well?", .communication),
-            ("What are you surprisingly high-maintenance about?", .dailyLife),
-            ("What are you a complete control freak about?", .identity),
-            ("What's the one thing you absolutely cannot be teased about?", .communication),
-            ("What's basically impossible for you to say no to?", .communication),
-            ("What's something about your partner that you fell in love with all over again recently?", .appreciation),
-            ("I feel most sensual when…", .sex),
-            ("I feel most attractive when…", .sex),
-            ("What's a song that always makes you think of us?", .appreciation),
-            ("What's the best surprise you've ever gotten from someone you love?", .appreciation),
-            ("What's your idea of a perfect lazy Sunday together?", .dailyLife),
-            ("What's something small I do that always makes you smile?", .appreciation),
-            ("If we could travel anywhere tomorrow, where would you want to go?", .dailyLife),
-            ("What's a hobby or skill you've always wanted us to try together?", .growth),
-            ("What's the most fun we've ever had doing something totally unplanned?", .past),
-            ("What's a movie or show that reminds you of our relationship?", .dailyLife),
-            ("What's your love language when you're stressed versus when you're happy?", .communication),
-            ("What's a tradition you'd love for us to start?", .values),
+            ("If you could know one thing about your future, what would you want to find out?", .dailyLife, [
+                "Why that answer, specifically?",
+                "How do you think knowing it would change the way you live now?",
+            ]),
+            ("What's something you're unreasonably stubborn about?", .identity, [
+                "What makes that one so hard for you to budge on?",
+                "What do you think it protects in you?",
+            ]),
+            ("What's something you know you're completely irrational about?", .identity, [
+                "What usually triggers that reaction in you?",
+                "Do you think it's tied to something older or deeper?",
+            ]),
+            ("What's a tiny personal preference you feel surprisingly passionate about?", .dailyLife, [
+                "Why do you think that one matters so much to you?",
+                "What does it reveal about the way you like life to feel?",
+            ]),
+            ("What do you spend way too much money on without any regret?", .dailyLife, [
+                "What does spending on that give you beyond the thing itself?",
+                "What would it be hard to replace that feeling with?",
+            ]),
+            ("What do you know you make a bigger deal about than you should?", .communication, [
+                "What does it touch in you that makes it feel bigger than it is?",
+                "What are you usually needing in those moments?",
+            ]),
+            ("What would you love to be able to spend more freely on?", .dailyLife, [
+                "What would that say about the kind of life you want?",
+                "What feeling are you hoping more freedom there would give you?",
+            ]),
+            ("Are you more of a host or a guest — and what does that say about you?", .dailyLife, [
+                "What part of that role feels most natural to you?",
+                "What does that role let you avoid or enjoy most?",
+            ]),
+            ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife, [
+                "What do those choices tell you about what keeps you steady?",
+                "Which one would be the hardest to go without, and why?",
+            ]),
+            ("What's your go-to midnight snack raid?", .dailyLife, [
+                "What mood are you usually in when that craving hits?",
+                "What do you think you're really reaching for in that moment?",
+            ]),
+            ("Who or what have you been quietly fascinated by lately?", .intimacy, [
+                "What is it about them or it that keeps pulling you in?",
+                "Do you think it connects to something you're wanting more of in your own life?",
+            ]),
+            ("What's the most disastrous date you've ever been on?", .dailyLife, [
+                "What made it go wrong so fast?",
+                "What did that experience teach you about yourself or dating?",
+            ]),
+            ("What's your favorite real love story — yours or someone else's?", .intimacy, [
+                "What part of that story moves you the most?",
+                "What does it reveal about the kind of love you believe in?",
+            ]),
+            ("What do you need most from me when you're not feeling well?", .communication, [
+                "What helps you feel cared for instead of just looked after?",
+                "What's easy for me to miss in those moments?",
+            ]),
+            ("What are you surprisingly high-maintenance about?", .dailyLife, [
+                "What makes that one worth the extra fuss to you?",
+                "Do you think it's more about comfort, control, or feeling cared for?",
+            ]),
+            ("What are you a complete control freak about?", .identity, [
+                "What feels at risk when you're not in control there?",
+                "Where do you think that need for control comes from?",
+            ]),
+            ("What's the one thing you absolutely cannot be teased about?", .communication, [
+                "What makes that one land differently than other jokes?",
+                "What does it touch in you that's still tender?",
+            ]),
+            ("What's basically impossible for you to say no to?", .communication, [
+                "What makes it so hard to resist?",
+                "What need in you does saying yes satisfy?",
+            ]),
+            ("What's something about your partner that you fell in love with all over again recently?", .appreciation, [
+                "What was it about that moment that hit you so strongly?",
+                "What did it remind you of about why you chose them?",
+            ]),
+            ("I feel most sensual when…", .sex, [
+                "What helps you settle into that feeling most naturally?",
+                "What tends to pull you away from it?",
+            ]),
+            ("I feel most attractive when…", .sex, [
+                "What is it about that moment that makes you feel seen that way?",
+                "How much of that feeling comes from you versus someone else's response?",
+            ]),
+            ("What's a song that always makes you think of us?", .appreciation, [
+                "What memory or feeling does it bring back first?",
+                "What part of us does that song seem to capture?",
+            ]),
+            ("What's the best surprise you've ever gotten from someone you love?", .appreciation, [
+                "What made that surprise feel so meaningful to you?",
+                "What did it show you about how that person knew you?",
+            ]),
+            ("What's your idea of a perfect lazy Sunday together?", .dailyLife, [
+                "What part of that day feels most nourishing to you?",
+                "What does that version of Sunday give you that everyday life doesn't?",
+            ]),
+            ("What's something small I do that always makes you smile?", .appreciation, [
+                "Why do you think that tiny thing means so much to you?",
+                "What does it make you feel in that moment?",
+            ]),
+            ("If we could travel anywhere tomorrow, where would you want to go?", .dailyLife, [
+                "What about that place feels right for us?",
+                "What are you hoping we'd feel there together?",
+            ]),
+            ("What's a hobby or skill you've always wanted us to try together?", .growth, [
+                "What do you imagine that bringing out in us?",
+                "What makes doing it together matter more than doing it alone?",
+            ]),
+            ("What's the most fun we've ever had doing something totally unplanned?", .past, [
+                "What do you think made that moment feel so alive?",
+                "What does it tell you about us at our best?",
+            ]),
+            ("What's a movie or show that reminds you of our relationship?", .dailyLife, [
+                "What dynamic or moment in it feels most like us?",
+                "Is that comparison sweet, funny, or a little too accurate?",
+            ]),
+            ("What's your love language when you're stressed versus when you're happy?", .communication, [
+                "How can someone tell which version of you they're getting?",
+                "What do you most want from me when you're in each state?",
+            ]),
+            ("What's a tradition you'd love for us to start?", .values, [
+                "What do you think that tradition would create between us over time?",
+                "Why does that kind of ritual matter to you?",
+            ]),
         ], mode: .couples, intensity: .light, depth: .warmUp)
     }
 

--- a/Connections/Data/ShareExperienceBank.swift
+++ b/Connections/Data/ShareExperienceBank.swift
@@ -38,27 +38,27 @@ private extension ShareExperienceBank {
 
     static func buildExperiences() -> [ShareExperience] {
         [
-            ShareExperience(id: "se1", text: "unbelievable", intensity: .light, topic: .dailyLife),
-            ShareExperience(id: "se2", text: "gutsy", intensity: .honest, topic: .growth),
-            ShareExperience(id: "se3", text: "nostalgic", intensity: .light, topic: .past),
+            ShareExperience(id: "se1", text: " that is unbelievable", intensity: .light, topic: .dailyLife),
+            ShareExperience(id: "se2", text: "was gutsy", intensity: .honest, topic: .growth),
+            ShareExperience(id: "se3", text: "warmly nostalgic", intensity: .light, topic: .past),
             ShareExperience(id: "se4", text: "provocative", intensity: .unfiltered, topic: .values),
-            ShareExperience(id: "se5", text: "heavy", intensity: .unfiltered, topic: .emotions),
+            ShareExperience(id: "se5", text: "sad or heavy", intensity: .unfiltered, topic: .emotions),
             ShareExperience(id: "se6", text: "life-changing", intensity: .honest, topic: .growth),
             ShareExperience(id: "se7", text: "joyful", intensity: .light, topic: .appreciation),
             ShareExperience(id: "se8", text: "unforgettable", intensity: .honest, topic: .past),
             ShareExperience(id: "se9", text: "from your teenage years", intensity: .light, topic: .past),
-            ShareExperience(id: "se10", text: "close to your heart", intensity: .honest, topic: .emotions),
+            ShareExperience(id: "se10", text: "that is close to your heart", intensity: .honest, topic: .emotions),
             ShareExperience(id: "se11", text: "that gets you worked up", intensity: .unfiltered, topic: .conflict),
             ShareExperience(id: "se12", text: "you wouldn't tell your mother", intensity: .unfiltered, topic: .identity),
             ShareExperience(id: "se13", text: "you wouldn't tell your coworkers", intensity: .honest, topic: .identity),
             ShareExperience(id: "se14", text: "you've never told anyone", intensity: .unfiltered, topic: .identity),
-            ShareExperience(id: "se15", text: "that changed your worldview", intensity: .honest, topic: .growth),
+            ShareExperience(id: "se15", text: "when you realized your parents weren't perfect", intensity: .honest, topic: .growth),
             ShareExperience(id: "se16", text: "you've kept secret", intensity: .unfiltered, topic: .identity),
-            ShareExperience(id: "se17", text: "crazy", intensity: .light, topic: .dailyLife),
-            ShareExperience(id: "se18", text: "out of character", intensity: .honest, topic: .identity),
-            ShareExperience(id: "se19", text: "risky", intensity: .unfiltered, topic: .growth),
+            ShareExperience(id: "se17", text: "made you feel thankful", intensity: .light, topic: .dailyLife),
+            ShareExperience(id: "se18", text: "you made feel pleased with who you are", intensity: .honest, topic: .identity),
+            ShareExperience(id: "se19", text: "seemed risky", intensity: .unfiltered, topic: .growth),
             ShareExperience(id: "se20", text: "heartbreaking", intensity: .unfiltered, topic: .emotions),
-            ShareExperience(id: "se21", text: "cringeworthy", intensity: .light, topic: .dailyLife),
+            ShareExperience(id: "se21", text: "changed the direction of your life", intensity: .light, topic: .dailyLife),
         ]
     }
 }

--- a/Connections/Models/IntensityTone.swift
+++ b/Connections/Models/IntensityTone.swift
@@ -11,9 +11,9 @@ extension Intensity {
     /// Use at low opacities to create subtle atmospheric tints.
     var toneColor: Color {
         switch self {
-        case .light:      return Color(red: 0.82, green: 0.70, blue: 0.50)
-        case .honest:     return Color(red: 0.48, green: 0.55, blue: 0.65)
-        case .unfiltered: return Color(red: 0.58, green: 0.40, blue: 0.55)
+        case .light:      return Color(red: 0.95, green: 0.78, blue: 0.42)
+        case .honest:     return Color(red: 0.42, green: 0.62, blue: 0.78)
+        case .unfiltered: return Color(red: 0.52, green: 0.40, blue: 0.72)
         }
     }
 

--- a/Connections/Models/Models.swift
+++ b/Connections/Models/Models.swift
@@ -117,13 +117,19 @@ enum Topic: String, CaseIterable, Identifiable, Codable {
 
     var isFree: Bool { Self.freeTopics.contains(self) }
 
+    /// Mode-aware display name (e.g. "Fall in Love" for couples, "Get Closer" for friends).
+    func displayName(for mode: Mode?) -> String {
+        if self == .fallInLove && mode == .friends { return "Get Closer" }
+        return displayName
+    }
+
     /// Topics that use a separate guided flow instead of the random session.
     var isGuidedFlow: Bool { self == .fallInLove }
 
     /// Topics only available for certain modes.
     static func availableFor(mode: Mode) -> [Topic] {
         Topic.allCases.filter { topic in
-            if topic == .fallInLove { return mode == .couples }
+            if topic == .fallInLove { return mode == .couples || mode == .friends }
             return true
         }
     }

--- a/Connections/Models/Models.swift
+++ b/Connections/Models/Models.swift
@@ -161,13 +161,23 @@ struct Prompt: Identifiable, Codable {
     }
 }
 
-struct FollowUp: Identifiable, Codable {
+enum FollowUpStyle: String, Codable, CaseIterable, Hashable {
+    case origin
+    case meaning
+    case impact
+    case need
+    case tension
+}
+
+struct FollowUp: Identifiable, Hashable, Codable {
     let id: UUID
     let text: String
+    let style: FollowUpStyle
 
-    init(id: UUID = UUID(), text: String) {
+    init(id: UUID = UUID(), text: String, style: FollowUpStyle = .meaning) {
         self.id = id
         self.text = text
+        self.style = style
     }
 }
 

--- a/Connections/Services/HapticsManager.swift
+++ b/Connections/Services/HapticsManager.swift
@@ -1,0 +1,42 @@
+//
+//  HapticsManager.swift
+//  Connections
+//
+
+import UIKit
+
+enum HapticsManager {
+    static func lightImpact() {
+        guard isEnabled else { return }
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    static func mediumImpact() {
+        guard isEnabled else { return }
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.prepare()
+        generator.impactOccurred()
+    }
+
+    static func success() {
+        guard isEnabled else { return }
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.success)
+    }
+
+    // Reads directly from the same UserDefaults key used by SettingsStore.
+    private static var isEnabled: Bool {
+        guard let data = UserDefaults.standard.data(forKey: "connections_settings"),
+              let decoded = try? JSONDecoder().decode(HapticCheck.self, from: data) else {
+            return true // default: enabled
+        }
+        return decoded.hapticsEnabled
+    }
+
+    private struct HapticCheck: Decodable {
+        let hapticsEnabled: Bool
+    }
+}

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -325,10 +325,17 @@ final class SessionManager {
     private func nextPrompt() -> Prompt? {
         guard let mode = selectedMode, let intensity = selectedIntensity else { return nil }
 
-        // Draw from all prompts at or below the current depth for maximum variety.
-        let available = PromptBank.shared
+        let all = PromptBank.shared
             .prompts(for: mode, intensity: intensity, unlockedThrough: currentDepth)
-            .filter { !shownPromptIDs.contains($0.id) }
+
+        // Filter out already-shown prompts when avoid repeats is enabled.
+        var available = avoidRepeats ? all.filter { !shownPromptIDs.contains($0.id) } : all
+
+        // If we've exhausted all prompts, reset and try again.
+        if available.isEmpty && avoidRepeats {
+            shownPromptIDs = []
+            available = all
+        }
 
         // Prefer the selected topic, fall back to all topics only as a last resort.
         let candidates: [Prompt]
@@ -340,8 +347,21 @@ final class SessionManager {
         }
 
         guard let chosen = candidates.randomElement() else { return nil }
-        shownPromptIDs.insert(chosen.id)
+        if avoidRepeats { shownPromptIDs.insert(chosen.id) }
         return chosen
+    }
+
+    /// Reads the avoid-repeats preference from UserDefaults.
+    private var avoidRepeats: Bool {
+        guard let data = UserDefaults.standard.data(forKey: "connections_settings"),
+              let decoded = try? JSONDecoder().decode(AvoidRepeatsCheck.self, from: data) else {
+            return true
+        }
+        return decoded.avoidRepeats
+    }
+
+    private struct AvoidRepeatsCheck: Decodable {
+        let avoidRepeats: Bool
     }
 }
 
@@ -355,22 +375,37 @@ struct FavoritesStore: Codable {
         let id: UUID
         let promptText: String
         let mode: Mode
+        let intensity: Intensity
+        let depth: DepthLevel
         let followUps: [FollowUp]
         let date: Date
 
-        init(promptID: UUID, promptText: String, mode: Mode, followUps: [FollowUp] = [], date: Date = .now) {
+        init(promptID: UUID, promptText: String, mode: Mode, intensity: Intensity = .honest, depth: DepthLevel = .warmUp, followUps: [FollowUp] = [], date: Date = .now) {
             self.id = promptID
             self.promptText = promptText
             self.mode = mode
+            self.intensity = intensity
+            self.depth = depth
             self.followUps = followUps
             self.date = date
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            promptText = try container.decode(String.self, forKey: .promptText)
+            mode = try container.decode(Mode.self, forKey: .mode)
+            intensity = try container.decodeIfPresent(Intensity.self, forKey: .intensity) ?? .honest
+            depth = try container.decodeIfPresent(DepthLevel.self, forKey: .depth) ?? .warmUp
+            followUps = try container.decode([FollowUp].self, forKey: .followUps)
+            date = try container.decode(Date.self, forKey: .date)
         }
     }
 
     /// Adds a prompt to favorites if not already present, and saves immediately.
     mutating func add(_ prompt: Prompt) {
         guard !entries.contains(where: { $0.id == prompt.id }) else { return }
-        let entry = FavoriteEntry(promptID: prompt.id, promptText: prompt.text, mode: prompt.mode, followUps: prompt.followUps)
+        let entry = FavoriteEntry(promptID: prompt.id, promptText: prompt.text, mode: prompt.mode, intensity: prompt.intensity, depth: prompt.depthLevel, followUps: prompt.followUps)
         entries.append(entry)
         save()
     }

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -6,6 +6,18 @@
 import Foundation
 import SwiftUI
 
+// MARK: - Prompt Interaction Tracking
+
+struct PromptInteraction {
+    let promptID: UUID
+    let promptText: String
+    var totalTimeSpent: TimeInterval = 0
+    var goDeeperCount: Int = 0
+    var wasFavorited: Bool = false
+    var revisitCount: Int = 0
+    var visitCount: Int = 1
+}
+
 @Observable
 final class SessionManager {
 
@@ -46,6 +58,14 @@ final class SessionManager {
 
     /// Number of prompts the user has *continued* (not skipped) at the current depth.
     private var continuedAtCurrentDepth: Int = 0
+
+    // MARK: - Interaction Tracking
+
+    /// Per-prompt interaction data for the current session, keyed by prompt ID.
+    private(set) var interactions: [UUID: PromptInteraction] = [:]
+
+    /// Timestamp when the current prompt became active (for elapsed time calculation).
+    private var promptActiveAt: Date?
 
     // MARK: - Connection Tracking
 
@@ -109,6 +129,8 @@ final class SessionManager {
         connectionTracker.reset()
         showFeelingCheckIn = false
         goDeeperCount = 0
+        interactions = [:]
+        promptActiveAt = nil
         resetFollowUpTracking()
         isSessionActive = true
 
@@ -117,11 +139,14 @@ final class SessionManager {
         // If the prompt bank has no matching prompts at all, end gracefully.
         if currentPrompt == nil {
             isSessionActive = false
+        } else if let prompt = currentPrompt {
+            beginTrackingPrompt(prompt)
         }
     }
 
     func continuePrompt(isFavorited: Bool = false) {
         guard let prompt = currentPrompt else { return }
+        finalizeCurrentPromptTiming()
         promptHistory.append(prompt)
         resetFollowUpTracking()
 
@@ -146,9 +171,11 @@ final class SessionManager {
         // Check if we should show a feeling check-in before the next prompt.
         if continuedSinceLastCheckIn >= Self.checkInInterval && !isSessionComplete {
             showFeelingCheckIn = true
+            // Timing paused — will resume when check-in resolves and a new prompt loads.
         } else if !isSessionComplete {
             currentPrompt = nextPrompt()
             if currentPrompt == nil { forceComplete() }
+            else { beginTrackingPrompt(currentPrompt!) }
         } else {
             currentPrompt = nil
         }
@@ -162,6 +189,7 @@ final class SessionManager {
         if !isSessionComplete {
             currentPrompt = nextPrompt()
             if currentPrompt == nil { forceComplete() }
+            else { beginTrackingPrompt(currentPrompt!) }
         } else {
             currentPrompt = nil
         }
@@ -170,11 +198,15 @@ final class SessionManager {
     /// Record a "Go deeper" tap (either showing follow-ups or triggering a check-in).
     func recordGoDeeper() {
         goDeeperCount += 1
+        if let prompt = currentPrompt {
+            interactions[prompt.id]?.goDeeperCount += 1
+        }
     }
 
     /// Trigger a check-in after a "Go deeper" interaction, if not already pending.
     func triggerCheckInFromGoDeeper() {
         guard !showFeelingCheckIn, !isSessionComplete else { return }
+        finalizeCurrentPromptTiming()
         showFeelingCheckIn = true
     }
 
@@ -203,6 +235,7 @@ final class SessionManager {
         if !isSessionComplete {
             currentPrompt = nextPrompt()
             if currentPrompt == nil { forceComplete() }
+            else { beginTrackingPrompt(currentPrompt!) }
         } else {
             currentPrompt = nil
         }
@@ -210,6 +243,7 @@ final class SessionManager {
 
     func skipPrompt() {
         guard let prompt = currentPrompt else { return }
+        finalizeCurrentPromptTiming()
         promptHistory.append(prompt)
 
         let response = PromptResponse(
@@ -223,6 +257,7 @@ final class SessionManager {
         if !isSessionComplete {
             currentPrompt = nextPrompt()
             if currentPrompt == nil { forceComplete() }
+            else { beginTrackingPrompt(currentPrompt!) }
         } else {
             currentPrompt = nil
         }
@@ -230,8 +265,10 @@ final class SessionManager {
 
     func goBack() {
         guard let previousPrompt = promptHistory.popLast() else { return }
+        finalizeCurrentPromptTiming()
         resetFollowUpTracking()
         currentPrompt = previousPrompt
+        beginTrackingPrompt(previousPrompt, isRevisit: true)
         promptsShown = max(0, promptsShown - 1)
         if !responses.isEmpty {
             responses.removeLast()
@@ -241,11 +278,13 @@ final class SessionManager {
     func favoriteCurrentPrompt() {
         guard let prompt = currentPrompt else { return }
         favorites.add(prompt)
+        interactions[prompt.id]?.wasFavorited = true
     }
 
     func toggleFavoriteCurrentPrompt() {
         guard let prompt = currentPrompt else { return }
         favorites.toggle(prompt)
+        interactions[prompt.id]?.wasFavorited = favorites.isFavorite(prompt)
     }
 
     func isCurrentPromptFavorited() -> Bool {
@@ -258,6 +297,7 @@ final class SessionManager {
     }
 
     func endSession() {
+        finalizeCurrentPromptTiming()
         isSessionActive = false
         currentPrompt = nil
         promptsShown = 0
@@ -267,6 +307,8 @@ final class SessionManager {
         continuedAtCurrentDepth = 0
         continuedSinceLastCheckIn = 0
         goDeeperCount = 0
+        interactions = [:]
+        promptActiveAt = nil
         currentDepth = .warmUp
         maxDepthReached = .warmUp
         showFeelingCheckIn = false
@@ -298,6 +340,68 @@ final class SessionManager {
         return SessionSummaryEngine.generate(from: signals)
     }
 
+    // MARK: - Interaction Tracking Helpers
+
+    /// Finalizes elapsed time for the current prompt's interaction.
+    private func finalizeCurrentPromptTiming() {
+        guard let prompt = currentPrompt, let start = promptActiveAt else { return }
+        let elapsed = Date().timeIntervalSince(start)
+        interactions[prompt.id]?.totalTimeSpent += elapsed
+        promptActiveAt = nil
+    }
+
+    /// Starts timing for a prompt and ensures an interaction record exists.
+    private func beginTrackingPrompt(_ prompt: Prompt, isRevisit: Bool = false) {
+        if var existing = interactions[prompt.id] {
+            existing.visitCount += 1
+            if isRevisit { existing.revisitCount += 1 }
+            interactions[prompt.id] = existing
+        } else {
+            interactions[prompt.id] = PromptInteraction(
+                promptID: prompt.id,
+                promptText: prompt.text
+            )
+        }
+        promptActiveAt = Date()
+    }
+
+    // MARK: - Interaction Scoring
+
+    /// Returns the top standout prompt interactions for the current session, scored by engagement signals.
+    func standoutPromptInteractions(limit: Int = 3) -> [PromptInteraction] {
+        let meaningful = interactions.values.filter { isMeaningful($0) }
+        let scored = meaningful.map { (interaction: $0, score: score($0)) }
+        let sorted = scored.sorted { $0.score > $1.score }
+        return sorted.prefix(limit).map { $0.interaction }
+    }
+
+    /// Scores a single interaction using normalized, balanced weights.
+    /// Time (normalized to ~1 point per 30s, capped at 3) is the strongest signal.
+    /// Go Deeper and favorites are strong explicit signals.
+    /// Revisits are moderate; raw visit count is weak.
+    private func score(_ interaction: PromptInteraction) -> Double {
+        let normalizedTime = min(interaction.totalTimeSpent / 30.0, 3.0)
+        let goDeeper = Double(interaction.goDeeperCount)
+        let revisit = Double(interaction.revisitCount)
+        let visits = Double(interaction.visitCount)
+        let favoriteBonus = interaction.wasFavorited ? 2.5 : 0.0
+
+        return
+            (normalizedTime * 2.0) +
+            (goDeeper * 2.5) +
+            favoriteBonus +
+            (revisit * 1.5) +
+            (visits * 0.3)
+    }
+
+    /// Filters out interactions with negligible engagement.
+    private func isMeaningful(_ interaction: PromptInteraction) -> Bool {
+        interaction.totalTimeSpent > 5 ||
+        interaction.goDeeperCount > 0 ||
+        interaction.wasFavorited ||
+        interaction.revisitCount > 0
+    }
+
     // MARK: - Internal
 
     private func resetFollowUpTracking() {
@@ -307,6 +411,7 @@ final class SessionManager {
 
     /// If prompts are exhausted before the session length is reached, mark the session complete.
     private func forceComplete() {
+        finalizeCurrentPromptTiming()
         promptsShown = totalPrompts
         currentPrompt = nil
     }

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -31,6 +31,19 @@ final class SessionManager {
     /// Prompt IDs already shown this session, to avoid repeats.
     private var shownPromptIDs: Set<UUID> = []
 
+    /// Stack of previously shown prompts, most recent last. Powers the "Back" button.
+    private var promptHistory: [Prompt] = []
+
+    var canGoBack: Bool {
+        !promptHistory.isEmpty && !isSessionComplete
+    }
+
+    /// Follow-ups revealed so far for the current prompt (progressive reveal).
+    private(set) var shownFollowUps: [FollowUp] = []
+
+    /// Styles already used for the current prompt, to prefer variety.
+    private var usedFollowUpStyles: Set<FollowUpStyle> = []
+
     /// Number of prompts the user has *continued* (not skipped) at the current depth.
     private var continuedAtCurrentDepth: Int = 0
 
@@ -92,9 +105,11 @@ final class SessionManager {
         promptsShown = 0
         responses = []
         shownPromptIDs = []
+        promptHistory = []
         connectionTracker.reset()
         showFeelingCheckIn = false
         goDeeperCount = 0
+        resetFollowUpTracking()
         isSessionActive = true
 
         currentPrompt = nextPrompt()
@@ -107,6 +122,8 @@ final class SessionManager {
 
     func continuePrompt(isFavorited: Bool = false) {
         guard let prompt = currentPrompt else { return }
+        promptHistory.append(prompt)
+        resetFollowUpTracking()
 
         let response = PromptResponse(
             promptID: prompt.id,
@@ -139,6 +156,7 @@ final class SessionManager {
 
     func recordFeeling(_ feeling: Feeling) {
         connectionTracker.record(feeling)
+        resetFollowUpTracking()
         continuedSinceLastCheckIn = 0
         showFeelingCheckIn = false
         if !isSessionComplete {
@@ -160,7 +178,26 @@ final class SessionManager {
         showFeelingCheckIn = true
     }
 
+    /// Whether the current prompt has more unrevealed follow-ups.
+    var hasMoreFollowUps: Bool {
+        guard let prompt = currentPrompt, followUpsEnabled else { return false }
+        return prompt.followUps.count > shownFollowUps.count
+    }
+
+    /// Reveals the next follow-up for the current prompt, preferring an unused style.
+    func revealNextFollowUp() {
+        guard let prompt = currentPrompt else { return }
+        let shown = Set(shownFollowUps.map(\.id))
+        let remaining = prompt.followUps.filter { !shown.contains($0.id) }
+        // Prefer a follow-up whose style hasn't been used yet
+        let preferred = remaining.filter { !usedFollowUpStyles.contains($0.style) }
+        guard let selected = (preferred.first ?? remaining.first) else { return }
+        usedFollowUpStyles.insert(selected.style)
+        shownFollowUps.append(selected)
+    }
+
     func dismissCheckIn() {
+        resetFollowUpTracking()
         continuedSinceLastCheckIn = 0
         showFeelingCheckIn = false
         if !isSessionComplete {
@@ -173,6 +210,7 @@ final class SessionManager {
 
     func skipPrompt() {
         guard let prompt = currentPrompt else { return }
+        promptHistory.append(prompt)
 
         let response = PromptResponse(
             promptID: prompt.id,
@@ -190,9 +228,33 @@ final class SessionManager {
         }
     }
 
+    func goBack() {
+        guard let previousPrompt = promptHistory.popLast() else { return }
+        resetFollowUpTracking()
+        currentPrompt = previousPrompt
+        promptsShown = max(0, promptsShown - 1)
+        if !responses.isEmpty {
+            responses.removeLast()
+        }
+    }
+
     func favoriteCurrentPrompt() {
         guard let prompt = currentPrompt else { return }
         favorites.add(prompt)
+    }
+
+    func toggleFavoriteCurrentPrompt() {
+        guard let prompt = currentPrompt else { return }
+        favorites.toggle(prompt)
+    }
+
+    func isCurrentPromptFavorited() -> Bool {
+        guard let prompt = currentPrompt else { return false }
+        return favorites.isFavorite(prompt)
+    }
+
+    func removeFavorite(id: UUID) {
+        favorites.remove(id: id)
     }
 
     func endSession() {
@@ -201,6 +263,7 @@ final class SessionManager {
         promptsShown = 0
         responses = []
         shownPromptIDs = []
+        promptHistory = []
         continuedAtCurrentDepth = 0
         continuedSinceLastCheckIn = 0
         goDeeperCount = 0
@@ -208,6 +271,7 @@ final class SessionManager {
         maxDepthReached = .warmUp
         showFeelingCheckIn = false
         connectionTracker.reset()
+        resetFollowUpTracking()
         followUpsEnabled = true
     }
 
@@ -235,6 +299,11 @@ final class SessionManager {
     }
 
     // MARK: - Internal
+
+    private func resetFollowUpTracking() {
+        shownFollowUps = []
+        usedFollowUpStyles = []
+    }
 
     /// If prompts are exhausted before the session length is reached, mark the session complete.
     private func forceComplete() {
@@ -286,12 +355,14 @@ struct FavoritesStore: Codable {
         let id: UUID
         let promptText: String
         let mode: Mode
+        let followUps: [FollowUp]
         let date: Date
 
-        init(promptID: UUID, promptText: String, mode: Mode, date: Date = .now) {
+        init(promptID: UUID, promptText: String, mode: Mode, followUps: [FollowUp] = [], date: Date = .now) {
             self.id = promptID
             self.promptText = promptText
             self.mode = mode
+            self.followUps = followUps
             self.date = date
         }
     }
@@ -299,7 +370,7 @@ struct FavoritesStore: Codable {
     /// Adds a prompt to favorites if not already present, and saves immediately.
     mutating func add(_ prompt: Prompt) {
         guard !entries.contains(where: { $0.id == prompt.id }) else { return }
-        let entry = FavoriteEntry(promptID: prompt.id, promptText: prompt.text, mode: prompt.mode)
+        let entry = FavoriteEntry(promptID: prompt.id, promptText: prompt.text, mode: prompt.mode, followUps: prompt.followUps)
         entries.append(entry)
         save()
     }
@@ -312,6 +383,23 @@ struct FavoritesStore: Codable {
     func contains(promptID: UUID) -> Bool {
         entries.contains { $0.id == promptID }
     }
+
+    /// Convenience: check if a Prompt is favorited.
+    func isFavorite(_ prompt: Prompt) -> Bool {
+        contains(promptID: prompt.id)
+    }
+
+    /// Toggle a prompt in/out of favorites.
+    mutating func toggle(_ prompt: Prompt) {
+        if contains(promptID: prompt.id) {
+            remove(id: prompt.id)
+        } else {
+            add(prompt)
+        }
+    }
+
+    /// All favorite entries.
+    var allFavorites: [FavoriteEntry] { entries }
 
     // MARK: - Persistence
 

--- a/Connections/Services/SettingsStore.swift
+++ b/Connections/Services/SettingsStore.swift
@@ -27,6 +27,32 @@ final class SettingsStore {
         didSet { save() }
     }
 
+    var skipFallInLoveIntroCouples: Bool {
+        didSet { save() }
+    }
+
+    var skipFallInLoveIntroFriends: Bool {
+        didSet { save() }
+    }
+
+    // MARK: - Onboarding
+
+    var hasSeenOnboarding: Bool {
+        didSet { save() }
+    }
+
+    // MARK: - Actions
+
+    func resetToDefaults() {
+        defaultSessionLength = .medium
+        followUpsByDefault = true
+        avoidRepeats = true
+        hapticsEnabled = true
+        skipFallInLoveIntroCouples = false
+        skipFallInLoveIntroFriends = false
+        hasSeenOnboarding = false
+    }
+
     // MARK: - Persistence
 
     private static let storageKey = "connections_settings"
@@ -37,6 +63,9 @@ final class SettingsStore {
         self.followUpsByDefault = defaults.followUpsByDefault
         self.avoidRepeats = defaults.avoidRepeats
         self.hapticsEnabled = defaults.hapticsEnabled
+        self.skipFallInLoveIntroCouples = defaults.skipFallInLoveIntroCouples
+        self.skipFallInLoveIntroFriends = defaults.skipFallInLoveIntroFriends
+        self.hasSeenOnboarding = defaults.hasSeenOnboarding
     }
 
     private func save() {
@@ -44,20 +73,26 @@ final class SettingsStore {
             defaultSessionLengthRaw: defaultSessionLength.rawValue,
             followUpsByDefault: followUpsByDefault,
             avoidRepeats: avoidRepeats,
-            hapticsEnabled: hapticsEnabled
+            hapticsEnabled: hapticsEnabled,
+            skipFallInLoveIntroCouples: skipFallInLoveIntroCouples,
+            skipFallInLoveIntroFriends: skipFallInLoveIntroFriends,
+            hasSeenOnboarding: hasSeenOnboarding
         )
         if let encoded = try? JSONEncoder().encode(data) {
             UserDefaults.standard.set(encoded, forKey: Self.storageKey)
         }
     }
 
-    private static func loadDefaults() -> (defaultSessionLength: SessionLength, followUpsByDefault: Bool, avoidRepeats: Bool, hapticsEnabled: Bool) {
+    private static func loadDefaults() -> (defaultSessionLength: SessionLength, followUpsByDefault: Bool, avoidRepeats: Bool, hapticsEnabled: Bool, skipFallInLoveIntroCouples: Bool, skipFallInLoveIntroFriends: Bool, hasSeenOnboarding: Bool) {
         guard let data = UserDefaults.standard.data(forKey: storageKey),
               let decoded = try? JSONDecoder().decode(PersistedSettings.self, from: data) else {
-            return (.medium, true, true, true)
+            return (.medium, true, true, true, false, false, false)
         }
         let length = SessionLength(rawValue: decoded.defaultSessionLengthRaw) ?? .medium
-        return (length, decoded.followUpsByDefault, decoded.avoidRepeats, decoded.hapticsEnabled)
+        // Migrate old single flag to couples if present
+        let couplesSkip = decoded.skipFallInLoveIntroCouples ?? decoded.skipFallInLoveIntro ?? false
+        let friendsSkip = decoded.skipFallInLoveIntroFriends ?? false
+        return (length, decoded.followUpsByDefault, decoded.avoidRepeats, decoded.hapticsEnabled, couplesSkip, friendsSkip, decoded.hasSeenOnboarding ?? false)
     }
 
     private struct PersistedSettings: Codable {
@@ -65,5 +100,9 @@ final class SettingsStore {
         let followUpsByDefault: Bool
         let avoidRepeats: Bool
         let hapticsEnabled: Bool
+        var skipFallInLoveIntro: Bool? = nil     // legacy, migrated to couples
+        let skipFallInLoveIntroCouples: Bool?
+        let skipFallInLoveIntroFriends: Bool?
+        let hasSeenOnboarding: Bool?
     }
 }

--- a/Connections/Services/SettingsStore.swift
+++ b/Connections/Services/SettingsStore.swift
@@ -1,0 +1,69 @@
+//
+//  SettingsStore.swift
+//  Connections
+//
+
+import Foundation
+
+@Observable
+final class SettingsStore {
+    // MARK: - Session
+
+    var defaultSessionLength: SessionLength {
+        didSet { save() }
+    }
+
+    var followUpsByDefault: Bool {
+        didSet { save() }
+    }
+
+    // MARK: - Experience
+
+    var avoidRepeats: Bool {
+        didSet { save() }
+    }
+
+    var hapticsEnabled: Bool {
+        didSet { save() }
+    }
+
+    // MARK: - Persistence
+
+    private static let storageKey = "connections_settings"
+
+    init() {
+        let defaults = Self.loadDefaults()
+        self.defaultSessionLength = defaults.defaultSessionLength
+        self.followUpsByDefault = defaults.followUpsByDefault
+        self.avoidRepeats = defaults.avoidRepeats
+        self.hapticsEnabled = defaults.hapticsEnabled
+    }
+
+    private func save() {
+        let data = PersistedSettings(
+            defaultSessionLengthRaw: defaultSessionLength.rawValue,
+            followUpsByDefault: followUpsByDefault,
+            avoidRepeats: avoidRepeats,
+            hapticsEnabled: hapticsEnabled
+        )
+        if let encoded = try? JSONEncoder().encode(data) {
+            UserDefaults.standard.set(encoded, forKey: Self.storageKey)
+        }
+    }
+
+    private static func loadDefaults() -> (defaultSessionLength: SessionLength, followUpsByDefault: Bool, avoidRepeats: Bool, hapticsEnabled: Bool) {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let decoded = try? JSONDecoder().decode(PersistedSettings.self, from: data) else {
+            return (.medium, true, true, true)
+        }
+        let length = SessionLength(rawValue: decoded.defaultSessionLengthRaw) ?? .medium
+        return (length, decoded.followUpsByDefault, decoded.avoidRepeats, decoded.hapticsEnabled)
+    }
+
+    private struct PersistedSettings: Codable {
+        let defaultSessionLengthRaw: Int
+        let followUpsByDefault: Bool
+        let avoidRepeats: Bool
+        let hapticsEnabled: Bool
+    }
+}

--- a/Connections/Views/ContentView.swift
+++ b/Connections/Views/ContentView.swift
@@ -12,11 +12,16 @@ struct ContentView: View {
     @State private var settings = SettingsStore()
 
     var body: some View {
-        NavigationStack {
-            HomeView()
+        if settings.hasSeenOnboarding {
+            NavigationStack {
+                HomeView()
+            }
+            .environment(session)
+            .environment(settings)
+        } else {
+            OnboardingView()
+                .environment(settings)
         }
-        .environment(session)
-        .environment(settings)
     }
 }
 

--- a/Connections/Views/ContentView.swift
+++ b/Connections/Views/ContentView.swift
@@ -9,12 +9,14 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var session = SessionManager()
+    @State private var settings = SettingsStore()
 
     var body: some View {
         NavigationStack {
             HomeView()
         }
         .environment(session)
+        .environment(settings)
     }
 }
 

--- a/Connections/Views/FallInLoveIntroView.swift
+++ b/Connections/Views/FallInLoveIntroView.swift
@@ -1,0 +1,206 @@
+//
+//  FallInLoveIntroView.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct FallInLoveIntroView: View {
+    @Environment(SessionManager.self) private var session
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var showWhySheet = false
+    @State private var dontShowAgain = false
+    @State private var navigateToSession = false
+
+    private var isFriends: Bool { session.selectedMode == .friends }
+
+    var body: some View {
+        ZStack {
+            AtmosphericBackground(intensity: .honest)
+
+            VStack(spacing: 0) {
+                Spacer()
+
+                // MARK: - Title & Body
+
+                VStack(spacing: 24) {
+                    Text(isFriends ? "Get closer" : "Fall in love again")
+                        .font(.system(size: 32, weight: .regular, design: .serif))
+                        .multilineTextAlignment(.center)
+
+                    Text(isFriends
+                         ? "Some conversations create clarity, trust, and unexpected connection.\n\nThese questions are designed to help two people move past surface-level talk and into something more honest, open, and real."
+                         : "Not by chance — but through attention, honesty, and shared moments.\n\nA series of thoughtfully designed questions can deepen connection, spark curiosity, and bring you closer — one conversation at a time.")
+                        .font(.system(size: 17))
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .lineSpacing(5)
+                }
+                .padding(.horizontal, 36)
+
+                Spacer()
+
+                // MARK: - Actions
+
+                VStack(spacing: 14) {
+                    Button {
+                        if dontShowAgain {
+                            if isFriends {
+                                settings.skipFallInLoveIntroFriends = true
+                            } else {
+                                settings.skipFallInLoveIntroCouples = true
+                            }
+                        }
+                        navigateToSession = true
+                    } label: {
+                        Text("Start session")
+                            .font(.system(size: 17, weight: .semibold))
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .foregroundColor(.white)
+                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                    }
+
+                    Button {
+                        showWhySheet = true
+                    } label: {
+                        Text("Why this works")
+                            .secondaryButtonStyle()
+                    }
+                }
+                .padding(.horizontal, 36)
+
+                // MARK: - Don't Show Again
+
+                Button {
+                    dontShowAgain.toggle()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: dontShowAgain ? "checkmark.square.fill" : "square")
+                            .font(.system(size: 16))
+                            .foregroundStyle(dontShowAgain ? .primary : .tertiary)
+
+                        Text("Don't show this again")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 20)
+                .padding(.bottom, 52)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .navigationDestination(isPresented: $navigateToSession) {
+            FallInLovePlayView()
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                BackButton()
+            }
+        }
+        .sheet(isPresented: $showWhySheet) {
+            WhyThisWorksSheet(isFriends: isFriends)
+        }
+    }
+}
+
+// MARK: - Why This Works Sheet
+
+private struct WhyThisWorksSheet: View {
+    let isFriends: Bool
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: 48)
+
+            Text("Why this works")
+                .font(.system(size: 28, weight: .regular, design: .serif))
+                .padding(.bottom, 24)
+
+            if isFriends {
+                VStack(alignment: .leading, spacing: 14) {
+                    BulletPoint("Meaningful questions build closeness")
+                    BulletPoint("Vulnerability increases trust")
+                    BulletPoint("Shared attention deepens connection")
+                    BulletPoint("Honest conversation changes how people see each other")
+                }
+                .padding(.horizontal, 36)
+
+                Text("Some connections grow gradually.\nThis gives them room to.")
+                    .font(.system(size: 17))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+                    .padding(.horizontal, 36)
+                    .padding(.top, 28)
+            } else {
+                VStack(alignment: .leading, spacing: 14) {
+                    BulletPoint("Meaningful questions create emotional closeness")
+                    BulletPoint("Vulnerability builds trust over time")
+                    BulletPoint("Shared attention strengthens bonds")
+                    BulletPoint("Small moments, repeated, create lasting connection")
+                }
+                .padding(.horizontal, 36)
+
+                Text("You don't fall in love all at once.\nYou build it — moment by moment.")
+                    .font(.system(size: 17))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(5)
+                    .padding(.horizontal, 36)
+                    .padding(.top, 28)
+            }
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Got it")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .foregroundColor(.white)
+                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+            }
+            .padding(.horizontal, 36)
+            .padding(.bottom, 52)
+        }
+        .presentationDragIndicator(.visible)
+    }
+}
+
+private struct BulletPoint: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text("•")
+                .font(.system(size: 17, weight: .medium))
+                .foregroundStyle(.secondary)
+
+            Text(text)
+                .font(.system(size: 17))
+                .foregroundStyle(.secondary)
+                .lineSpacing(4)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FallInLoveIntroView()
+            .environment(SessionManager())
+            .environment(SettingsStore())
+    }
+}

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -6,12 +6,19 @@
 import SwiftUI
 
 struct FallInLovePlayView: View {
+    @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
     @State private var manager = FallInLoveManager()
+
+    private var isFriends: Bool { session.selectedMode == .friends }
     @State private var promptTransitionID = UUID()
+    @State private var promptVisible = true
     @State private var showResetConfirmation = false
 
     var body: some View {
+        ZStack {
+            AtmosphericBackground(intensity: .honest)
+
         VStack(spacing: 0) {
 
             // MARK: - Top Bar
@@ -21,7 +28,7 @@ struct FallInLovePlayView: View {
 
                 Spacer()
 
-                TopBarLabel(text: "Fall in Love")
+                TopBarLabel(text: isFriends ? "Get Closer" : "Fall in Love")
 
                 Spacer()
 
@@ -58,6 +65,9 @@ struct FallInLovePlayView: View {
                 Text(prompt.text)
                     .promptTextStyle()
                     .id(promptTransitionID)
+                    .opacity(promptVisible ? 1 : 0)
+                    .offset(y: promptVisible ? 0 : 10)
+                    .animation(.easeInOut(duration: 0.24), value: promptVisible)
             }
 
             Spacer()
@@ -86,9 +96,12 @@ struct FallInLovePlayView: View {
                 HStack(spacing: 12) {
                     if manager.canGoBack {
                         Button {
-                            manager.goBack()
-                            withAnimation(AppAnimation.transition) {
+                            HapticsManager.lightImpact()
+                            withAnimation(.easeOut(duration: 0.16)) { promptVisible = false }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                                manager.goBack()
                                 promptTransitionID = UUID()
+                                promptVisible = true
                             }
                         } label: {
                             Text("Previous")
@@ -101,9 +114,12 @@ struct FallInLovePlayView: View {
                     }
 
                     Button {
-                        manager.advance()
-                        withAnimation(AppAnimation.transition) {
+                        HapticsManager.lightImpact()
+                        withAnimation(.easeOut(duration: 0.16)) { promptVisible = false }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                            manager.advance()
                             promptTransitionID = UUID()
+                            promptVisible = true
                         }
                     } label: {
                         Text("Next")
@@ -115,7 +131,7 @@ struct FallInLovePlayView: View {
                 .animation(AppAnimation.standard, value: manager.canGoBack)
             }
         }
-        .background(Intensity.honest.backgroundTint.ignoresSafeArea())
+        } // ZStack
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .alert("Start Over?", isPresented: $showResetConfirmation) {
@@ -142,7 +158,9 @@ struct FallInLovePlayView: View {
                 .font(AppFont.promptText())
                 .multilineTextAlignment(.center)
 
-            Text("Take a moment to appreciate the connection you've built.")
+            Text(isFriends
+                 ? "You made space for a deeper kind of conversation."
+                 : "Take a moment to appreciate the connection you've built.")
                 .font(AppFont.subtitle())
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -154,5 +172,6 @@ struct FallInLovePlayView: View {
 #Preview {
     NavigationStack {
         FallInLovePlayView()
+            .environment(SessionManager())
     }
 }

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -8,20 +8,20 @@ import SwiftUI
 struct FavoritesPlayView: View {
     @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
+    @State private var localFavorites: [FavoritesStore.FavoriteEntry] = []
     @State private var currentIndex = 0
     @State private var promptTransitionID = UUID()
     @State private var shownFollowUps: [FollowUp] = []
     @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
-
-    private var favorites: [FavoritesStore.FavoriteEntry] {
-        session.favorites.allFavorites
-    }
+    @State private var promptVisible = true
+    @State private var followUpVisible = true
 
     private var currentEntry: FavoritesStore.FavoriteEntry? {
-        guard !favorites.isEmpty, currentIndex < favorites.count else { return nil }
-        return favorites[currentIndex]
+        guard !localFavorites.isEmpty, currentIndex < localFavorites.count else { return nil }
+        return localFavorites[currentIndex]
     }
 
     private var hasMoreFollowUps: Bool {
@@ -29,11 +29,16 @@ struct FavoritesPlayView: View {
         return shownFollowUps.count < entry.followUps.count
     }
 
+    private var progress: Double {
+        guard !localFavorites.isEmpty else { return 0 }
+        return Double(currentIndex + 1) / Double(localFavorites.count)
+    }
+
     var body: some View {
         ZStack {
-            AtmosphericBackground(intensity: nil)
+            AtmosphericBackground(intensity: currentEntry?.intensity)
 
-            if favorites.isEmpty {
+            if localFavorites.isEmpty {
                 emptyState
             } else {
                 VStack(spacing: 0) {
@@ -45,38 +50,49 @@ struct FavoritesPlayView: View {
                             dismiss()
                         } label: {
                             Image(systemName: "xmark")
-                                .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
+                                .font(.system(size: 15, weight: .medium))
                         }
                         .tint(.secondary)
 
                         Spacer()
 
                         Text("Favorites")
-                            .font(AppFont.caption())
-                            .foregroundStyle(.tertiary)
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
 
                         Spacer()
 
                         heartButton
                     }
-                    .padding(.horizontal, AppSpacing.screenHorizontal)
-                    .padding(.top, AppSpacing.topBarTop)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 12)
 
                     // MARK: - Progress
 
-                    HStack {
-                        Spacer()
+                    VStack(spacing: 6) {
+                        ProgressView(value: progress)
+                            .tint(currentEntry?.intensity.toneColor ?? AppColor.primaryButtonBg(colorScheme))
 
-                        Text("Card \(currentIndex + 1) of \(favorites.count)")
-                            .font(AppFont.detail())
-                            .foregroundStyle(.tertiary)
+                        HStack {
+                            if let entry = currentEntry {
+                                Text("\(entry.mode.rawValue) · \(entry.intensity.rawValue) · \(entry.depth.title)")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+
+                            Text("Card \(currentIndex + 1) of \(localFavorites.count)")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        }
                     }
-                    .padding(.horizontal, AppSpacing.progressHorizontal)
-                    .padding(.top, AppSpacing.progressTop)
+                    .padding(.horizontal, 28)
+                    .padding(.top, 16)
 
-                    // MARK: - Prompt + Follow-ups
+                    // MARK: - Content Area
 
-                    Spacer()
+                    Spacer(minLength: 40)
 
                     promptContent
 
@@ -90,6 +106,9 @@ struct FavoritesPlayView: View {
         }
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
+        .onAppear {
+            localFavorites = session.favorites.allFavorites.shuffled()
+        }
     }
 
     // MARK: - Prompt Content
@@ -99,29 +118,35 @@ struct FavoritesPlayView: View {
         if let entry = currentEntry {
             VStack(spacing: 0) {
                 Text(entry.promptText)
-                    .font(AppFont.promptText())
+                    .font(.system(size: 28, weight: .regular, design: .serif))
                     .multilineTextAlignment(.center)
-                    .lineSpacing(6)
-                    .padding(.horizontal, AppSpacing.promptHorizontal)
-                    .padding(.vertical, 40)
+                    .lineSpacing(8)
+                    .padding(.horizontal, 28)
+                    .padding(.vertical, 44)
                     .id(promptTransitionID)
+                    .opacity(promptVisible ? 1 : 0)
+                    .offset(y: promptVisible ? 0 : 10)
+                    .animation(.easeInOut(duration: 0.2), value: promptVisible)
 
                 if !shownFollowUps.isEmpty {
                     VStack(spacing: 8) {
                         ForEach(shownFollowUps) { followUp in
                             Text(followUp.text)
-                                .font(AppFont.subtitle())
+                                .font(.system(size: 15))
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 20)
                                 .padding(.vertical, 10)
                                 .background(
                                     Capsule()
-                                        .fill(Color.primary.opacity(0.04))
+                                        .fill(entry.intensity.cardTint)
                                 )
                         }
                     }
                     .transition(.opacity.combined(with: .move(edge: .bottom)))
                     .padding(.bottom, 24)
+                    .opacity(followUpVisible ? 1 : 0)
+                    .offset(y: followUpVisible ? 0 : 8)
+                    .animation(.easeInOut(duration: 0.2), value: followUpVisible)
                 }
             }
         }
@@ -132,13 +157,31 @@ struct FavoritesPlayView: View {
     private var heartButton: some View {
         Button {
             guard let entry = currentEntry else { return }
-            session.removeFavorite(id: entry.id)
-            shownFollowUps = []
-            if !favorites.isEmpty && currentIndex >= favorites.count {
-                currentIndex = max(0, favorites.count - 1)
+            HapticsManager.lightImpact()
+
+            withAnimation(.easeOut(duration: 0.16)) {
+                promptVisible = false
+                followUpVisible = false
             }
-            withAnimation(.easeInOut(duration: 0.25)) {
-                promptTransitionID = UUID()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                session.removeFavorite(id: entry.id)
+                localFavorites.removeAll { $0.id == entry.id }
+                shownFollowUps = []
+                showGoDeeperHint = true
+
+                if localFavorites.isEmpty {
+                    // allow empty state to render
+                } else if currentIndex >= localFavorites.count {
+                    currentIndex = max(0, localFavorites.count - 1)
+                    promptTransitionID = UUID()
+                    promptVisible = true
+                    followUpVisible = true
+                } else {
+                    promptTransitionID = UUID()
+                    promptVisible = true
+                    followUpVisible = true
+                }
             }
         } label: {
             Image(systemName: "heart.fill")
@@ -153,15 +196,21 @@ struct FavoritesPlayView: View {
     private var actionButtons: some View {
         VStack(spacing: 0) {
 
-            // MARK: Go Deeper
+            // MARK: Follow-up questions
 
             if hasMoreFollowUps {
                 VStack(spacing: 6) {
                     Button {
                         goDeeperPressed = true
                         HapticsManager.mediumImpact()
-                        withAnimation(.easeOut(duration: 0.25)) {
+                        withAnimation(.easeOut(duration: 0.12)) {
+                            followUpVisible = false
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                             revealNextFollowUp()
+                            withAnimation(.easeIn(duration: 0.2)) {
+                                followUpVisible = true
+                            }
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                             goDeeperPressed = false
@@ -169,20 +218,20 @@ struct FavoritesPlayView: View {
                     } label: {
                         HStack(spacing: 6) {
                             Image(systemName: "sparkles")
-                                .font(.system(size: 12, weight: .medium))
-                            Text("Follow-up questions")
-                                .font(.system(size: 14, weight: .medium))
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("Go deeper")
+                                .font(.system(size: 15, weight: .semibold))
                         }
-                        .foregroundStyle(.primary.opacity(0.7))
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 22)
+                        .padding(.vertical, 12)
                         .background(
                             Capsule()
-                                .fill(Color.primary.opacity(0.04))
+                                .fill((currentEntry?.intensity.cardTint ?? Color.primary).opacity(0.18))
                         )
                         .overlay(
                             Capsule()
-                                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                                .strokeBorder((currentEntry?.intensity.cardTint ?? Color.primary).opacity(0.35), lineWidth: 1)
                         )
                         .scaleEffect(goDeeperPressed ? 0.95 : 1.0)
                         .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
@@ -192,7 +241,7 @@ struct FavoritesPlayView: View {
                     if showGoDeeperHint {
                         Text("Adds deeper follow-up questions")
                             .font(.system(size: 11))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .padding(.bottom, 20)
@@ -204,53 +253,74 @@ struct FavoritesPlayView: View {
             HStack(spacing: 12) {
                 if currentIndex > 0 {
                     Button {
-                        currentIndex -= 1
-                        shownFollowUps = []
-                        withAnimation(.easeInOut(duration: 0.25)) {
+                        HapticsManager.lightImpact()
+
+                        withAnimation(.easeOut(duration: 0.16)) {
+                            promptVisible = false
+                            followUpVisible = false
+                        }
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                            currentIndex -= 1
+                            shownFollowUps = []
+                            showGoDeeperHint = true
                             promptTransitionID = UUID()
+                            promptVisible = true
+                            followUpVisible = true
                         }
                     } label: {
                         Text("Back")
-                            .font(AppFont.buttonSecondary())
+                            .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
-                            .background(Color.primary.opacity(0.04), in: .capsule)
+                            .background(AppColor.surface(colorScheme), in: .capsule)
                     }
                 }
 
-                if currentIndex < favorites.count - 1 {
+                if currentIndex < localFavorites.count - 1 {
                     Button {
-                        currentIndex += 1
-                        shownFollowUps = []
+                        HapticsManager.lightImpact()
                         if !shownFollowUps.isEmpty { showGoDeeperHint = false }
-                        withAnimation(.easeInOut(duration: 0.25)) {
+
+                        withAnimation(.easeOut(duration: 0.16)) {
+                            promptVisible = false
+                            followUpVisible = false
+                        }
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                            currentIndex += 1
+                            shownFollowUps = []
+                            showGoDeeperHint = true
                             promptTransitionID = UUID()
+                            promptVisible = true
+                            followUpVisible = true
                         }
                     } label: {
                         Text("Next")
-                            .font(AppFont.buttonPrimary())
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
-                            .background(Color(.darkGray), in: .capsule)
+                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                     }
                 } else {
                     Button {
                         dismiss()
                     } label: {
                         Text("Done")
-                            .font(AppFont.buttonPrimary())
+                            .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
-                            .background(Color(.darkGray), in: .capsule)
+                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                     }
                 }
             }
+
         }
-        .padding(.horizontal, AppSpacing.contentHorizontal)
-        .padding(.bottom, AppSpacing.bottomPadding)
+        .padding(.horizontal, 28)
+        .padding(.bottom, 48)
         .animation(.easeOut(duration: 0.2), value: shownFollowUps.count)
     }
 
@@ -260,26 +330,25 @@ struct FavoritesPlayView: View {
         VStack(spacing: 16) {
             Image(systemName: "heart")
                 .font(.system(size: 40))
-                .foregroundStyle(.tertiary)
-
-            Text("No favorites yet")
-                .font(AppFont.screenTitle())
                 .foregroundStyle(.secondary)
 
-            Text("Tap the heart on any prompt to save it here")
-                .font(AppFont.subtitle())
-                .foregroundStyle(.tertiary)
+            Text("No favorites yet")
+                .font(.system(size: 28, weight: .regular, design: .serif))
+
+            Text("Tap the heart on any prompt to save it here for later.")
+                .font(.system(size: 15))
+                .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
 
             Button {
                 dismiss()
             } label: {
-                Text("Go Back")
-                    .font(AppFont.buttonSecondary())
+                Text("Return Home")
+                    .font(.system(size: 15, weight: .medium))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 24)
                     .padding(.vertical, 12)
-                    .background(Color.primary.opacity(0.04), in: .capsule)
+                    .background(AppColor.surface(colorScheme), in: .capsule)
             }
             .padding(.top, 8)
         }
@@ -302,5 +371,6 @@ struct FavoritesPlayView: View {
     NavigationStack {
         FavoritesPlayView()
             .environment(SessionManager())
+
     }
 }

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -159,7 +159,7 @@ struct FavoritesPlayView: View {
                 VStack(spacing: 6) {
                     Button {
                         goDeeperPressed = true
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        HapticsManager.mediumImpact()
                         withAnimation(.easeOut(duration: 0.25)) {
                             revealNextFollowUp()
                         }

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -1,0 +1,306 @@
+//
+//  FavoritesPlayView.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct FavoritesPlayView: View {
+    @Environment(SessionManager.self) private var session
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var currentIndex = 0
+    @State private var promptTransitionID = UUID()
+    @State private var shownFollowUps: [FollowUp] = []
+    @State private var showGoDeeperHint = true
+    @State private var goDeeperPressed = false
+
+    private var favorites: [FavoritesStore.FavoriteEntry] {
+        session.favorites.allFavorites
+    }
+
+    private var currentEntry: FavoritesStore.FavoriteEntry? {
+        guard !favorites.isEmpty, currentIndex < favorites.count else { return nil }
+        return favorites[currentIndex]
+    }
+
+    private var hasMoreFollowUps: Bool {
+        guard let entry = currentEntry else { return false }
+        return shownFollowUps.count < entry.followUps.count
+    }
+
+    var body: some View {
+        ZStack {
+            AtmosphericBackground(intensity: nil)
+
+            if favorites.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: 0) {
+
+                    // MARK: - Top Bar
+
+                    HStack {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Image(systemName: "xmark")
+                                .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
+                        }
+                        .tint(.secondary)
+
+                        Spacer()
+
+                        Text("Favorites")
+                            .font(AppFont.caption())
+                            .foregroundStyle(.tertiary)
+
+                        Spacer()
+
+                        heartButton
+                    }
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
+                    .padding(.top, AppSpacing.topBarTop)
+
+                    // MARK: - Progress
+
+                    HStack {
+                        Spacer()
+
+                        Text("Card \(currentIndex + 1) of \(favorites.count)")
+                            .font(AppFont.detail())
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.horizontal, AppSpacing.progressHorizontal)
+                    .padding(.top, AppSpacing.progressTop)
+
+                    // MARK: - Prompt + Follow-ups
+
+                    Spacer()
+
+                    promptContent
+
+                    Spacer()
+
+                    // MARK: - Actions
+
+                    actionButtons
+                }
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar(.hidden, for: .navigationBar)
+    }
+
+    // MARK: - Prompt Content
+
+    @ViewBuilder
+    private var promptContent: some View {
+        if let entry = currentEntry {
+            VStack(spacing: 0) {
+                Text(entry.promptText)
+                    .font(AppFont.promptText())
+                    .multilineTextAlignment(.center)
+                    .lineSpacing(6)
+                    .padding(.horizontal, AppSpacing.promptHorizontal)
+                    .padding(.vertical, 40)
+                    .id(promptTransitionID)
+
+                if !shownFollowUps.isEmpty {
+                    VStack(spacing: 8) {
+                        ForEach(shownFollowUps) { followUp in
+                            Text(followUp.text)
+                                .font(AppFont.subtitle())
+                                .foregroundStyle(.secondary)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 10)
+                                .background(
+                                    Capsule()
+                                        .fill(Color.primary.opacity(0.04))
+                                )
+                        }
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .padding(.bottom, 24)
+                }
+            }
+        }
+    }
+
+    // MARK: - Heart Button
+
+    private var heartButton: some View {
+        Button {
+            guard let entry = currentEntry else { return }
+            session.removeFavorite(id: entry.id)
+            shownFollowUps = []
+            if !favorites.isEmpty && currentIndex >= favorites.count {
+                currentIndex = max(0, favorites.count - 1)
+            }
+            withAnimation(.easeInOut(duration: 0.25)) {
+                promptTransitionID = UUID()
+            }
+        } label: {
+            Image(systemName: "heart.fill")
+                .font(.system(size: 22))
+                .foregroundColor(.red)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Action Buttons
+
+    private var actionButtons: some View {
+        VStack(spacing: 0) {
+
+            // MARK: Go Deeper
+
+            if hasMoreFollowUps {
+                VStack(spacing: 6) {
+                    Button {
+                        goDeeperPressed = true
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        withAnimation(.easeOut(duration: 0.25)) {
+                            revealNextFollowUp()
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                            goDeeperPressed = false
+                        }
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "sparkles")
+                                .font(.system(size: 12, weight: .medium))
+                            Text("Follow-up questions")
+                                .font(.system(size: 14, weight: .medium))
+                        }
+                        .foregroundStyle(.primary.opacity(0.7))
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 10)
+                        .background(
+                            Capsule()
+                                .fill(Color.primary.opacity(0.04))
+                        )
+                        .overlay(
+                            Capsule()
+                                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                        )
+                        .scaleEffect(goDeeperPressed ? 0.95 : 1.0)
+                        .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
+                    }
+                    .buttonStyle(.plain)
+
+                    if showGoDeeperHint {
+                        Text("Adds deeper follow-up questions")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.tertiary)
+                    }
+                }
+                .padding(.bottom, 20)
+                .transition(.opacity)
+            }
+
+            // MARK: Back / Next / Done
+
+            HStack(spacing: 12) {
+                if currentIndex > 0 {
+                    Button {
+                        currentIndex -= 1
+                        shownFollowUps = []
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            promptTransitionID = UUID()
+                        }
+                    } label: {
+                        Text("Back")
+                            .font(AppFont.buttonSecondary())
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color.primary.opacity(0.04), in: .capsule)
+                    }
+                }
+
+                if currentIndex < favorites.count - 1 {
+                    Button {
+                        currentIndex += 1
+                        shownFollowUps = []
+                        if !shownFollowUps.isEmpty { showGoDeeperHint = false }
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            promptTransitionID = UUID()
+                        }
+                    } label: {
+                        Text("Next")
+                            .font(AppFont.buttonPrimary())
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color(.darkGray), in: .capsule)
+                    }
+                } else {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Text("Done")
+                            .font(AppFont.buttonPrimary())
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color(.darkGray), in: .capsule)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, AppSpacing.contentHorizontal)
+        .padding(.bottom, AppSpacing.bottomPadding)
+        .animation(.easeOut(duration: 0.2), value: shownFollowUps.count)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "heart")
+                .font(.system(size: 40))
+                .foregroundStyle(.tertiary)
+
+            Text("No favorites yet")
+                .font(AppFont.screenTitle())
+                .foregroundStyle(.secondary)
+
+            Text("Tap the heart on any prompt to save it here")
+                .font(AppFont.subtitle())
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Go Back")
+                    .font(AppFont.buttonSecondary())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+                    .background(Color.primary.opacity(0.04), in: .capsule)
+            }
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, 40)
+    }
+
+    // MARK: - Helpers
+
+    private func revealNextFollowUp() {
+        guard let entry = currentEntry else { return }
+        let shown = Set(shownFollowUps.map(\.id))
+        let remaining = entry.followUps.filter { !shown.contains($0.id) }
+        guard let next = remaining.first else { return }
+        shownFollowUps.append(next)
+        showGoDeeperHint = false
+    }
+}
+
+#Preview {
+    NavigationStack {
+        FavoritesPlayView()
+            .environment(SessionManager())
+    }
+}

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -7,8 +7,13 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(SessionManager.self) private var session
+    @State private var navigateToFavorites = false
+
     var body: some View {
         GeometryReader { geo in
+            ZStack {
+                NeutralBackground()
+
             VStack(spacing: 0) {
 
                 // MARK: - Header
@@ -43,19 +48,21 @@ struct HomeView: View {
                                 .secondaryButtonStyle()
                         }
                     }
+
+                    if !session.favorites.allFavorites.isEmpty {
+                        Button {
+                            navigateToFavorites = true
+                        } label: {
+                            Text("Play Favorites (\(session.favorites.allFavorites.count))")
+                                .secondaryButtonStyle()
+                        }
+                    }
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
 
                 // MARK: - Secondary
 
                 HStack(spacing: 36) {
-                    Button {
-                        // Favorites — next step
-                    } label: {
-                        Label("Favorites", systemImage: "heart")
-                            .font(AppFont.label())
-                    }
-
                     Button {
                         // Settings — next step
                     } label: {
@@ -67,6 +74,10 @@ struct HomeView: View {
                 .padding(.top, 24)
                 .padding(.bottom, max(geo.safeAreaInsets.bottom + 16, AppSpacing.bottomPadding))
             }
+            .navigationDestination(isPresented: $navigateToFavorites) {
+                FavoritesPlayView()
+            }
+            } // ZStack
         }
     }
 }

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct HomeView: View {
     @Environment(SessionManager.self) private var session
     @State private var navigateToFavorites = false
+    @State private var navigateToSettings = false
 
     var body: some View {
         GeometryReader { geo in
@@ -19,7 +20,7 @@ struct HomeView: View {
                 // MARK: - Header
 
                 VStack(spacing: 16) {
-                    Text("Layers")
+                    Text("Connections")
                         .font(AppFont.heroTitle())
                         .tracking(1)
 
@@ -64,7 +65,7 @@ struct HomeView: View {
 
                 HStack(spacing: 36) {
                     Button {
-                        // Settings — next step
+                        navigateToSettings = true
                     } label: {
                         Label("Settings", systemImage: "gearshape")
                             .font(AppFont.label())
@@ -76,6 +77,9 @@ struct HomeView: View {
             }
             .navigationDestination(isPresented: $navigateToFavorites) {
                 FavoritesPlayView()
+            }
+            .navigationDestination(isPresented: $navigateToSettings) {
+                SettingsView()
             }
             } // ZStack
         }

--- a/Connections/Views/IntensitySelectionView.swift
+++ b/Connections/Views/IntensitySelectionView.swift
@@ -12,30 +12,37 @@ struct IntensitySelectionView: View {
     @State private var navigateToSetup = false
 
     var body: some View {
-        VStack(spacing: 0) {
+        ZStack {
+            AtmosphericBackground(intensity: session.selectedIntensity)
 
-            // MARK: - Header
+            VStack(spacing: 0) {
 
-            ScreenHeader(title: "Set the tone", subtitle: "How deep do you want to go?")
+                // MARK: - Header
 
-            // MARK: - Intensity Cards
+                ScreenHeader(title: "Set the tone", subtitle: "How deep do you want to go?")
 
-            VStack(spacing: AppSpacing.cardSpacing) {
-                ForEach(Intensity.allCases) { intensity in
-                    SelectionCard(
-                        title: intensity.rawValue,
-                        subtitle: intensity.description,
-                        tintColor: intensity.toneColor
-                    ) {
-                        session.selectedIntensity = intensity
-                        navigateToSetup = true
+                // MARK: - Intensity Cards
+
+                VStack(spacing: AppSpacing.cardSpacing) {
+                    ForEach(Intensity.allCases) { intensity in
+                        SelectionCard(
+                            title: intensity.rawValue,
+                            subtitle: intensity.description,
+                            tintColor: intensity.toneColor,
+                            isSelected: session.selectedIntensity == intensity,
+                            glassEffect: true
+                        ) {
+                            session.selectedIntensity = intensity
+                            navigateToSetup = true
+                        }
                     }
                 }
-            }
-            .padding(.horizontal, AppSpacing.screenHorizontal)
+                .padding(.horizontal, AppSpacing.screenHorizontal)
 
-            Spacer()
+                Spacer()
+            }
         }
+        .animation(.easeInOut(duration: 0.35), value: session.selectedIntensity)
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $navigateToSetup) {
             SessionSetupView()
@@ -46,6 +53,7 @@ struct IntensitySelectionView: View {
             }
         }
     }
+
 }
 
 #Preview {

--- a/Connections/Views/ModeSelectionView.swift
+++ b/Connections/Views/ModeSelectionView.swift
@@ -13,6 +13,9 @@ struct ModeSelectionView: View {
     @State private var navigateToShare = false
 
     var body: some View {
+        ZStack {
+            NeutralBackground()
+
         VStack(spacing: 0) {
 
             // MARK: - Header
@@ -39,6 +42,7 @@ struct ModeSelectionView: View {
 
             Spacer()
         }
+        } // ZStack
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $navigateToIntensity) {
             IntensitySelectionView()

--- a/Connections/Views/OnboardingView.swift
+++ b/Connections/Views/OnboardingView.swift
@@ -1,0 +1,133 @@
+//
+//  OnboardingView.swift
+//  Connections
+//
+
+import SwiftUI
+
+private struct OnboardingPage: Identifiable {
+    let id = UUID()
+    let title: String
+    let body: String
+}
+
+struct OnboardingView: View {
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var currentPage = 0
+
+    private let pages: [OnboardingPage] = [
+        OnboardingPage(
+            title: "Go deeper",
+            body: "Most conversations stay on the surface.\nThis helps you move into something more honest, meaningful, and real."
+        ),
+        OnboardingPage(
+            title: "Built for connection",
+            body: "Thoughtful questions help you slow down, open up, and discover what's underneath the usual answers."
+        ),
+        OnboardingPage(
+            title: "Simple by design",
+            body: "Choose a mode\nSet the tone\nAnswer honestly\nGo deeper when it feels right"
+        ),
+        OnboardingPage(
+            title: "Start where you are",
+            body: "With a partner, a friend, family — or just yourself.\nThere's no right way to begin."
+        )
+    ]
+
+    var body: some View {
+        ZStack {
+            NeutralBackground()
+
+            VStack(spacing: 0) {
+
+                // MARK: - Skip
+
+                HStack {
+                    Spacer()
+
+                    if currentPage < pages.count - 1 {
+                        Button("Skip") {
+                            settings.hasSeenOnboarding = true
+                        }
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+
+                // MARK: - Pages
+
+                TabView(selection: $currentPage) {
+                    ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
+                        VStack(spacing: 0) {
+                            Spacer()
+
+                            VStack(spacing: 24) {
+                                Text(page.title)
+                                    .font(.system(size: 32, weight: .regular, design: .serif))
+                                    .multilineTextAlignment(.center)
+
+                                Text(page.body)
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.center)
+                                    .lineSpacing(5)
+                                    .padding(.horizontal, 36)
+                            }
+                            .frame(maxWidth: 520)
+
+                            Spacer()
+                        }
+                        .tag(index)
+                    }
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+
+                // MARK: - Page Indicators
+
+                HStack(spacing: 8) {
+                    ForEach(0..<pages.count, id: \.self) { index in
+                        Capsule()
+                            .fill(
+                                index == currentPage
+                                ? AppColor.primaryButtonBg(colorScheme)
+                                : AppColor.surface(colorScheme)
+                            )
+                            .frame(width: index == currentPage ? 20 : 8, height: 8)
+                            .animation(.easeInOut(duration: 0.2), value: currentPage)
+                    }
+                }
+                .padding(.bottom, 28)
+
+                // MARK: - Button
+
+                Button {
+                    if currentPage < pages.count - 1 {
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            currentPage += 1
+                        }
+                    } else {
+                        settings.hasSeenOnboarding = true
+                    }
+                } label: {
+                    Text(currentPage < pages.count - 1 ? "Next" : "Start")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .foregroundColor(.white)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                }
+                .padding(.horizontal, 36)
+                .padding(.bottom, 52)
+            }
+        }
+    }
+}
+
+#Preview {
+    OnboardingView()
+        .environment(SettingsStore())
+}

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -8,10 +8,13 @@ import SwiftUI
 struct SessionPlayView: View {
     @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var promptTransitionID = UUID()
     @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
+    @State private var promptVisible = true
+    @State private var followUpVisible = true
     var body: some View {
         ZStack {
             AtmosphericBackground(intensity: session.selectedIntensity)
@@ -35,7 +38,7 @@ struct SessionPlayView: View {
                 if let mode = session.selectedMode, let intensity = session.selectedIntensity {
                     Text("\(mode.rawValue) · \(intensity.rawValue)")
                         .font(.system(size: 13))
-                        .foregroundStyle(.tertiary)
+                        .foregroundStyle(.secondary)
                 }
 
                 Spacer()
@@ -62,7 +65,7 @@ struct SessionPlayView: View {
             if !session.isSessionComplete {
                 VStack(spacing: 6) {
                     ProgressView(value: session.sessionProgress)
-                        .tint(Color(.darkGray))
+                        .tint(session.selectedIntensity?.toneColor ?? AppColor.primaryButtonBg(colorScheme))
 
                     HStack {
                         Text(session.currentDepth.title)
@@ -73,7 +76,7 @@ struct SessionPlayView: View {
 
                         Text("Card \(min(session.promptsShown + 1, session.totalPrompts)) of \(session.totalPrompts)")
                             .font(.system(size: 12))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.secondary)
                     }
                 }
                 .padding(.horizontal, 28)
@@ -82,7 +85,7 @@ struct SessionPlayView: View {
 
             // MARK: - Content Area
 
-            Spacer()
+            Spacer(minLength: 40)
 
             if session.isSessionComplete {
                 // Session complete
@@ -124,7 +127,7 @@ struct SessionPlayView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 18)
-                        .background(Color(.darkGray), in: .capsule)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                 }
                 .padding(.horizontal, 36)
                 .padding(.bottom, 52)
@@ -146,12 +149,15 @@ struct SessionPlayView: View {
     private func promptContent(_ prompt: Prompt) -> some View {
         VStack(spacing: 0) {
             Text(prompt.text)
-                .font(.system(size: 24, weight: .regular, design: .serif))
+                .font(.system(size: 28, weight: .regular, design: .serif))
                 .multilineTextAlignment(.center)
-                .lineSpacing(6)
-                .padding(.horizontal, 32)
-                .padding(.vertical, 40)
+                .lineSpacing(8)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 44)
                 .id(promptTransitionID)
+                .opacity(promptVisible ? 1 : 0)
+                .offset(y: promptVisible ? 0 : 10)
+                .animation(.easeInOut(duration: 0.2), value: promptVisible)
 
             if !session.shownFollowUps.isEmpty && session.followUpsEnabled {
                 VStack(spacing: 8) {
@@ -169,6 +175,9 @@ struct SessionPlayView: View {
                 }
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .padding(.bottom, 24)
+                .opacity(followUpVisible ? 1 : 0)
+                .offset(y: followUpVisible ? 0 : 8)
+                .animation(.easeInOut(duration: 0.2), value: followUpVisible)
             }
         }
     }
@@ -178,7 +187,7 @@ struct SessionPlayView: View {
     private var actionButtons: some View {
         VStack(spacing: 0) {
 
-            // MARK: Go deeper (above primary actions, with breathing room)
+            // MARK: Follow-up questions (above primary actions, with breathing room)
 
             if session.followUpsEnabled && session.hasMoreFollowUps {
                 VStack(spacing: 6) {
@@ -186,8 +195,14 @@ struct SessionPlayView: View {
                         goDeeperPressed = true
                         HapticsManager.mediumImpact()
                         session.recordGoDeeper()
-                        withAnimation(.easeOut(duration: 0.25)) {
+                        withAnimation(.easeOut(duration: 0.12)) {
+                            followUpVisible = false
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                             session.revealNextFollowUp()
+                            withAnimation(.easeIn(duration: 0.2)) {
+                                followUpVisible = true
+                            }
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                             goDeeperPressed = false
@@ -195,31 +210,27 @@ struct SessionPlayView: View {
                     } label: {
                         HStack(spacing: 6) {
                             Image(systemName: "sparkles")
-                                .font(.system(size: 12, weight: .medium))
-                            Text("Follow-up questions")
-                                .font(.system(size: 14, weight: .medium))
+                                .font(.system(size: 13, weight: .semibold))
+                            Text("Go deeper")
+                                .font(.system(size: 15, weight: .semibold))
                         }
-                        .foregroundStyle(.primary.opacity(0.7))
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
+                        .foregroundStyle(.primary)
+                        .padding(.horizontal, 22)
+                        .padding(.vertical, 12)
                         .background(
                             Capsule()
-                                .fill(Color.primary.opacity(0.04))
+                                .fill(session.selectedIntensity?.cardTint.opacity(0.18) ?? Color.primary.opacity(0.1))
                         )
                         .overlay(
                             Capsule()
-                                .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+                                .strokeBorder(session.selectedIntensity?.cardTint.opacity(0.35) ?? Color.primary.opacity(0.2), lineWidth: 1)
                         )
                         .scaleEffect(goDeeperPressed ? 0.95 : 1.0)
                         .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
                     }
                     .buttonStyle(.plain)
 
-                    if showGoDeeperHint {
-                        Text("Adds deeper follow-up questions")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.tertiary)
-                    }
+
                 }
                 .padding(.bottom, 20)
                 .transition(.opacity)
@@ -230,29 +241,51 @@ struct SessionPlayView: View {
             HStack(spacing: 12) {
                 if session.canGoBack {
                     Button {
-                        session.goBack()
-                        advanceToNext()
+                        HapticsManager.lightImpact()
+
+                        withAnimation(.easeOut(duration: 0.16)) {
+                            promptVisible = false
+                            followUpVisible = false
+                        }
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                            session.goBack()
+                            promptTransitionID = UUID()
+                            promptVisible = true
+                            followUpVisible = true
+                        }
                     } label: {
                         Text("Back")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(.secondary)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
-                            .background(Color.primary.opacity(0.04), in: .capsule)
+                            .background(AppColor.surface(colorScheme), in: .capsule)
                     }
                 }
 
                 Button {
                     HapticsManager.lightImpact()
-                    session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
-                    advanceToNext()
+                    if !session.shownFollowUps.isEmpty { showGoDeeperHint = false }
+
+                    withAnimation(.easeOut(duration: 0.16)) {
+                        promptVisible = false
+                        followUpVisible = false
+                    }
+
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
+                        session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
+                        promptTransitionID = UUID()
+                        promptVisible = true
+                        followUpVisible = true
+                    }
                 } label: {
                     Text("Next")
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .background(Color(.darkGray), in: .capsule)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                 }
             }
 
@@ -268,6 +301,8 @@ struct SessionPlayView: View {
                     Image(systemName: session.isCurrentPromptFavorited() ? "heart.fill" : "heart")
                         .font(.system(size: 22))
                         .foregroundColor(session.isCurrentPromptFavorited() ? .red : .gray)
+                        .scaleEffect(session.isCurrentPromptFavorited() ? 1.15 : 1.0)
+                        .animation(.spring(response: 0.25, dampingFraction: 0.6), value: session.isCurrentPromptFavorited())
                 }
                 .buttonStyle(.plain)
 
@@ -285,7 +320,7 @@ struct SessionPlayView: View {
                         .foregroundStyle(.white)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
-                        .background(Capsule().fill(Color(.darkGray)))
+                        .background(Capsule().fill(AppColor.primaryButtonBg(colorScheme)))
                     }
                     .buttonStyle(.plain)
                     .transition(.opacity)
@@ -344,7 +379,7 @@ struct SessionPlayView: View {
                     if let nextStep = summary.nextStep {
                         Text(nextStep)
                             .font(.system(size: 13, weight: .regular, design: .serif))
-                            .foregroundStyle(.tertiary)
+                            .foregroundStyle(.secondary)
                             .italic()
                             .padding(.top, 4)
                     }
@@ -355,16 +390,7 @@ struct SessionPlayView: View {
         }
     }
 
-    // MARK: - Helpers
 
-    private func advanceToNext() {
-        if !session.shownFollowUps.isEmpty { showGoDeeperHint = false }
-        if !session.showFeelingCheckIn {
-            withAnimation(.easeInOut(duration: 0.25)) {
-                promptTransitionID = UUID()
-            }
-        }
-    }
 }
 
 #Preview {

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import MessageUI
 
 struct SessionPlayView: View {
     @Environment(SessionManager.self) private var session
@@ -15,8 +14,6 @@ struct SessionPlayView: View {
     @State private var promptTransitionID = UUID()
     @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
-    @State private var showShareSheet = false
-
     var body: some View {
         VStack(spacing: 0) {
 
@@ -47,11 +44,9 @@ struct SessionPlayView: View {
                         ConnectionHeartView(fillAmount: session.connectionTracker.fillAmount, size: 16)
                     }
 
-                    if session.currentPrompt != nil && !session.isSessionComplete && MFMessageComposeViewController.canSendText() {
-                        Button {
-                            showShareSheet = true
-                        } label: {
-                            Image(systemName: "message")
+                    if let prompt = session.currentPrompt, !session.isSessionComplete {
+                        ShareLink(item: prompt.text) {
+                            Image(systemName: "square.and.arrow.up")
                                 .font(.system(size: 14, weight: .medium))
                                 .foregroundStyle(.secondary)
                         }
@@ -137,11 +132,6 @@ struct SessionPlayView: View {
         .background((session.selectedIntensity?.backgroundTint ?? Color.clear).ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
-        .sheet(isPresented: $showShareSheet) {
-            if let prompt = session.currentPrompt {
-                MessageComposer(body: prompt.text)
-            }
-        }
         .animation(.easeInOut(duration: 0.3), value: session.showFeelingCheckIn)
         .animation(.easeInOut(duration: 0.3), value: session.isSessionComplete)
     }
@@ -368,38 +358,6 @@ struct SessionPlayView: View {
             withAnimation(.easeInOut(duration: 0.25)) {
                 promptTransitionID = UUID()
             }
-        }
-    }
-}
-
-// MARK: - Message Composer
-
-private struct MessageComposer: UIViewControllerRepresentable {
-    let body: String
-    @Environment(\.dismiss) private var dismiss
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(dismiss: dismiss)
-    }
-
-    func makeUIViewController(context: Context) -> MFMessageComposeViewController {
-        let controller = MFMessageComposeViewController()
-        controller.body = body
-        controller.messageComposeDelegate = context.coordinator
-        return controller
-    }
-
-    func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {}
-
-    class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
-        let dismiss: DismissAction
-
-        init(dismiss: DismissAction) {
-            self.dismiss = dismiss
-        }
-
-        func messageComposeViewController(_ controller: MFMessageComposeViewController, didFinishWith result: MessageComposeResult) {
-            dismiss()
         }
     }
 }

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -11,7 +11,6 @@ struct SessionPlayView: View {
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var promptTransitionID = UUID()
-    @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
     @State private var promptVisible = true
     @State private var followUpVisible = true
@@ -80,7 +79,7 @@ struct SessionPlayView: View {
                     }
                 }
                 .padding(.horizontal, 28)
-                .padding(.top, 16)
+                .padding(.top, 12)
             }
 
             // MARK: - Content Area
@@ -266,8 +265,6 @@ struct SessionPlayView: View {
 
                 Button {
                     HapticsManager.lightImpact()
-                    if !session.shownFollowUps.isEmpty { showGoDeeperHint = false }
-
                     withAnimation(.easeOut(duration: 0.16)) {
                         promptVisible = false
                         followUpVisible = false
@@ -344,7 +341,7 @@ struct SessionPlayView: View {
                 )
             }
 
-            Text("Session complete")
+            Text("Something was shared here")
                 .font(.system(size: 28, weight: .regular, design: .serif))
 
             VStack(spacing: 6) {
@@ -386,6 +383,31 @@ struct SessionPlayView: View {
                 }
                 .padding(.horizontal, 32)
                 .padding(.top, 8)
+            }
+
+            // Standout Prompts
+            let standout = session.standoutPromptInteractions(limit: 3)
+
+            if !standout.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Moments you stayed with")
+                        .font(.system(size: 18, weight: .medium, design: .serif))
+
+                    Text("You spent more time on these questions or chose to go deeper.")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        ForEach(standout, id: \.promptID) { interaction in
+                            Text("• \(interaction.promptText)")
+                                .font(.system(size: 14))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+                .padding(.horizontal, 32)
+                .padding(.top, 16)
             }
         }
     }

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -9,12 +9,13 @@ struct SessionPlayView: View {
     @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
 
-    @State private var isFavorited = false
-    @State private var showFollowUps = false
     @State private var promptTransitionID = UUID()
     @State private var showGoDeeperHint = true
     @State private var goDeeperPressed = false
     var body: some View {
+        ZStack {
+            AtmosphericBackground(intensity: session.selectedIntensity)
+
         VStack(spacing: 0) {
 
             // MARK: - Top Bar
@@ -129,7 +130,7 @@ struct SessionPlayView: View {
                 .padding(.bottom, 52)
             }
         }
-        .background((session.selectedIntensity?.backgroundTint ?? Color.clear).ignoresSafeArea())
+        } // ZStack
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .animation(.easeInOut(duration: 0.3), value: session.showFeelingCheckIn)
@@ -149,9 +150,9 @@ struct SessionPlayView: View {
                 .padding(.vertical, 40)
                 .id(promptTransitionID)
 
-            if showFollowUps && session.followUpsEnabled {
+            if !session.shownFollowUps.isEmpty && session.followUpsEnabled {
                 VStack(spacing: 8) {
-                    ForEach(prompt.followUps) { followUp in
+                    ForEach(session.shownFollowUps) { followUp in
                         Text(followUp.text)
                             .font(.system(size: 15))
                             .foregroundStyle(.secondary)
@@ -176,14 +177,14 @@ struct SessionPlayView: View {
 
             // MARK: Go deeper (above primary actions, with breathing room)
 
-            if session.followUpsEnabled && !showFollowUps {
+            if session.followUpsEnabled && session.hasMoreFollowUps {
                 VStack(spacing: 6) {
                     Button {
                         goDeeperPressed = true
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
                         session.recordGoDeeper()
                         withAnimation(.easeOut(duration: 0.25)) {
-                            showFollowUps = true
+                            session.revealNextFollowUp()
                         }
                         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
                             goDeeperPressed = false
@@ -192,7 +193,7 @@ struct SessionPlayView: View {
                         HStack(spacing: 6) {
                             Image(systemName: "sparkles")
                                 .font(.system(size: 12, weight: .medium))
-                            Text("Go deeper")
+                            Text("Follow-up questions")
                                 .font(.system(size: 14, weight: .medium))
                         }
                         .foregroundStyle(.primary.opacity(0.7))
@@ -221,23 +222,25 @@ struct SessionPlayView: View {
                 .transition(.opacity)
             }
 
-            // MARK: Skip / Next
+            // MARK: Back / Next
 
             HStack(spacing: 12) {
-                Button {
-                    session.skipPrompt()
-                    advanceToNext()
-                } label: {
-                    Text("Skip")
-                        .font(.system(size: 15, weight: .medium))
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(Color.primary.opacity(0.04), in: .capsule)
+                if session.canGoBack {
+                    Button {
+                        session.goBack()
+                        advanceToNext()
+                    } label: {
+                        Text("Back")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(Color.primary.opacity(0.04), in: .capsule)
+                    }
                 }
 
                 Button {
-                    session.continuePrompt(isFavorited: isFavorited)
+                    session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
                     advanceToNext()
                 } label: {
                     Text("Next")
@@ -253,18 +256,15 @@ struct SessionPlayView: View {
 
             HStack(spacing: 28) {
                 Button {
-                    isFavorited.toggle()
-                    if isFavorited {
-                        session.favoriteCurrentPrompt()
-                    }
+                    session.toggleFavoriteCurrentPrompt()
                 } label: {
-                    Image(systemName: isFavorited ? "heart.fill" : "heart")
-                        .font(.system(size: 18))
-                        .foregroundStyle(isFavorited ? Color(.darkGray) : .secondary)
+                    Image(systemName: session.isCurrentPromptFavorited() ? "heart.fill" : "heart")
+                        .font(.system(size: 22))
+                        .foregroundColor(session.isCurrentPromptFavorited() ? .red : .gray)
                 }
                 .buttonStyle(.plain)
 
-                if session.followUpsEnabled && showFollowUps {
+                if session.followUpsEnabled && !session.shownFollowUps.isEmpty && !session.hasMoreFollowUps {
                     Button {
                         session.recordGoDeeper()
                         session.triggerCheckInFromGoDeeper()
@@ -288,7 +288,7 @@ struct SessionPlayView: View {
         }
         .padding(.horizontal, 28)
         .padding(.bottom, 48)
-        .animation(.easeOut(duration: 0.2), value: showFollowUps)
+        .animation(.easeOut(duration: 0.2), value: session.shownFollowUps.count)
     }
 
     // MARK: - Session Complete Content
@@ -351,9 +351,7 @@ struct SessionPlayView: View {
     // MARK: - Helpers
 
     private func advanceToNext() {
-        isFavorited = false
-        if showFollowUps { showGoDeeperHint = false }
-        showFollowUps = false
+        if !session.shownFollowUps.isEmpty { showGoDeeperHint = false }
         if !session.showFeelingCheckIn {
             withAnimation(.easeInOut(duration: 0.25)) {
                 promptTransitionID = UUID()

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -135,6 +135,9 @@ struct SessionPlayView: View {
         .toolbar(.hidden, for: .navigationBar)
         .animation(.easeInOut(duration: 0.3), value: session.showFeelingCheckIn)
         .animation(.easeInOut(duration: 0.3), value: session.isSessionComplete)
+        .onChange(of: session.isSessionComplete) { _, complete in
+            if complete { HapticsManager.success() }
+        }
     }
 
     // MARK: - Prompt Content
@@ -181,7 +184,7 @@ struct SessionPlayView: View {
                 VStack(spacing: 6) {
                     Button {
                         goDeeperPressed = true
-                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                        HapticsManager.mediumImpact()
                         session.recordGoDeeper()
                         withAnimation(.easeOut(duration: 0.25)) {
                             session.revealNextFollowUp()
@@ -240,6 +243,7 @@ struct SessionPlayView: View {
                 }
 
                 Button {
+                    HapticsManager.lightImpact()
                     session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
                     advanceToNext()
                 } label: {
@@ -256,6 +260,9 @@ struct SessionPlayView: View {
 
             HStack(spacing: 28) {
                 Button {
+                    if !session.isCurrentPromptFavorited() {
+                        HapticsManager.lightImpact()
+                    }
                     session.toggleFavoriteCurrentPrompt()
                 } label: {
                     Image(systemName: session.isCurrentPromptFavorited() ? "heart.fill" : "heart")

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 
 struct SessionSetupView: View {
     @Environment(SessionManager.self) private var session
+    @Environment(SettingsStore.self) private var settings
     @Environment(\.dismiss) private var dismiss
 
     private var availableTopics: [Topic] {
@@ -19,6 +20,7 @@ struct SessionSetupView: View {
     @State private var selectedLength: SessionLength = .medium
     @State private var selectedTopic: Topic? = nil
     @State private var followUps: Bool = true
+    @State private var didApplyDefaults = false
     @State private var navigateToSession = false
     @State private var navigateToFallInLove = false
     @State private var showAgeConfirmation = false
@@ -169,6 +171,13 @@ struct SessionSetupView: View {
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("Sex prompts contain mature content. Please confirm you are 18 years or older to continue.")
+        }
+        .onAppear {
+            if !didApplyDefaults {
+                selectedLength = settings.defaultSessionLength
+                followUps = settings.followUpsByDefault
+                didApplyDefaults = true
+            }
         }
         .onChange(of: session.selectedMode) { _, _ in selectedTopic = nil }
         .onChange(of: session.selectedIntensity) { _, _ in selectedTopic = nil }
@@ -384,5 +393,6 @@ private struct FlowLayout: Layout {
                 s.selectedIntensity = .honest
                 return s
             }())
+            .environment(SettingsStore())
     }
 }

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -27,6 +27,9 @@ struct SessionSetupView: View {
     var body: some View {
         @Bindable var session = session
 
+        ZStack {
+            AtmosphericBackground(intensity: session.selectedIntensity)
+
         VStack(spacing: 0) {
 
             // MARK: - Header
@@ -48,7 +51,7 @@ struct SessionSetupView: View {
 
             if selectedTopic != .fallInLove {
                 VStack(alignment: .leading, spacing: 14) {
-                    Text("Session length")
+                    Text("Question count")
                         .font(.system(size: 14, weight: .medium))
                         .foregroundStyle(.secondary)
                         .padding(.leading, 4)
@@ -150,7 +153,7 @@ struct SessionSetupView: View {
             .padding(.horizontal, 36)
             .padding(.bottom, 52)
         }
-        .background((session.selectedIntensity?.backgroundTint ?? Color.clear).ignoresSafeArea())
+        } // ZStack
         .navigationBarBackButtonHidden(true)
         .navigationDestination(isPresented: $navigateToSession) {
             SessionPlayView()

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -9,6 +9,7 @@ struct SessionSetupView: View {
     @Environment(SessionManager.self) private var session
     @Environment(SettingsStore.self) private var settings
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     private var availableTopics: [Topic] {
         guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
@@ -150,7 +151,7 @@ struct SessionSetupView: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 18)
                     .foregroundColor(.white)
-                    .background(Color(.darkGray), in: .capsule)
+                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
             }
             .padding(.horizontal, 36)
             .padding(.bottom, 52)
@@ -199,6 +200,7 @@ struct SessionSetupView: View {
 // MARK: - Length Option
 
 private struct LengthOption: View {
+    @Environment(\.colorScheme) private var colorScheme
     let label: String
     let isSelected: Bool
     let action: () -> Void
@@ -212,7 +214,7 @@ private struct LengthOption: View {
                 .padding(.vertical, 14)
                 .background(
                     RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(isSelected ? Color(.darkGray) : Color.primary.opacity(0.04))
+                        .fill(isSelected ? AppColor.primaryButtonBg(colorScheme) : AppColor.surface(colorScheme))
                 )
         }
         .buttonStyle(.plain)
@@ -282,6 +284,7 @@ private enum TopicChipState {
 }
 
 private struct TopicChip: View {
+    @Environment(\.colorScheme) private var colorScheme
     let label: String
     let state: TopicChipState
     let action: () -> Void
@@ -322,9 +325,9 @@ private struct TopicChip: View {
 
     private var backgroundColor: Color {
         switch state {
-        case .selected: return Color(.darkGray)
-        case .available: return Color.primary.opacity(0.04)
-        case .locked: return Color.primary.opacity(0.02)
+        case .selected: return AppColor.primaryButtonBg(colorScheme)
+        case .available: return AppColor.surface(colorScheme)
+        case .locked: return AppColor.surfaceSubtle(colorScheme)
         }
     }
 }

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -24,6 +24,7 @@ struct SessionSetupView: View {
     @State private var didApplyDefaults = false
     @State private var navigateToSession = false
     @State private var navigateToFallInLove = false
+    @State private var navigateToFallInLoveIntro = false
     @State private var showAgeConfirmation = false
     @State private var ageConfirmed = false
 
@@ -84,6 +85,7 @@ struct SessionSetupView: View {
                 TopicSelector(
                     selectedTopic: $selectedTopic,
                     availableTopics: availableTopics,
+                    mode: session.selectedMode,
                     onSelectTopic: { topic in
                         if topic == .sex && !ageConfirmed {
                             showAgeConfirmation = true
@@ -113,7 +115,7 @@ struct SessionSetupView: View {
 
                     Toggle("", isOn: $followUps)
                         .labelsHidden()
-                        .tint(Color(red: 0.45, green: 0.42, blue: 0.38))
+                        .tint(AppColor.toggleTint)
                 }
                 .padding(.horizontal, 28)
                 .padding(.top, 32)
@@ -137,7 +139,14 @@ struct SessionSetupView: View {
 
             Button {
                 if selectedTopic == .fallInLove {
-                    navigateToFallInLove = true
+                    let skip = session.selectedMode == .friends
+                        ? settings.skipFallInLoveIntroFriends
+                        : settings.skipFallInLoveIntroCouples
+                    if skip {
+                        navigateToFallInLove = true
+                    } else {
+                        navigateToFallInLoveIntro = true
+                    }
                 } else {
                     session.selectedSessionLength = selectedLength
                     session.selectedTopic = selectedTopic
@@ -163,6 +172,9 @@ struct SessionSetupView: View {
         }
         .navigationDestination(isPresented: $navigateToFallInLove) {
             FallInLovePlayView()
+        }
+        .navigationDestination(isPresented: $navigateToFallInLoveIntro) {
+            FallInLoveIntroView()
         }
         .alert("Age Confirmation", isPresented: $showAgeConfirmation) {
             Button("I'm 18 or older") {
@@ -227,6 +239,7 @@ private struct LengthOption: View {
 private struct TopicSelector: View {
     @Binding var selectedTopic: Topic?
     let availableTopics: [Topic]
+    var mode: Mode? = nil
     var onSelectTopic: ((Topic) -> Void)? = nil
 
     /// All topics, with free ones that have prompts first, then locked ones.
@@ -254,7 +267,7 @@ private struct TopicSelector: View {
                         : selectedTopic == topic ? .selected
                         : .available
 
-                    TopicChip(label: topic.displayName, state: state) {
+                    TopicChip(label: topic.displayName(for: mode), state: state) {
                         if isAvailable {
                             if let onSelectTopic {
                                 onSelectTopic(topic)

--- a/Connections/Views/SettingsView.swift
+++ b/Connections/Views/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
 
     @State private var showInstructions = false
     @State private var showPurpose = false
+    @State private var showResetConfirmation = false
 
     var body: some View {
         @Bindable var settings = settings
@@ -99,6 +100,26 @@ struct SettingsView: View {
                             }
                         }
                     }
+
+                    // MARK: - Reset
+
+                    SettingsSection(title: "Reset") {
+                        Button {
+                            showResetConfirmation = true
+                        } label: {
+                            HStack {
+                                Text("Reset to Defaults")
+                                    .font(AppFont.label())
+                                    .foregroundStyle(.red)
+
+                                Spacer()
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
                 }
                 .padding(.horizontal, AppSpacing.screenHorizontal)
                 .padding(.top, 16)
@@ -120,6 +141,14 @@ struct SettingsView: View {
         }
         .sheet(isPresented: $showPurpose) {
             PurposeSheet()
+        }
+        .alert("Reset settings?", isPresented: $showResetConfirmation) {
+            Button("Reset", role: .destructive) {
+                settings.resetToDefaults()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("This will restore your preferences to their default values.")
         }
     }
 }

--- a/Connections/Views/SettingsView.swift
+++ b/Connections/Views/SettingsView.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(SettingsStore.self) private var settings
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var showInstructions = false
     @State private var showPurpose = false
@@ -42,7 +43,7 @@ struct SettingsView: View {
                                                 .padding(.vertical, 12)
                                                 .background(
                                                     RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                                        .fill(settings.defaultSessionLength == length ? Color(.darkGray) : Color.primary.opacity(0.04))
+                                                        .fill(settings.defaultSessionLength == length ? AppColor.primaryButtonBg(colorScheme) : AppColor.surface(colorScheme))
                                                 )
                                         }
                                         .buttonStyle(.plain)

--- a/Connections/Views/SettingsView.swift
+++ b/Connections/Views/SettingsView.swift
@@ -1,0 +1,345 @@
+//
+//  SettingsView.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showInstructions = false
+    @State private var showPurpose = false
+
+    var body: some View {
+        @Bindable var settings = settings
+
+        ZStack {
+            NeutralBackground()
+
+            ScrollView {
+                VStack(spacing: 32) {
+
+                    // MARK: - Session
+
+                    SettingsSection(title: "Session") {
+                        VStack(spacing: 0) {
+                            // Default Session Length
+                            VStack(alignment: .leading, spacing: 12) {
+                                Text("Default question count")
+                                    .font(AppFont.label())
+
+                                HStack(spacing: 10) {
+                                    ForEach(SessionLength.allCases) { length in
+                                        Button {
+                                            settings.defaultSessionLength = length
+                                        } label: {
+                                            Text("\(length.rawValue)")
+                                                .font(.system(size: 15, weight: settings.defaultSessionLength == length ? .semibold : .regular))
+                                                .foregroundStyle(settings.defaultSessionLength == length ? .white : .primary)
+                                                .frame(maxWidth: .infinity)
+                                                .padding(.vertical, 12)
+                                                .background(
+                                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                                        .fill(settings.defaultSessionLength == length ? Color(.darkGray) : Color.primary.opacity(0.04))
+                                                )
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                            }
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 14)
+
+                            Divider().padding(.leading, 16)
+
+                            // Follow-up Questions
+                            SettingsToggleRow(
+                                title: "Follow-up questions",
+                                subtitle: "Show \"Go Deeper\" prompts during sessions",
+                                isOn: $settings.followUpsByDefault
+                            )
+                        }
+                    }
+
+                    // MARK: - Experience
+
+                    SettingsSection(title: "Experience") {
+                        VStack(spacing: 0) {
+                            SettingsToggleRow(
+                                title: "Avoid repeats",
+                                subtitle: "Try not to show the same prompt twice in a session",
+                                isOn: $settings.avoidRepeats
+                            )
+
+                            Divider().padding(.leading, 16)
+
+                            SettingsToggleRow(
+                                title: "Haptics",
+                                subtitle: "Vibration feedback on interactions",
+                                isOn: $settings.hapticsEnabled
+                            )
+                        }
+                    }
+
+                    // MARK: - About
+
+                    SettingsSection(title: "About") {
+                        VStack(spacing: 0) {
+                            SettingsNavRow(title: "Instructions") {
+                                showInstructions = true
+                            }
+
+                            Divider().padding(.leading, 16)
+
+                            SettingsNavRow(title: "Purpose") {
+                                showPurpose = true
+                            }
+                        }
+                    }
+                }
+                .padding(.horizontal, AppSpacing.screenHorizontal)
+                .padding(.top, 16)
+                .padding(.bottom, AppSpacing.bottomPadding)
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                BackButton()
+            }
+            ToolbarItem(placement: .principal) {
+                Text("Settings")
+                    .font(AppFont.label())
+            }
+        }
+        .sheet(isPresented: $showInstructions) {
+            InstructionsSheet()
+        }
+        .sheet(isPresented: $showPurpose) {
+            PurposeSheet()
+        }
+    }
+}
+
+// MARK: - Section Container
+
+private struct SettingsSection<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title.uppercased())
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.tertiary)
+                .padding(.leading, 4)
+
+            content
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(.ultraThinMaterial)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .strokeBorder(Color.primary.opacity(0.06), lineWidth: 0.5)
+                )
+        }
+    }
+}
+
+// MARK: - Toggle Row
+
+private struct SettingsToggleRow: View {
+    let title: String
+    let subtitle: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(AppFont.label())
+
+                Text(subtitle)
+                    .font(AppFont.fine())
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+                .tint(AppColor.toggleTint)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+}
+
+// MARK: - Nav Row
+
+private struct SettingsNavRow: View {
+    let title: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                Text(title)
+                    .font(AppFont.label())
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Instructions Sheet
+
+private struct InstructionsSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                NeutralBackground()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text("How to use the app")
+                            .font(AppFont.screenTitle())
+                            .padding(.bottom, 4)
+
+                        VStack(alignment: .leading, spacing: 12) {
+                            InstructionStep(number: "1", text: "Choose a mode")
+                            InstructionStep(number: "2", text: "Choose the tone you want for the conversation")
+                            InstructionStep(number: "3", text: "Pick a session length")
+                            InstructionStep(number: "4", text: "Read the prompt out loud or reflect on it silently")
+                            InstructionStep(number: "5", text: "Use Go Deeper if you want a more specific follow-up")
+                            InstructionStep(number: "6", text: "Tap the heart to save favorite prompts for later")
+                        }
+
+                        Text("Best experience")
+                            .font(AppFont.label())
+                            .padding(.top, 8)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            BulletPoint("Answer honestly")
+                            BulletPoint("Don't rush")
+                            BulletPoint("Let silence happen")
+                            BulletPoint("Skip anything that doesn't fit")
+                            BulletPoint("Revisit favorites when you want a different kind of session")
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
+                    .padding(.top, 16)
+                    .padding(.bottom, AppSpacing.bottomPadding)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .font(AppFont.label())
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Purpose Sheet
+
+private struct PurposeSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                NeutralBackground()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        Text("Connection through guided conversation")
+                            .font(AppFont.screenTitle())
+                            .padding(.bottom, 4)
+
+                        Text("This app is designed to help people move beyond surface-level talk and into more meaningful connection. Whether you're using it with a partner, friend, family member, or for solo reflection, the prompts are meant to create honesty, curiosity, and emotional presence.")
+                            .font(AppFont.subtitle())
+                            .foregroundStyle(.secondary)
+                            .lineSpacing(4)
+                    }
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
+                    .padding(.top, 16)
+                    .padding(.bottom, AppSpacing.bottomPadding)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .font(AppFont.label())
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private struct InstructionStep: View {
+    let number: String
+    let text: String
+
+    init(number: String, text: String) {
+        self.number = number
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Text(number)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 20, alignment: .trailing)
+
+            Text(text)
+                .font(AppFont.subtitle())
+                .foregroundStyle(.primary)
+        }
+    }
+}
+
+private struct BulletPoint: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text("·")
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(.tertiary)
+
+            Text(text)
+                .font(AppFont.subtitle())
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        SettingsView()
+            .environment(SettingsStore())
+    }
+}

--- a/Connections/Views/ShareExperiencePlayView.swift
+++ b/Connections/Views/ShareExperiencePlayView.swift
@@ -10,6 +10,7 @@ struct ShareExperiencePlayView: View {
 
     @State private var selectedIntensity: Intensity?
     @State private var currentExperience: ShareExperience?
+    @State private var experienceHistory: [ShareExperience] = []
     @State private var transitionID = UUID()
 
     private let bank = ShareExperienceBank.shared
@@ -83,17 +84,32 @@ struct ShareExperiencePlayView: View {
 
             Spacer()
 
-            // MARK: - Next Button
+            // MARK: - Back / Next
 
-            Button {
-                nextExperience()
-            } label: {
-                Text("Next")
-                    .font(.system(size: 17, weight: .semibold))
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
-                    .background(Color(.darkGray), in: .capsule)
+            HStack(spacing: 12) {
+                if !experienceHistory.isEmpty {
+                    Button {
+                        goBackExperience()
+                    } label: {
+                        Text("Back")
+                            .font(.system(size: 17, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .background(Color.primary.opacity(0.04), in: .capsule)
+                    }
+                }
+
+                Button {
+                    nextExperience()
+                } label: {
+                    Text("Next")
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .background(Color(.darkGray), in: .capsule)
+                }
             }
             .padding(.horizontal, 36)
             .padding(.bottom, 52)
@@ -112,6 +128,7 @@ struct ShareExperiencePlayView: View {
         let isSelected = selectedIntensity == intensity
         return Button {
             selectedIntensity = intensity
+            experienceHistory = []
             nextExperience()
         } label: {
             Text(label)
@@ -132,8 +149,19 @@ struct ShareExperiencePlayView: View {
     // MARK: - Helpers
 
     private func nextExperience() {
+        if let current = currentExperience {
+            experienceHistory.append(current)
+        }
         withAnimation(.easeInOut(duration: 0.25)) {
             currentExperience = bank.getRandomExperience(intensity: selectedIntensity)
+            transitionID = UUID()
+        }
+    }
+
+    private func goBackExperience() {
+        guard let previous = experienceHistory.popLast() else { return }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            currentExperience = previous
             transitionID = UUID()
         }
     }

--- a/ConnectionsTests/FallInLoveManagerTests.swift
+++ b/ConnectionsTests/FallInLoveManagerTests.swift
@@ -1,74 +1,67 @@
-import XCTest
+import Testing
 @testable import Connections
 
-final class FallInLoveManagerTests: XCTestCase {
+private let progressKey = "layers_fallInLove_progress"
 
-    private let progressKey = "layers_fallInLove_progress"
+@Suite("FallInLoveManager", .serialized)
+struct FallInLoveManagerTests {
 
-    override func setUp() {
-        super.setUp()
+    init() {
         UserDefaults.standard.removeObject(forKey: progressKey)
     }
 
-    override func tearDown() {
-        super.tearDown()
-        UserDefaults.standard.removeObject(forKey: progressKey)
-    }
-
-    func testAdvanceIncrementsIndex() {
+    @Test func advanceIncrementsIndex() {
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(manager.currentIndex == 0)
         manager.advance()
-        XCTAssertEqual(manager.currentIndex, 1)
+        #expect(manager.currentIndex == 1)
     }
 
-    func testAdvanceDoesNotIncrementPastEnd() {
+    @Test func advanceDoesNotIncrementPastEnd() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<total { manager.advance() }
-        // currentIndex stays at totalPrompts - 1 when isComplete flips
-        XCTAssertEqual(manager.currentIndex, total - 1)
+        #expect(manager.currentIndex == total - 1)
     }
 
-    func testIsCompleteFlipsAtLastPrompt() {
+    @Test func isCompleteFlipsAtLastPrompt() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<(total - 1) { manager.advance() }
-        XCTAssertFalse(manager.isComplete)
+        #expect(!manager.isComplete)
         manager.advance()
-        XCTAssertTrue(manager.isComplete)
+        #expect(manager.isComplete)
     }
 
-    func testGoBackDecrementsIndex() {
+    @Test func goBackDecrementsIndex() {
         UserDefaults.standard.set(3, forKey: progressKey)
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 3)
+        #expect(manager.currentIndex == 3)
         manager.goBack()
-        XCTAssertEqual(manager.currentIndex, 2)
+        #expect(manager.currentIndex == 2)
     }
 
-    func testGoBackClampsAtZero() {
+    @Test func goBackClampsAtZero() {
         let manager = FallInLoveManager()
-        XCTAssertEqual(manager.currentIndex, 0)
         manager.goBack()
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(manager.currentIndex == 0)
     }
 
-    func testResetClearsIndexAndCompleteFlag() {
+    @Test func resetClearsIndexAndCompleteFlag() {
         UserDefaults.standard.set(5, forKey: progressKey)
         let manager = FallInLoveManager()
         manager.reset()
-        XCTAssertEqual(manager.currentIndex, 0)
-        XCTAssertFalse(manager.isComplete)
+        #expect(manager.currentIndex == 0)
+        #expect(!manager.isComplete)
     }
 
-    func testResetAfterCompletionAllowsRestart() {
+    @Test func resetAfterCompletionAllowsRestart() {
         let manager = FallInLoveManager()
         let total = manager.totalPrompts
         for _ in 0..<total { manager.advance() }
-        XCTAssertTrue(manager.isComplete)
+        #expect(manager.isComplete)
         manager.reset()
-        XCTAssertFalse(manager.isComplete)
-        XCTAssertEqual(manager.currentIndex, 0)
+        #expect(!manager.isComplete)
+        #expect(manager.currentIndex == 0)
     }
 }


### PR DESCRIPTION
## Summary
- **Onboarding flow**: 4-screen first-run introduction with skip and persistence
- **Fall in Love intro**: Pre-session screen with "Why this works" modal, per-mode skip flags
- **Friends support**: 36-question flow available for Friends mode with "Get Closer" framing
- **Prompt interaction tracking**: Per-prompt time, go deeper, favorite, and revisit signals
- **Standout scoring**: Normalized scoring system identifies prompts the user stayed with
- **End-of-session reflection**: "Moments you stayed with" section on completion screen
- **Settings polish**: Reset to Defaults, blue toggle tint, onboarding reset support
- **Dark mode**: Adaptive colors across all screens
- **Topic coverage**: 27 new prompts filling Daily Life, Communication, Emotions, Conflict gaps
- **Transition polish**: Fade+offset prompt transitions, atmospheric backgrounds

## Test plan
- [ ] Fresh install shows onboarding; completing or skipping persists correctly
- [ ] Fall in Love topic appears for Couples and Friends only
- [ ] Friends mode shows "Get Closer" framing throughout intro and play screens
- [ ] "Don't show again" persists independently per mode
- [ ] Complete a session — verify "Moments you stayed with" appears with relevant prompts
- [ ] Verify standout prompts reflect actual engagement (time spent, go deeper usage)
- [ ] Settings: Reset to Defaults restores all preferences including onboarding
- [ ] Dark mode renders correctly across all screens
- [ ] All topic chips show as available (no unexpected greyed-out topics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)