### PR TITLE
Session Builder, secondary screen polish, and guided flow favorites

### DIFF
--- a/Connections/Components/SummaryRow.swift
+++ b/Connections/Components/SummaryRow.swift
@@ -1,0 +1,73 @@
+//
+//  SummaryRow.swift
+//  Connections
+//
+
+import SwiftUI
+
+/// A compact tappable row representing a collapsed selection in the Session Builder.
+/// Shows the selected value with an option to change it.
+struct SummaryRow: View {
+    let icon: String?
+    let title: String
+    let subtitle: String
+    var tintColor: Color? = nil
+    let onChange: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button(action: onChange) {
+            HStack(spacing: 10) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(tintColor ?? .secondary)
+                }
+
+                Text(title)
+                    .font(.system(size: 15, weight: .medium))
+
+                Text("·")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.tertiary)
+
+                Text(subtitle)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(backgroundFill)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .strokeBorder(strokeColor, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var backgroundFill: Color {
+        if let tint = tintColor {
+            return tint.opacity(0.08)
+        }
+        return AppColor.surface(colorScheme)
+    }
+
+    private var strokeColor: Color {
+        if let tint = tintColor {
+            return tint.opacity(0.15)
+        }
+        return Color.primary.opacity(0.06)
+    }
+}

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -134,19 +134,19 @@ private extension PromptBank {
             ]),
             ("What do you spend a lot of money on without any regrets?", .dailyLife, [
                 "What does spending on that give you beyond the thing itself?",
-                "What would it be hard to replace that feeling with anything else?",
+                "What would be hard to replace if you gave that up?",
             ]),
-            ("What do you to excited about than you probably shouldn't?", .communication, [
+            ("What do you get more excited about than you probably should?", .communication, [
                 "What does it touch in you that makes it feel bigger than it is?",
-                "What are you usually needing in those moments?",
+                "What does that excitement seem to wake up in you?",
             ]),
             ("What would you love to be able to spend more freely on?", .dailyLife, [
                 "How would that change things for you or in your life?",
-                "What feeling are you hoping more of that this spending would provide you?",
+                "What feeling are you hoping this would give you more of?",
             ]),
-            ("Do you like being a host or would your rather be the guest?", .dailyLife, [
+            ("Do you like being the host, or would you rather be the guest?", .dailyLife, [
                 "What part of that role feels most natural to you?",
-                "What does that role let you avoid?",
+                "What does that role make easier for you?",
             ]),
             ("If you were stuck at home for months, what three things would you absolutely need?", .dailyLife, [
                 "What do those choices tell you about what keeps you steady?",
@@ -154,38 +154,38 @@ private extension PromptBank {
             ]),
             ("What's your go-to midnight snack?", .dailyLife, [
                 "What mood are you usually in when that craving hits?",
-                "Are there more positives to this snack adventure than negatives?",
+                "What does that choice say about the kind of comfort you reach for?",
             ]),
             ("Who or what have you been quietly fascinated by lately?", .intimacy, [
-                "What about them or it attracts you?",
-                "Does it help motivate or give you pleasure?",
+                "What is it about them or it that attracts you?",
+                "Does it energize you, comfort you, or just pull you in?",
             ]),
             ("What's the most disastrous date you've ever been on?", .dailyLife, [
                 "What made it go wrong so fast?",
-                "What did that experience teach you about yourself and or dating?",
+                "What did that experience teach you about yourself or dating?",
             ]),
             ("What's your favorite real love story — yours or someone else's?", .intimacy, [
                 "What part of that story moves you the most?",
-                "Are there aspects of this love story that exist in your life?",
+                "Do you see any pieces of that kind of love in us?",
             ]),
             ("What do you need most from me when you're not feeling well?", .communication, [
                 "What helps you feel cared for instead of just looked after?",
-                "What's easy for me to miss in those moments that would make you happy?",
+                "What's easy for me to miss in those moments that would help you feel better?",
             ]),
-            ("What do you feel is high-maintenance about you?", .dailyLife, [
+            ("What's something about you that takes a little extra care?", .dailyLife, [
                 "What makes that one thing worth the extra effort for you?",
                 "Do you think it's about comfort, control, or feeling cared for?",
             ]),
-            ("What are you a often complete control freak about?", .identity, [
+            ("Where do you like to have a lot of control?", .identity, [
                 "What feels at risk when you're not in control?",
-                "Why do you think you control over this for?",
+                "Why do you think you need so much control there?",
             ]),
             ("What's the one thing you absolutely do not like being teased about?", .communication, [
-                "Why does that cause you discomfort?",
-                "What part of your past does it touch in you that's still tender?",
+                "What about that one lands badly for you?",
+                "Does it touch something older or more tender in you?",
             ]),
             ("What or who is it basically impossible for you to say no to?", .communication, [
-                "Is this a wonderful guilty pleasure?",
+                "Is that a guilty pleasure, a soft spot, or something else?",
                 "Do you feel pressure to always say yes?",
             ]),
             ("What's something about your partner that you fell in love with all over again recently?", .appreciation, [
@@ -198,7 +198,7 @@ private extension PromptBank {
             ]),
             ("You feel most attractive when I do or say…", .sex, [
                 "When was the last time I did or said that?",
-                "Can you help me remember and recognize when I do it correctly?",
+                "Can you help me notice when I'm getting it right?",
             ]),
             ("What's a song that always makes you think of us?", .appreciation, [
                 "What memory or feeling does it bring back first?",
@@ -209,8 +209,8 @@ private extension PromptBank {
                 "What did it show you about how that person knew you?",
             ]),
             ("What's your idea of a perfect lazy vacation day together?", .dailyLife, [
-                "What can I do to make those days feels most nourishing to you?",
-                "What does that version of Sunday give you that everyday life doesn't?",
+                "What can I do to make those days feel most nourishing to you?",
+                "Do we do enough of these days? Should we do more?",
             ]),
             ("What's something small I do that always makes you smile?", .appreciation, [
                 "Why do you think that tiny thing means so much to you?",
@@ -221,19 +221,19 @@ private extension PromptBank {
                 "What are you hoping we'd feel there together?",
             ]),
             ("What's a hobby or skill you've always wanted us to try together?", .growth, [
-                "How do you imagine doing that together will bring us closer together?",
+                "How do you imagine that bringing us closer?",
                 "Why do you think doing it together matters more than doing it alone?",
             ]),
             ("What's the most fun we've ever had doing something totally unplanned?", .past, [
-                "Do you want to do more spontaneous activities?",
-                "Would you like me to surprise you with more spontaneous activities, and what kind?",
+                "What do you think made that spontaneity work so well for us?",
+                "Do you wish we made more room for that side of us?",
             ]),
             ("What's a movie or show that reminds you of our relationship?", .dailyLife, [
-                "What's your favorite part of the movie and why?",
-                "What can I do to help bring more of that favorite part into our relationship?",
+                "What part of it feels most like us?",
+                "What does that say about how you experience our relationship?",
             ]),
             ("What's your love language when you're stressed versus when you're happy?", .communication, [
-                "Help me understand how to speak it or what to do to help you during these times?",
+                "What does that look like in real life when you're stressed versus happy?",
                 "What do you most want from me when you're in each state?",
             ]),
             ("What's a tradition you'd love for us to start?", .values, [
@@ -241,7 +241,7 @@ private extension PromptBank {
                 "Is there anything in your life that makes that kind of ritual important to you?",
             ]),
             ("What's a small thing that can instantly shift your mood for the better?", .emotions, [
-                "Does your partner know about that one?",
+                "Do I know that about you already?",
                 "What's the opposite — the tiny thing that can ruin a good mood?",
             ]),
             ("What's the silliest thing we've ever actually disagreed about?", .conflict, [
@@ -256,7 +256,7 @@ private extension PromptBank {
     static func couples_light_realTalk() -> [Prompt] {
         make([
             ("What's the most unexpected compliment you've ever received?", .appreciation, [
-                "Why do you think that one suprised you so much?",
+                "Why do you think that one surprised you so much?",
                 "What did it make you feel about yourself in that moment?",
             ]),
             ("When was the last time you were completely lost in a great experience?", .dailyLife, [
@@ -267,37 +267,37 @@ private extension PromptBank {
                 "Why do you think that story is so endearing to us?",
                 "What does the reason we laugh about it say about us?",
             ]),
-            ("Something I do that turns me off is…", .sex, [
-                "Why do you think it turns you off?",
-                "Is that something you'd want to talk through or just have me know?",
+            ("Something that tends to shut me down a little is…", .sex, [
+                "What about that takes you out of the moment?",
+                "Would you want to talk it through together, or just have it understood?",
             ]),
             ("Something that tends to turn me on is…", .sex, [
                 "When did you first notice that about yourself?",
-                "What is it about that thing that gets to you?",
+                "What is it about that that really lands for you?",
             ]),
             ("One of the most sensual experiences I've had that didn't involve sex was…", .sex, [
                 "What made that moment feel so charged?",
-                "What does sensuality mean to you outside the bedroom?",
+                "What does that tell you about what sensuality means to you?",
             ]),
             ("I still remember a time I felt deeply desired when…", .sex, [
                 "What about that moment made you feel so wanted?",
-                "How does feeling desired change the way you show up?",
+                "What opens up in you when you feel that desired?",
             ]),
             ("An intimate memory that still makes me cringe a little is…", .sex, [
                 "What makes it cringeworthy — and do you laugh about it now?",
-                "Did it change anything about how you approach intimacy?",
+                "Did it change anything about what helps you feel at ease?",
             ]),
             ("One of the most memorable intimate moments I've had was…", .sex, [
                 "What made that one stand out above the rest?",
-                "What do you think made the connection feel so strong?",
+                "What do you think made it feel so connected?",
             ]),
-            ("Something I do that helps make intimacy more engaging is…", .sex, [
+            ("Something I do that helps intimacy feel more alive is…", .sex, [
                 "How did you figure that out about yourself?",
                 "What does it feel like when that effort lands?",
             ]),
             ("An embarrassing intimate moment I've experienced was…", .sex, [
                 "How did you recover from it in the moment?",
-                "Did it end up bringing you closer or making things awkward?",
+                "Did it leave you feeling closer, awkward, or a little of both?",
             ]),
             ("What makes me feel most desired by you is…", .sex, [
                 "What is it about that gesture that gets through to you?",
@@ -305,7 +305,7 @@ private extension PromptBank {
             ]),
             ("A moment I felt truly connected to you physically was…", .sex, [
                 "What made the emotional and physical feel so aligned?",
-                "What do you think creates that kind of connection between us?",
+                "What do you think helps create that kind of connection between us?",
             ]),
         ], mode: .couples, intensity: .light, depth: .realTalk)
     }
@@ -315,7 +315,7 @@ private extension PromptBank {
     static func couples_light_deepDive() -> [Prompt] {
         make([
             ("What moment made you think — okay, this person really gets me?", .intimacy, [
-                "What did I do different from others that made you feel like that?",
+                "What did I do differently that helped you feel understood?",
                 "How did that moment change the way you saw me?",
             ]),
             ("What's something about us you'd never want to change?", .appreciation, [
@@ -345,7 +345,7 @@ private extension PromptBank {
                 "How long have you been carrying that?",
                 "What would it take for that weight to lift even a little?",
             ]),
-            ("When was the last time you got way more upset than the situation deserved?", .conflict, [
+            ("When did something hit you harder than it seemed like it should?", .conflict, [
                 "What do you think was really underneath that reaction?",
                 "Did you realize it in the moment or only after?",
             ]),
@@ -359,15 +359,15 @@ private extension PromptBank {
             ]),
             ("What's something you wish I understood better about you?", .communication, [
                 "What's the part of it that's hardest to explain?",
-                "How would things feel different for you if I could understood this better?",
+                "How would things feel different for you if I understood this better?",
             ]),
             ("What's a fear you haven't told me about?", .emotions, [
                 "What's kept you from saying it out loud?",
-                "What would it mean for you if I knew?",
+                "What would it be like for you if I knew that about you?",
             ]),
             ("When do you feel most disconnected from me?", .intimacy, [
                 "What's happening in you during those moments?",
-                "What would help you feel like we're back on the same page?",
+                "What helps you start to feel your way back toward me?",
             ]),
             ("What's something I do that makes you feel truly seen?", .appreciation, [
                 "What is it about that gesture that reaches you?",
@@ -379,11 +379,11 @@ private extension PromptBank {
             ]),
             ("What's a habit of mine that quietly frustrates you?", .conflict, [
                 "What does it bring up in you when it happens?",
-                "Have you ever tried to say something about it? If not why not?",
+                "What makes it hard to bring up with me directly?",
             ]),
             ("What's something you've been meaning to apologize for?", .conflict, [
                 "What's been holding the apology back?",
-                "What do you think it would change if you said it?",
+                "What do you imagine might shift if you said it out loud?",
             ]),
             ("When do you feel the safest with me?", .intimacy, [
                 "What is it about those moments that lets your guard down?",
@@ -401,7 +401,7 @@ private extension PromptBank {
                 "What about it kept echoing after it ended?",
                 "Did it change anything about how you see us?",
             ]),
-            ("What do you think we're both avoiding right now?", .communication, [
+            ("What's something between us that feels a little avoided right now?", .communication, [
                 "What makes that topic feel so untouchable?",
                 "What do you think would happen if we actually went there?",
             ]),
@@ -442,12 +442,12 @@ private extension PromptBank {
                 "What would help you feel more settled about it?",
             ]),
             ("What's something I said recently that meant more than I probably realized?", .appreciation, [
-                "What nerve did it touch in a good way?",
+                "What did it touch in you that stayed with you?",
                 "Do you wish I said things like that more often?",
             ]),
             ("What do you need from me that you find hard to ask for?", .communication, [
                 "What makes that request feel so difficult to voice?",
-                "What would it mean to you if I just knew to offer it?",
+                "What would it mean to you if I knew to offer it without being asked?",
             ]),
             ("What's a small moment between us that you keep replaying?", .intimacy, [
                 "What is it about that moment that holds so much weight?",
@@ -482,7 +482,7 @@ private extension PromptBank {
             ]),
             ("When was the last time you held back tears and pretended you were fine?", .emotions, [
                 "What were you protecting yourself from by holding it in?",
-                "What would have happened if you had let yourself cry?",
+                "What do you imagine might have happened if you had let yourself cry?",
             ]),
             ("Who would you most want to show the person you've become?", .appreciation, [
                 "What would you want them to see in you now?",
@@ -514,7 +514,7 @@ private extension PromptBank {
             ]),
             ("When was the last time jealousy really got under your skin?", .emotions, [
                 "What was the deeper fear underneath it?",
-                "How did you handle it — and was that the right call?",
+                "How did you handle it, and how do you feel about that now?",
             ]),
             ("What do you admire most about the way your partner handles hard things?", .appreciation, [
                 "Is there a specific moment that showed you that strength?",
@@ -526,17 +526,17 @@ private extension PromptBank {
             ]),
             ("I tend to lose interest during intimacy when…", .sex, [
                 "What do you think is happening emotionally in those moments?",
-                "What would help you stay present instead?",
+                "What helps you stay present and connected instead?",
             ]),
             ("A message I sometimes imagine sending you is…", .sex, [
                 "What stops you from actually sending it?",
-                "What response are you hoping for in your imagination?",
+                "What kind of response are you hoping for when you imagine it?",
             ]),
             ("A message I secretly wish I'd receive from you is…", .sex, [
                 "What would reading that message do to you?",
                 "What need would it speak to?",
             ]),
-            ("In terms of energy or dynamic, I tend to lean more toward…", .sex, [
+            ("In intimacy, I tend to lean more toward…", .sex, [
                 "Has that always been the case, or did it develop over time?",
                 "What does leaning into that side give you?",
             ]),
@@ -581,11 +581,11 @@ private extension PromptBank {
             ]),
             ("During intimacy, everything else fades away when…", .sex, [
                 "What do you think creates that level of presence?",
-                "How often do you reach that state?",
+                "What helps you get there more easily?",
             ]),
             ("A sexual question or uncertainty I still think about is…", .sex, [
                 "What makes that question hard to settle?",
-                "Who would you trust enough to explore it with?",
+                "What would help it feel safer to talk about or explore?",
             ]),
             ("A belief about sex I've had to rethink over time is…", .sex, [
                 "What experience pushed you to rethink it?",
@@ -601,7 +601,7 @@ private extension PromptBank {
             ]),
             ("An early experience that shaped how I think about sex was…", .sex, [
                 "How did that experience color the way you approach intimacy now?",
-                "Is there a part of it you're still working through?",
+                "Does any part of it still stay with you now?",
             ]),
             ("The difference between emotional intimacy and physical intimacy feels like…", .sex, [
                 "Which one do you reach for first when you need to feel close?",
@@ -609,7 +609,7 @@ private extension PromptBank {
             ]),
             ("Sex feels most meaningful to me when…", .sex, [
                 "What makes the difference between meaningful and just physical?",
-                "How often do you feel that deeper meaning?",
+                "What helps create that deeper meaning for you?",
             ]),
             ("Growing up, the message I got about sex was…", .sex, [
                 "How has that message stayed with you or been rewritten?",
@@ -617,7 +617,7 @@ private extension PromptBank {
             ]),
             ("What makes me feel most safe during intimacy is…", .sex, [
                 "What does safety in that context actually feel like in your body?",
-                "What's the quickest way that safety can be broken?",
+                "What tends to help that sense of safety stay intact?",
             ]),
             ("What helps me fully relax and be present with you is…", .sex, [
                 "What usually gets in the way of that presence?",
@@ -635,8 +635,8 @@ private extension PromptBank {
                 "How does hiding it affect the way you show up?",
             ]),
             ("What's something about us that you've never quite figured out?", .communication, [
-                "Does not understanding it bother you or have you made peace with it?",
-                "What opens up if you finally understand it?",
+                "Does that still bother you, or have you made some peace with it?",
+                "What do you think would shift if it made more sense to you?",
             ]),
             ("How honest do you think we really are with each other?", .communication, [
                 "Where do you think the gaps are?",
@@ -664,11 +664,15 @@ private extension PromptBank {
             ]),
             ("What's something about me that you've had to learn to accept?", .growth, [
                 "Was the accepting gradual or did something shift it?",
-                "What did that acceptance cost you?",
+                "What was hard about getting there?",
             ]),
             ("What's a version of yourself you only show to me?", .identity, [
                 "What is it about us that makes that version feel safe?",
                 "Do you like that version of yourself?",
+            ]),
+            ("Do you feel appreciated by me in the ways that matter most to you?", .appreciation, [
+                "Where do you feel it clearly, and where does it still feel thin?",
+                "What kind of appreciation lands hardest for you: words, help, attention, or something else?",
             ]),
             ("What scares you most about our future together?", .emotions, [
                 "Is that fear rooted in us or in something older?",
@@ -702,21 +706,21 @@ private extension PromptBank {
                 "What was it about that moment that stripped your guard away?",
                 "Did that vulnerability bring us closer or leave you exposed?",
             ]),
-            ("What do you think our biggest blind spot as a couple is?", .growth, [
-                "What would someone on the outside probably see that we can't?",
-                "What becomes possible if we finally face it?",
+            ("What do you think is our biggest blind spot as a couple?", .growth, [
+                "What do you think is hardest for us to see clearly from the inside?",
+                "What might change if we could see it more honestly?",
             ]),
             ("What's a truth about yourself that you're afraid would change how I see you?", .emotions, [
                 "What's the worst version of how you imagine I'd react?",
                 "What would it mean if I heard it and nothing changed?",
             ]),
-            ("When have you sacrificed too much of yourself for this relationship?", .values, [
+            ("Have you ever felt like you sacrificed too much of yourself for this relationship?", .values, [
                 "Did you realize it was too much at the time or only after?",
-                "What part of yourself did you lose in the process?",
+                "What do you wish had happened differently from your point of view?",
             ]),
             ("What's a fight we had that actually changed something for the better?", .conflict, [
-                "What broke through in that fight that couldn't have come out any other way?",
-                "How did it change the way you see conflict between us?",
+                "What broke through in that fight that might not have surfaced otherwise?",
+                "Did it change anything about the way you see conflict between us?",
             ]),
             ("What's something about my past that still sits with you?", .past, [
                 "What about it keeps pulling at you?",
@@ -742,17 +746,21 @@ private extension PromptBank {
                 "How does that avoidance show up in the way we treat each other?",
                 "What would happen if we stopped avoiding it?",
             ]),
-            ("What's a way you've changed since being with me that worries you?", .identity, [
+            ("Is there any way you've changed since being with me that worries you?", .identity, [
                 "Is it a change you chose or one that happened to you?",
                 "What would the old version of you think?",
             ]),
             ("What's something about us that you'd be embarrassed for others to know?", .intimacy, [
-                "What does the embarrassment protect?",
-                "Would telling someone actually change anything?",
+                "What do you think the embarrassment is protecting?",
+                "What feels most exposed about it?",
             ]),
             ("What's a household habit of mine that quietly drives you crazy?", .dailyLife, [
                 "Have you ever tried to bring it up, or do you just absorb it?",
                 "What would it mean if I actually changed it?",
+            ]),
+            ("Do I show enough appreciation for what you quietly carry at home?", .appreciation, [
+                "Which things feel most invisible to you right now?",
+                "What kind of acknowledgment would actually reach you?",
             ]),
         ], mode: .couples, intensity: .unfiltered, depth: .warmUp)
     }
@@ -763,15 +771,15 @@ private extension PromptBank {
         make([
             ("What's something you've been pretending is fine when it really isn't?", .emotions, [
                 "How long have you been holding that performance together?",
-                "What would happen if you stopped pretending?",
+                "What do you think might happen if you stopped pretending?",
             ]),
             ("When did you hurt someone without meaning to, and what happened after?", .conflict, [
                 "Did you realize it right away or did it take time?",
                 "What did that teach you about the gap between intention and impact?",
             ]),
-            ("What makes you the hardest to live with — if you're being honest?", .conflict, [
-                "How do you think that quality affects the people closest to you?",
-                "Have you tried to change it or accepted it as part of who you are?",
+            ("What's something about you that can be hard to live with — if you're being honest?", .conflict, [
+                "How do you think that part of you affects the people closest to you?",
+                "Is that something you're trying to change, or something you're still learning about yourself?",
             ]),
             ("When did you last feel genuinely lost, and what was happening?", .emotions, [
                 "What did you reach for to try to find your footing?",
@@ -783,7 +791,11 @@ private extension PromptBank {
             ]),
             ("How do you tend to withdraw your love or attention when you're upset?", .conflict, [
                 "Are you always aware you're doing it?",
-                "What would it take for you to stay present instead of pulling back?",
+                "What would help you stay present instead of pulling back?",
+            ]),
+            ("Do I thank you enough for what you do to keep our life running?", .appreciation, [
+                "What do you do that feels most taken for granted?",
+                "When do you feel most like your effort disappears into the background?",
             ]),
             ("When was a time you admitted you were wrong — and how did that feel?", .conflict, [
                 "What made that admission so hard?",
@@ -795,11 +807,15 @@ private extension PromptBank {
             ]),
             ("The word \u{201C}forbidden\u{201D} makes me think of…", .sex, [
                 "What is it about that edge that pulls you in?",
-                "How do you feel about having that thought?",
+                "What feeling comes with having that thought?",
             ]),
             ("What's an invisible expectation you carry at home that I've never acknowledged?", .dailyLife, [
                 "How long have you been holding that without saying anything?",
                 "What would it look like if I actually saw it?",
+            ]),
+            ("Do I say I love you often enough for it to still feel real to you?", .appreciation, [
+                "When does hearing it land most deeply for you?",
+                "What makes it feel meaningful instead of automatic?",
             ]),
         ], mode: .couples, intensity: .unfiltered, depth: .realTalk)
     }
@@ -824,33 +840,37 @@ private extension PromptBank {
                 "How did that lesson change what you need from a partner?",
                 "Are you still learning it, or have you made peace with it?",
             ]),
+            ("Do I show appreciation for you in front of other people in a way you can actually feel?", .appreciation, [
+                "When do you feel publicly cherished by me, and when do you not?",
+                "What would make that appreciation feel more visible and more true?",
+            ]),
             ("What's the heartbreak that hit you the hardest?", .emotions, [
                 "What part of you did it break open?",
                 "How did it reshape the way you protect your heart?",
             ]),
             ("When was the last time you felt truly lonely, even if you weren't alone?", .emotions, [
                 "What was missing in that moment?",
-                "What would it take to not feel that way again?",
+                "What do you think would have helped you feel less alone?",
             ]),
-            ("What would be something you could never forgive in a relationship?", .conflict, [
+            ("What's something you don't think you could forgive in a relationship?", .conflict, [
                 "What does that boundary protect in you?",
                 "Has anything ever come close to testing it?",
             ]),
-            ("If my partner had an affair, I think I would…", .sex, [
+            ("If I found out my partner had an affair, I think I would…", .sex, [
                 "What does your gut reaction tell you about what you value most?",
                 "Do you think your actual response would match what you imagine?",
             ]),
             ("One of the most awkward or uncomfortable moments I've had after intimacy was…", .sex, [
                 "What made that moment land so uncomfortably?",
-                "Did it change anything about how you handle vulnerability after sex?",
+                "Did it change anything about how you handle closeness afterward?",
             ]),
             ("A fantasy I have mixed feelings about is…", .sex, [
                 "What's the tension between the part that wants it and the part that resists?",
-                "What do you think the fantasy is really about underneath?",
+                "What do you think that fantasy is reaching for underneath?",
             ]),
             ("Something I haven't been fully honest about in my sexual past is…", .sex, [
                 "What's kept you from sharing it until now?",
-                "What would it feel like to finally have someone know?",
+                "What do you imagine it would feel like to have someone know?",
             ]),
             ("A recurring fantasy I've had is…", .sex, [
                 "What do you think that fantasy is really reaching for?",
@@ -859,6 +879,10 @@ private extension PromptBank {
             ("What part of our daily life together feels like it's slowly wearing you down?", .dailyLife, [
                 "When did you first notice the weight of it?",
                 "What would need to change for it to feel sustainable again?",
+            ]),
+            ("What could I do more consistently to make you feel deeply appreciated, not just loved?", .appreciation, [
+                "What kind of appreciation do you hunger for that I may still miss?",
+                "What would change in you if you felt that more often from me?",
             ]),
         ], mode: .couples, intensity: .unfiltered, depth: .deepDive)
     }
@@ -985,7 +1009,7 @@ private extension PromptBank {
             ]),
             ("What's something you only do when nobody's watching?", .identity, [
                 "Why do you keep it private?",
-                "What would happen if someone caught you?",
+                "What do you think someone would misunderstand about it?",
             ]),
             ("What's a feeling you've had recently that caught you off guard?", .emotions, [
                 "What do you think triggered it?",
@@ -1009,6 +1033,10 @@ private extension PromptBank {
             ("Who do you owe a long-overdue thank you?", .appreciation, [
                 "What's been stopping you from saying it?",
                 "What would you want them to know?",
+            ]),
+            ("What's something friendship taught you about being chosen that nothing else really could have?", .growth, [
+                "Who or what taught you that lesson?",
+                "How does that lesson shape the way you show up with people now?",
             ]),
         ], mode: .friends, intensity: .light, depth: .realTalk)
     }
@@ -1054,7 +1082,7 @@ private extension PromptBank {
             ]),
             ("What was the last lie you told, and why did you tell it?", .communication, [
                 "What were you trying to protect by lying?",
-                "Do you think the person believed you?",
+                "What felt too risky to tell more directly?",
             ]),
             ("What are you the most judgmental about, even if you'd never admit it?", .values, [
                 "Where do you think that judgment comes from?",
@@ -1088,7 +1116,7 @@ private extension PromptBank {
                 "What does that thing give you that keeps you coming back?",
                 "What would have to change for you to stop?",
             ]),
-            ("What do you find hardest about maintaining friendships as you get older?", .communication, [
+            ("What do you find hardest about staying woven into your friends' lives as you get older?", .communication, [
                 "What do you think has changed the most?",
                 "What would your ideal friendship look like at this stage?",
             ]),
@@ -1118,7 +1146,7 @@ private extension PromptBank {
             ]),
             ("What's something you've been overthinking lately?", .emotions, [
                 "What's the thought that keeps looping back?",
-                "What would it take to finally let it settle?",
+                "What do you think would help it settle a little?",
             ]),
             ("What's an opinion you hold that you know your friends would push back on?", .values, [
                 "What makes you hold onto it anyway?",
@@ -1150,7 +1178,7 @@ private extension PromptBank {
             ]),
             ("What's something you pretend to be okay with but actually aren't?", .emotions, [
                 "How long have you been carrying that pretense?",
-                "What would happen if you dropped it?",
+                "What do you think might happen if you dropped it?",
             ]),
             ("What's a risk you wish you had the courage to take right now?", .growth, [
                 "What's the worst thing that could actually happen?",
@@ -1195,9 +1223,9 @@ private extension PromptBank {
                 "What gave you the push to take it?",
                 "Would you take it again knowing how it turned out?",
             ]),
-            ("What's something only your closest friends know about you?", .intimacy, [
-                "Why do you keep that one in a smaller circle?",
-                "How would things feel different if more people knew?",
+            ("What's something only the people who've known you a long time really see about you?", .intimacy, [
+                "Why do you think that part of you only comes out in that kind of history?",
+                "What does it change to be known that way by only a few people?",
             ]),
             ("What's a message you sent that you immediately wished you could take back?", .communication, [
                 "What were you feeling when you hit send?",
@@ -1235,7 +1263,7 @@ private extension PromptBank {
                 "What kept pulling you back into the same mistake?",
                 "What finally made it stick?",
             ]),
-            ("When was the last time you felt like a friend wasn't really there when it mattered?", .dailyLife, [
+            ("Think of a recent moment when a friend wasn't really there when it mattered — what happened?", .dailyLife, [
                 "Did you say anything or just let it go?",
                 "How did it change what you expect from that friendship?",
             ]),
@@ -1254,13 +1282,13 @@ private extension PromptBank {
                 "What's been stopping you from offering it?",
                 "What do you think it would change — for them and for you?",
             ]),
-            ("Who's a friend you haven't shown up for the way you should have?", .conflict, [
+            ("Who's a friend you haven't shown up for the way you wish you had?", .conflict, [
                 "What got in the way?",
                 "If you could go back to that moment, what would you do differently?",
             ]),
             ("How do you decide which friendships are worth the effort when life gets overwhelming?", .dailyLife, [
                 "Have you ever let a friendship slip away that you now regret?",
-                "What does it take for someone to stay in your inner circle?",
+                "What helps you know which friendships you want to keep tending?",
             ]),
         ], mode: .friends, intensity: .honest, depth: .deepDive)
     }
@@ -1339,7 +1367,7 @@ private extension PromptBank {
             ]),
             ("What's something you've never been able to forgive yourself for?", .emotions, [
                 "What would forgiving yourself actually require?",
-                "Do you think you deserve that forgiveness?",
+                "What's made that forgiveness so hard to give yourself?",
             ]),
             ("What do you wish people would stop pretending to care about?", .values, [
                 "What does the performance bother you about specifically?",
@@ -1350,8 +1378,8 @@ private extension PromptBank {
                 "What did you do with that realization?",
             ]),
             ("What's something dark you've thought about that you'd never say out loud?", .emotions, [
-                "What do you think that thought says about you?",
-                "Does having it scare you or do you accept it as part of being human?",
+                "What do you think that thought is really pointing to?",
+                "Does having it scare you, or does it feel more human than you expected?",
             ]),
             ("What's the most honest thing you've ever said to someone's face?", .communication, [
                 "How did they take it?",
@@ -1359,11 +1387,11 @@ private extension PromptBank {
             ]),
             ("What's an experience that hardened you in a way others don't see?", .past, [
                 "What part of you did it close off?",
-                "Do you see the hardening as protection or damage?",
+                "Does that hardening feel more like protection, loss, or both?",
             ]),
             ("When did you last feel truly ashamed of yourself?", .emotions, [
                 "What triggered the shame?",
-                "Have you been able to work through it?",
+                "What has helped you move through any of it, if at all?",
             ]),
             ("What's a secret you've kept from your closest friends?", .intimacy, [
                 "What would change in those friendships if they knew?",
@@ -1400,27 +1428,27 @@ private extension PromptBank {
 
     static func friends_unfiltered_realTalk() -> [Prompt] {
         make([
-            ("When's a time you should have admitted you were wrong but couldn't bring yourself to?", .conflict, [
+            ("When's a time you knew you were wrong but couldn't bring yourself to admit it?", .conflict, [
                 "What was at stake that made the admission feel impossible?",
                 "Do you think the other person knew you were wrong?",
             ]),
-            ("What's something you've never told anyone how you really feel about?", .emotions, [
+            ("What's something you've never really told anyone how you feel about?", .emotions, [
                 "What has keeping it inside done to you?",
                 "What would finally saying it change?",
             ]),
             ("What's something you really hope certain people never find out about?", .intimacy, [
                 "What are you most afraid they'd think?",
-                "Would the truth actually be as bad as you imagine?",
+                "What do you imagine would change if they knew?",
             ]),
             ("Who was the last person who really pushed you past your breaking point?", .conflict, [
                 "What did your breaking point look like?",
-                "How did you come back from it?",
+                "What helped you come back from it?",
             ]),
-            ("What's a grudge you've been carrying longer than you probably should?", .conflict, [
+            ("What's a grudge you've been carrying longer than you want to?", .conflict, [
                 "What would it take to finally set it down?",
-                "What is holding onto it giving you?",
+                "What does holding onto it give you?",
             ]),
-            ("What's a relationship you damaged that you sometimes still think about?", .conflict, [
+            ("What's a friendship you damaged that you sometimes still think about?", .conflict, [
                 "What do you think you would have done differently?",
                 "Do you think repair is still possible?",
             ]),
@@ -1428,9 +1456,9 @@ private extension PromptBank {
                 "When has your loyalty been tested the hardest?",
                 "Where do you draw the line between loyalty and self-respect?",
             ]),
-            ("How honest are you about how much emotional labor you actually put into your friendships?", .dailyLife, [
-                "Who gets the most from you, and do they even know it?",
-                "What would happen if you stopped carrying that weight?",
+            ("How honest are you about how much emotional effort your friendships take from you?", .dailyLife, [
+                "Who tends to get the most from you, and do they know it?",
+                "What do you imagine would happen if you stopped carrying quite so much of it?",
             ]),
         ], mode: .friends, intensity: .unfiltered, depth: .realTalk)
     }
@@ -1445,11 +1473,11 @@ private extension PromptBank {
             ]),
             ("What's a story you've told before but never the complete, honest version?", .intimacy, [
                 "What's the part you always leave out?",
-                "What would the full version reveal about you?",
+                "What do you think the full version would reveal about you?",
             ]),
             ("When did someone break your trust in a way that changed how you operate?", .conflict, [
-                "What defense did you build because of it?",
-                "Has anyone since earned back the kind of trust you lost?",
+                "What kind of protection did you build because of it?",
+                "Has anyone since earned the kind of trust you lost?",
             ]),
             ("What's a way you've quietly stopped making effort in a friendship without ever saying why?", .dailyLife, [
                 "Was it a conscious decision or did it just happen?",
@@ -1479,8 +1507,8 @@ private extension PromptBank {
                 "How does it make you feel when it hits you unexpectedly?",
             ]),
             ("What's something you genuinely can't believe you got away with growing up?", .past, [
-                "Would you be proud or horrified if your kids did the same?",
-                "Who else knows about it?",
+                "How do you feel about that version of yourself now?",
+                "Who still knows that story besides you?",
             ]),
             ("What completely breaks your willpower every single time?", .dailyLife, [
                 "What is it about that thing that makes you cave?",
@@ -1520,9 +1548,9 @@ private extension PromptBank {
             ]),
             ("What's the most meaningful gift anyone has ever given you?", .appreciation, [
                 "What made it so special?",
-                "Do you still have it?",
+                "What does it still hold for you now?",
             ]),
-            ("What makes you the proudest about your family?", .appreciation, [
+            ("What makes you feel proudest about your family?", .appreciation, [
                 "Is that something your family knows you feel?",
                 "What do you think built that quality?",
             ]),
@@ -1538,7 +1566,7 @@ private extension PromptBank {
                 "Who was at the center of it?",
                 "Does it still come up at every gathering?",
             ]),
-            ("What's something a family member taught you that you still use today?", .appreciation, [
+            ("What's something you still do because of the way a family member taught you?", .appreciation, [
                 "Were they teaching you on purpose or was it just by example?",
                 "Have you ever thanked them for it?",
             ]),
@@ -1570,7 +1598,7 @@ private extension PromptBank {
                 "Did they know you were learning from them?",
                 "How has that skill shaped your life?",
             ]),
-            ("What's the best piece of advice a family member ever gave you?", .values, [
+            ("What's a piece of advice from a family member that still stays with you?", .values, [
                 "When did you first realize they were right?",
                 "Has it held up over time?",
             ]),
@@ -1578,7 +1606,7 @@ private extension PromptBank {
                 "What would it feel like if that tradition stopped?",
                 "What does it represent to you beyond the tradition itself?",
             ]),
-            ("Who in your family always knows how to make you feel better?", .appreciation, [
+            ("Who in your family has always known how to make you feel a little better?", .appreciation, [
                 "What do they do that works so well?",
                 "Do they know they have that power?",
             ]),
@@ -1615,7 +1643,11 @@ private extension PromptBank {
             ]),
             ("What's something your family does that you didn't appreciate until you were older?", .appreciation, [
                 "What made you finally see it differently?",
-                "Have you told them you appreciate it now?",
+                "Have you ever let them know you see it that way now?",
+            ]),
+            ("What's something about your family that felt ordinary growing up but now feels special to you?", .appreciation, [
+                "When did you start seeing it differently?",
+                "What does it mean to you now?",
             ]),
         ], mode: .family, intensity: .light, depth: .realTalk)
     }
@@ -1661,7 +1693,7 @@ private extension PromptBank {
             ]),
             ("What's a family expectation you've struggled to live up to?", .values, [
                 "Do you want to meet that expectation, or let it go?",
-                "What pressure does it put on you?",
+                "What kind of pressure does it put on you?",
             ]),
             ("What's something you wish you had said to a family member sooner?", .communication, [
                 "What stopped you from saying it when it mattered?",
@@ -1687,8 +1719,8 @@ private extension PromptBank {
                 "What about it still gets to you?",
                 "Who else in your family shares that memory?",
             ]),
-            ("What do you wish your parents had done differently?", .past, [
-                "How do you think it would have changed you?",
+            ("What's something you wish your parents had done differently?", .past, [
+                "How do you think it might have changed you?",
                 "Have you been able to talk to them about it?",
             ]),
             ("What's a sacrifice a family member made for you that you think about often?", .appreciation, [
@@ -1712,14 +1744,14 @@ private extension PromptBank {
                 "What would it take to finally clear the air?",
             ]),
             ("What do you think your family worries about most when it comes to you?", .emotions, [
-                "Is their worry justified?",
+                "Does any part of that worry feel true to you?",
                 "How do you feel knowing they carry that concern?",
             ]),
             ("What's a moment where your family really came together?", .appreciation, [
                 "What brought everyone together?",
                 "What did you learn about your family in that moment?",
             ]),
-            ("What's something about your family dynamic that outsiders wouldn't understand?", .communication, [
+            ("What's something about the role everyone plays in your family that outsiders wouldn't understand?", .communication, [
                 "Does it work for you, or do you wish it were different?",
                 "What would you want someone outside to know?",
             ]),
@@ -1747,8 +1779,8 @@ private extension PromptBank {
                 "Is that emotion something you carry with you still?",
                 "How does it color the way you think about home now?",
             ]),
-            ("What's something you've forgiven a family member for that was really hard?", .conflict, [
-                "What did forgiving them cost you?",
+            ("What's something you've forgiven a family member for that took a lot out of you?", .conflict, [
+                "What did that forgiveness ask of you?",
                 "Did the forgiveness change the relationship?",
             ]),
             ("What do you think your family's greatest strength is?", .appreciation, [
@@ -1759,7 +1791,7 @@ private extension PromptBank {
                 "What did it help you understand about who they are?",
                 "Did it make you feel closer to them or more complicated about them?",
             ]),
-            ("What's something your family doesn't talk about but probably should?", .communication, [
+            ("What's something your family doesn't really talk about but probably should?", .communication, [
                 "What keeps the silence going?",
                 "Who do you think would need to go first?",
             ]),
@@ -1778,7 +1810,7 @@ private extension PromptBank {
 
     static func family_honest_realTalk() -> [Prompt] {
         make([
-            ("What's a conversation you know you need to have with your parents?", .communication, [
+            ("What's a conversation with your parents that's been waiting for its moment?", .communication, [
                 "What's been holding it back?",
                 "How do you imagine it going?",
             ]),
@@ -1786,7 +1818,7 @@ private extension PromptBank {
                 "Did you have any say in it at the time?",
                 "How do you feel about it now — grateful, resentful, or somewhere in between?",
             ]),
-            ("Who really holds the power in your family, and how does that affect everyone?", .communication, [
+            ("Who tends to hold the most power in your family, and how does that shape everyone else?", .communication, [
                 "Is that power dynamic acknowledged or unspoken?",
                 "How has it shaped your own relationship with authority?",
             ]),
@@ -1806,11 +1838,11 @@ private extension PromptBank {
                 "What do you feel looking at that version of yourself?",
                 "What would you want that kid to know?",
             ]),
-            ("What's something you did that you refuse to apologize for?", .values, [
+            ("What's something you did that you still don't think you should apologize for?", .values, [
                 "What principle are you standing on?",
                 "Does anyone in your life still hold it against you?",
             ]),
-            ("Who in your family carries the most invisible labor, and does anyone acknowledge it?", .dailyLife, [
+            ("Who in your family carries a lot of invisible labor, and does it get acknowledged?", .dailyLife, [
                 "How did that role get assigned?",
                 "What would change if they stopped doing it for a week?",
             ]),
@@ -1838,7 +1870,7 @@ private extension PromptBank {
                 "Did they know they were teaching you?",
             ]),
             ("If you could change one thing about the way you were raised, what would it be?", .past, [
-                "How do you think that one change would have rippled through your life?",
+                "How do you think that one change might have rippled through your life?",
                 "Have you been able to talk to your parents about it?",
             ]),
             ("What would you go back and whisper to your younger self?", .past, [
@@ -1858,7 +1890,7 @@ private extension PromptBank {
         make([
             ("What role do you play in your family, and how did that happen?", .identity, [
                 "Is it a role you want, or one that was assigned to you?",
-                "What would that free you to be?",
+                "Who might you be if you didn't have to carry that role?",
             ]),
             ("What conversation are you dreading that you know needs to happen?", .conflict, [
                 "What's the worst outcome you're imagining?",
@@ -1874,7 +1906,7 @@ private extension PromptBank {
             ]),
             ("What's the biggest lie your family tells itself?", .communication, [
                 "Who benefits from keeping that lie alive?",
-                "What would the truth demand from everyone?",
+                "What do you think the truth would ask of everyone?",
             ]),
             ("What's something about your childhood you've never fully processed?", .emotions, [
                 "What happens when it surfaces?",
@@ -1896,8 +1928,8 @@ private extension PromptBank {
                 "Do you feel responsible for that weight?",
                 "Who else in the family carries it with you?",
             ]),
-            ("What's something a family member did that you've never been able to fully forgive?", .conflict, [
-                "What would forgiveness require from you?",
+            ("What's something a family member did that you've never really been able to forgive?", .conflict, [
+                "What do you think forgiveness would require from you?",
                 "What keeps the wound open?",
             ]),
             ("What do you wish your parents really knew about your life right now?", .communication, [
@@ -1908,13 +1940,13 @@ private extension PromptBank {
                 "Does it still happen?",
                 "How has that feeling shaped the way you see yourself?",
             ]),
-            ("What's a toxic pattern in your family that you're trying not to repeat?", .growth, [
+            ("What's a harmful pattern in your family that you're trying not to repeat?", .growth, [
                 "When do you catch yourself falling into it?",
-                "What's your alternative look like?",
+                "What are you trying to practice instead?",
             ]),
             ("What's the hardest thing about loving someone in your family?", .emotions, [
                 "What makes the love complicated?",
-                "Is the difficulty worth it?",
+                "How do you make sense of that difficulty now?",
             ]),
             ("What's a part of your identity that your family still doesn't fully accept?", .identity, [
                 "How does their lack of acceptance affect you day to day?",
@@ -1928,7 +1960,7 @@ private extension PromptBank {
                 "What did it cost you to hold that line?",
                 "Has it been respected since?",
             ]),
-            ("What's something you've never confronted a family member about but probably should?", .communication, [
+            ("What's something you've never confronted a family member about but may need to?", .communication, [
                 "What's held you back?",
                 "What would you say if you finally did?",
             ]),
@@ -1991,7 +2023,7 @@ private extension PromptBank {
                 "What makes those topics feel off-limits?",
                 "What do you think would happen if you went there anyway?",
             ]),
-            ("What's a topic that's completely off-limits in your family?", .communication, [
+            ("What's a topic that feels completely off-limits in your family?", .communication, [
                 "Who enforces that boundary?",
                 "What do you think the silence is protecting?",
             ]),
@@ -2005,7 +2037,7 @@ private extension PromptBank {
             ]),
             ("What household role were you assigned growing up that you never actually agreed to?", .dailyLife, [
                 "How did it shape the way you show up in your family now?",
-                "Have you ever tried to hand it back?",
+                "Have you ever tried to set it down or hand it back?",
             ]),
         ], mode: .family, intensity: .unfiltered, depth: .realTalk)
     }
@@ -2017,10 +2049,6 @@ private extension PromptBank {
             ("What's something that was taken from you — not necessarily a physical thing?", .past, [
                 "How did losing that shape who you became?",
                 "Do you think you'll ever get it back in some form?",
-            ]),
-            ("Whose loss are you the most afraid of?", .emotions, [
-                "What would that loss take from your world?",
-                "Does the fear of it change how you love them now?",
             ]),
             ("Who are you most afraid of losing in your life?", .emotions, [
                 "What makes that person irreplaceable to you?",
@@ -2042,8 +2070,8 @@ private extension PromptBank {
                 "What would you say differently?",
                 "What do you wish you had heard?",
             ]),
-            ("What's a practical tension in your family that everyone just works around instead of fixing?", .dailyLife, [
-                "What would it take to actually address it head-on?",
+            ("What's a practical tension in your family that everyone works around instead of really addressing?", .dailyLife, [
+                "What would it take to actually address it?",
                 "Who benefits most from leaving it unresolved?",
             ]),
         ], mode: .family, intensity: .unfiltered, depth: .deepDive)
@@ -2173,7 +2201,7 @@ private extension PromptBank {
                 "How did you find that thing?",
                 "What does it give you that goal-driven things don't?",
             ]),
-            ("What's something you've been meaning to say to someone but keep putting off?", .communication, [
+            ("Who have you been carrying unsaid words for lately?", .communication, [
                 "What's making it hard to bring up?",
                 "How do you think you'd feel once you finally said it?",
             ]),
@@ -2242,7 +2270,7 @@ private extension PromptBank {
 
     static func solo_honest_warmUp() -> [Prompt] {
         make([
-            ("When you look in the mirror, what's the first thing that comes to mind?", .emotions, [
+            ("When you catch your reflection, what's the first thought that tends to show up?", .emotions, [
                 "Is that thought kind or critical?",
                 "Has the voice in your head always said that?",
             ]),
@@ -2258,7 +2286,7 @@ private extension PromptBank {
                 "What's underneath that hesitation?",
                 "What are you protecting by holding back?",
             ]),
-            ("What's a part of your life that doesn't match who you thought you'd be by now?", .identity, [
+            ("Where does your life feel most out of sync with who you thought you'd be by now?", .identity, [
                 "Does that gap feel motivating or discouraging?",
                 "What would closing it require?",
             ]),
@@ -2278,9 +2306,9 @@ private extension PromptBank {
                 "How long have you been repeating that story?",
                 "What would change if you let it go?",
             ]),
-            ("What's a relationship in your life that needs more attention?", .intimacy, [
+            ("What's a relationship in your life that's asking for more attention?", .intimacy, [
                 "What's been getting in the way?",
-                "What would showing up more look like?",
+                "What would showing up for it a little more actually look like?",
             ]),
             ("What's something you're carrying that you haven't shared with anyone?", .emotions, [
                 "What would it take for you to share it?",
@@ -2294,9 +2322,9 @@ private extension PromptBank {
                 "What's the version of events where you made the right call?",
                 "What would put the second-guessing to rest?",
             ]),
-            ("What's something you need to hear right now but nobody's saying?", .emotions, [
+            ("What's something you need to hear right now that nobody's saying?", .emotions, [
                 "Why do you think no one has said it?",
-                "Can you say it to yourself and have it count?",
+                "What would it be like to offer that to yourself anyway?",
             ]),
             ("What's an area of your life where you've been coasting?", .growth, [
                 "What would it look like if you started trying again?",
@@ -2306,7 +2334,7 @@ private extension PromptBank {
                 "How many decisions has it shaped without you realizing?",
                 "What would you choose if that fear weren't there?",
             ]),
-            ("What would change in your life if you stopped people-pleasing?", .growth, [
+            ("What would change in your life if you stopped trying to please everyone?", .growth, [
                 "Who would you disappoint first?",
                 "What would you gain by being honest instead?",
             ]),
@@ -2358,9 +2386,9 @@ private extension PromptBank {
                 "What's the change you're most afraid of?",
                 "What would life look like on the other side of it?",
             ]),
-            ("What would you change about yourself if you had a magic wand to make it happen?", .values, [
-                "Name three reasons why you would make that change?",
-                "How would your life change if you made the change?",
+            ("What would you change about yourself if you could change it instantly?", .values, [
+                "Why does that change matter so much to you?",
+                "How do you imagine your life would feel different if it happened?",
             ]),
         ], mode: .soloReflection, intensity: .honest, depth: .warmUp)
     }
@@ -2369,7 +2397,7 @@ private extension PromptBank {
 
     static func solo_honest_realTalk() -> [Prompt] {
         make([
-            ("What's a blind spot you're slowly starting to see in yourself?", .growth, [
+            ("What's something you're slowly becoming unable to unsee about yourself?", .growth, [
                 "What helped you start to notice it?",
                 "How has recognizing it changed anything in your life?",
             ]),
@@ -2381,7 +2409,7 @@ private extension PromptBank {
                 "Are you comfortable with power, or does it make you uneasy?",
                 "How do you handle the responsibility that comes with it?",
             ]),
-            ("What's one thing about yourself you know you need to change?", .growth, [
+            ("What's one thing about yourself you know you want to change?", .growth, [
                 "What has that thing cost you already?",
                 "What would be different once you made the change?",
             ]),
@@ -2393,9 +2421,9 @@ private extension PromptBank {
                 "What gave you the courage to do it?",
                 "How did it change what you expect from yourself?",
             ]),
-            ("What's something you've been holding onto way longer than you need to?", .past, [
+            ("What have you been carrying longer than it still deserves space in you?", .past, [
                 "What would happen if you finally let it go?",
-                "What does holding on give you?",
+                "What has holding onto it been doing for you?",
             ]),
             ("When was the last time you bent the rules in a way that still sits with you?", .conflict, [
                 "Do you feel guilty about it or justified?",
@@ -2417,7 +2445,7 @@ private extension PromptBank {
                 "What experience made that idea feel less real?",
                 "How has that changed the way you see fairness or people?",
             ]),
-            ("What's something you once believed would always work out, but now aren't so sure about?", .emotions, [
+            ("What's something you once believed would always work out, but now you're not so sure about?", .emotions, [
                 "What caused that belief to shift?",
                 "How do you feel holding that uncertainty now?",
             ]),
@@ -2428,9 +2456,9 @@ private extension PromptBank {
 
     static func solo_honest_deepDive() -> [Prompt] {
         make([
-            ("What would you give anything to have a second chance at?", .past, [
+            ("What do you still wish you had a second chance at?", .past, [
                 "What would you do differently this time?",
-                "What has not getting that chance taught you about your choices in life?",
+                "What has not getting that chance taught you about the choices you make now?",
             ]),
             ("What do you know you need to let go of but can't seem to release?", .growth, [
                 "What would your life look like without it?",
@@ -2438,7 +2466,7 @@ private extension PromptBank {
             ]),
             ("What's the gap between who you are and who you want to be — and what lives in that gap?", .growth, [
                 "What fills that space right now — fear, habit, or something else?",
-                "What's the first step changing this and and moving a step towards who you want to be?",
+                "What's the first step toward closing that gap?",
             ]),
         ], mode: .soloReflection, intensity: .honest, depth: .deepDive)
     }
@@ -2459,7 +2487,7 @@ private extension PromptBank {
                 "What are you afraid would happen if you let it out?",
                 "How is holding it in affecting you?",
             ]),
-            ("What's the ugliest thought you've had about yourself recently?", .emotions, [
+            ("What's the harshest thought you've had about yourself recently?", .emotions, [
                 "Where do you think that thought came from?",
                 "Do you believe it, or can you see it as just a thought that passed through?",
             ]),
@@ -2481,7 +2509,7 @@ private extension PromptBank {
             ]),
             ("What's a coping mechanism you rely on that isn't actually healthy?", .growth, [
                 "What does it numb or avoid?",
-                "What is a healthier replacement and what would it do for you?",
+                "What might a healthier replacement give you instead?",
             ]),
             ("What would people think if they could see your internal monologue?", .emotions, [
                 "Would they be surprised, concerned, or relieved?",
@@ -2499,7 +2527,7 @@ private extension PromptBank {
                 "When does it tend to come back?",
                 "Is it a version you miss or one you're trying to outgrow?",
             ]),
-            ("What's the hardest thing about being you that nobody sees?", .emotions, [
+            ("What's one of the hardest parts of being you that nobody really sees?", .emotions, [
                 "What would it mean for someone to finally see it?",
                 "How do you carry that alone?",
             ]),
@@ -2540,8 +2568,8 @@ private extension PromptBank {
                 "What do you think it's trying to resolve?",
             ]),
             ("What's the thing you're most afraid of other people finding out about you?", .identity, [
-                "Does it really matter if others know?",
-                "What's the worst thing that could happen and how would you prepare for it?",
+                "What feels most at risk if other people knew?",
+                "What do you imagine would actually happen if it came to light?",
             ]),
             ("What's something you've numbed yourself to that you know you need to eventually face?", .emotions, [
                 "How are you avoiding it?",
@@ -2549,7 +2577,7 @@ private extension PromptBank {
             ]),
             ("What's a part of your story you've rewritten to make it easier to tell?", .past, [
                 "What did you leave out and why?",
-                "What would the unedited version reveal about you or expect others to accept?",
+                "What would the unedited version reveal about you?",
             ]),
             ("When was the last time you felt completely happy with yourself?", .emotions, [
                 "Why did it make you feel that way?",
@@ -2557,15 +2585,15 @@ private extension PromptBank {
             ]),
             ("What's a sacrifice you made that nobody ever thanked you for?", .appreciation, [
                 "Did it help the relationship or damage it?",
-                "Would you do it again knowing no one would noticed?",
+                "Would you do it again knowing no one would notice?",
             ]),
-            ("Do you think that confession of wrongs is necessary for you to move forward?", .values, [
-                "Who does the confession actually help and why?",
-                "Is there a social prupose to the confession of worngs."
+            ("Do you think saying out loud what you've done wrong is necessary for you to move forward?", .values, [
+                "Who do you think that would help most?",
+                "What do you hope saying it out loud would make possible for you?",
             ]),
-            ("Do you have a wound in your heart that never fully heals?", .emotions, [
-                "Is this something you can change or do you need help from others? Who?",
-                "What would healing actually require and what would be the benefits?",
+            ("Is there a hurt in you that never seems to fully heal?", .emotions, [
+                "Is this something you can tend on your own, or do you need help from someone else?",
+                "What do you think healing would actually require?",
             ]),
             ("What's a habit you keep returning to that you know isn't good for you?", .dailyLife, [
                 "What does it give you in the moment that's hard to get elsewhere?",
@@ -2598,19 +2626,19 @@ private extension PromptBank {
                 "How did you move through the doubt?",
                 "Did it reveal something real or was it just noise?",
             ]),
-            ("What have you been faking lately that you wish you could just stop?", .growth, [
+            ("What have you been faking lately that you're tired of keeping up?", .growth, [
                 "Who are you performing for?",
                 "What would dropping the act actually cost you?",
             ]),
             ("What's a lie you told once that you still think about?", .conflict, [
                 "Why does it still have a hold on you?",
-                "What would making it right look like now?",
+                "If you wanted to make it right now, what might that look like?",
             ]),
-            ("When did you first realize that you will one day die?", .emotions, [
+            ("When did you first really realize you would die one day?", .emotions, [
                 "How old were you, and what made that realization land?",
                 "Does that awareness change how you think about your life now?",
             ]),
-            ("How much of your daily life is built around avoiding things you don't want to feel?", .dailyLife, [
+            ("How much of your daily life is shaped around avoiding what you don't want to feel?", .dailyLife, [
                 "What feelings are you most skilled at dodging?",
                 "What would a day without that avoidance actually look like?",
             ]),
@@ -2623,7 +2651,7 @@ private extension PromptBank {
         make([
             ("What's something you've been putting off being honest with yourself about?", .identity, [
                 "What would the honest version sound like if you said it out loud?",
-                "What are you afraid will shift once you admit it?",
+                "What feels most likely to shift once you admit it?",
             ]),
             ("Is there a relationship in your life that you know has run its course?", .conflict, [
                 "What's keeping you from walking away?",
@@ -2635,7 +2663,7 @@ private extension PromptBank {
             ]),
             ("What's something you still carry guilt about?", .emotions, [
                 "What would it take to finally put it down?",
-                "Do you think you've earned forgiveness, even if you haven't given it to yourself?",
+                "What makes it so hard to offer yourself any forgiveness?",
             ]),
             ("What's a belief you hold deeply but have never actually said out loud?", .values, [
                 "What makes it feel too risky to share?",

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -59,6 +59,12 @@ final class SessionManager {
     /// Number of prompts the user has *continued* (not skipped) at the current depth.
     private var continuedAtCurrentDepth: Int = 0
 
+    /// Lightweight topic history to reduce clumping and create a smoother session rhythm.
+    private var recentTopics: [Topic] = []
+
+    /// Session-wide topic counts so we can gently reward variety over repetition.
+    private var shownTopicCounts: [Topic: Int] = [:]
+
     // MARK: - Interaction Tracking
 
     /// Per-prompt interaction data for the current session, keyed by prompt ID.
@@ -126,6 +132,8 @@ final class SessionManager {
         responses = []
         shownPromptIDs = []
         promptHistory = []
+        recentTopics = []
+        shownTopicCounts = [:]
         connectionTracker.reset()
         showFeelingCheckIn = false
         goDeeperCount = 0
@@ -221,9 +229,18 @@ final class SessionManager {
         guard let prompt = currentPrompt else { return }
         let shown = Set(shownFollowUps.map(\.id))
         let remaining = prompt.followUps.filter { !shown.contains($0.id) }
-        // Prefer a follow-up whose style hasn't been used yet
-        let preferred = remaining.filter { !usedFollowUpStyles.contains($0.style) }
-        guard let selected = (preferred.first ?? remaining.first) else { return }
+        let preferredStyles = preferredFollowUpStyles(for: prompt, revealIndex: shownFollowUps.count)
+
+        let selected = preferredStyles
+            .lazy
+            .compactMap { style in
+                remaining.first { $0.style == style && !self.usedFollowUpStyles.contains($0.style) }
+            }
+            .first
+            ?? remaining.first { !self.usedFollowUpStyles.contains($0.style) }
+            ?? remaining.first
+
+        guard let selected else { return }
         usedFollowUpStyles.insert(selected.style)
         shownFollowUps.append(selected)
     }
@@ -304,6 +321,8 @@ final class SessionManager {
         responses = []
         shownPromptIDs = []
         promptHistory = []
+        recentTopics = []
+        shownTopicCounts = [:]
         continuedAtCurrentDepth = 0
         continuedSinceLastCheckIn = 0
         goDeeperCount = 0
@@ -451,9 +470,223 @@ final class SessionManager {
             candidates = available
         }
 
-        guard let chosen = candidates.randomElement() else { return nil }
+        guard let chosen = choosePrompt(from: candidates) else { return nil }
         if avoidRepeats { shownPromptIDs.insert(chosen.id) }
+        recentTopics.append(chosen.topic)
+        if recentTopics.count > 3 {
+            recentTopics.removeFirst(recentTopics.count - 3)
+        }
+        shownTopicCounts[chosen.topic, default: 0] += 1
         return chosen
+    }
+
+    /// Chooses a prompt with light pacing rules so sessions feel shaped instead of random.
+    private func choosePrompt(from candidates: [Prompt]) -> Prompt? {
+        guard !candidates.isEmpty else { return nil }
+
+        let scored = candidates.map { prompt in
+            (prompt: prompt, score: promptScore(prompt))
+        }
+
+        guard let bestScore = scored.map(\.score).max() else { return nil }
+
+        // Keep a little variety by choosing among the strongest few candidates.
+        let topBand = scored
+            .filter { $0.score >= bestScore - 1 }
+            .map(\.prompt)
+
+        return topBand.randomElement()
+    }
+
+    /// Scores a prompt using depth pacing, topic variety, and gentle end-of-session deepening.
+    private func promptScore(_ prompt: Prompt) -> Int {
+        var score = 0
+
+        // Strongly prefer the currently active depth once it has unlocked.
+        if prompt.depthLevel == currentDepth {
+            score += 6
+        } else if prompt.depthLevel == maxDepthReached {
+            score += 4
+        } else if prompt.depthLevel < currentDepth {
+            score += 1
+        }
+
+        // Once we reach the back half of a session, prefer the deeper unlocked layer.
+        if totalPrompts > 0, promptsRemaining <= max(2, totalPrompts / 4), prompt.depthLevel == maxDepthReached {
+            score += 2
+        }
+
+        score += topicAffinityScore(for: prompt)
+
+        // Reduce immediate topic repetition unless the user explicitly selected a topic.
+        if selectedTopic == nil {
+            if prompt.topic == recentTopics.last {
+                score -= 4
+            }
+            let recentMatches = recentTopics.filter { $0 == prompt.topic }.count
+            score -= recentMatches * 2
+
+            let timesShown = shownTopicCounts[prompt.topic, default: 0]
+            if timesShown == 0 {
+                score += 1
+            } else if timesShown >= 2 {
+                score -= (timesShown - 1)
+            }
+        }
+
+        return score
+    }
+
+    /// Adds light topic sequencing so tones feel more intentionally shaped.
+    private func topicAffinityScore(for prompt: Prompt) -> Int {
+        guard let mode = selectedMode, let intensity = selectedIntensity else { return 0 }
+
+        let preferredTopics = preferredTopics(for: mode, intensity: intensity, depth: prompt.depthLevel)
+        guard let index = preferredTopics.firstIndex(of: prompt.topic) else { return -2 }
+
+        // Earlier-listed topics are a stronger fit for that mode/intensity/depth slice.
+        return max(0, 5 - index)
+    }
+
+    /// Follow-up pacing by tone/depth so "Go deeper" feels guided instead of random.
+    private func preferredFollowUpStyles(for prompt: Prompt, revealIndex: Int) -> [FollowUpStyle] {
+        let stagedOrder: [FollowUpStyle]
+
+        switch (prompt.intensity, prompt.depthLevel, revealIndex) {
+        case (.light, .warmUp, _):
+            stagedOrder = [.origin, .meaning, .impact, .need, .tension]
+
+        case (.light, .realTalk, 0):
+            stagedOrder = [.meaning, .origin, .impact, .need, .tension]
+        case (.light, .realTalk, _):
+            stagedOrder = [.impact, .meaning, .need, .origin, .tension]
+
+        case (.light, .deepDive, 0):
+            stagedOrder = [.meaning, .impact, .origin, .need, .tension]
+        case (.light, .deepDive, _):
+            stagedOrder = [.need, .impact, .meaning, .origin, .tension]
+
+        case (.honest, .warmUp, 0):
+            stagedOrder = [.meaning, .origin, .impact, .need, .tension]
+        case (.honest, .warmUp, _):
+            stagedOrder = [.need, .impact, .meaning, .origin, .tension]
+
+        case (.honest, .realTalk, 0):
+            stagedOrder = [.meaning, .impact, .need, .origin, .tension]
+        case (.honest, .realTalk, _):
+            stagedOrder = [.need, .impact, .meaning, .tension, .origin]
+
+        case (.honest, .deepDive, 0):
+            stagedOrder = [.meaning, .need, .impact, .origin, .tension]
+        case (.honest, .deepDive, _):
+            stagedOrder = [.need, .tension, .impact, .meaning, .origin]
+
+        case (.unfiltered, .warmUp, 0):
+            stagedOrder = [.meaning, .impact, .origin, .need, .tension]
+        case (.unfiltered, .warmUp, _):
+            stagedOrder = [.need, .impact, .meaning, .tension, .origin]
+
+        case (.unfiltered, .realTalk, 0):
+            stagedOrder = [.meaning, .need, .impact, .origin, .tension]
+        case (.unfiltered, .realTalk, _):
+            stagedOrder = [.need, .tension, .impact, .meaning, .origin]
+
+        case (.unfiltered, .deepDive, 0):
+            stagedOrder = [.need, .meaning, .tension, .impact, .origin]
+        case (.unfiltered, .deepDive, _):
+            stagedOrder = [.tension, .need, .meaning, .impact, .origin]
+        }
+
+        return stagedOrder
+    }
+
+    /// Topic ordering by mode/intensity/depth. This keeps sessions feeling guided without making them deterministic.
+    private func preferredTopics(for mode: Mode, intensity: Intensity, depth: DepthLevel) -> [Topic] {
+        switch (mode, intensity, depth) {
+        case (.couples, .light, .warmUp):
+            return [.appreciation, .dailyLife, .communication, .identity, .past, .values]
+        case (.couples, .light, .realTalk):
+            return [.communication, .emotions, .growth, .intimacy, .past, .values]
+        case (.couples, .light, .deepDive):
+            return [.intimacy, .emotions, .past, .growth, .values, .communication]
+
+        case (.couples, .honest, .warmUp):
+            return [.communication, .emotions, .growth, .appreciation, .values, .past]
+        case (.couples, .honest, .realTalk):
+            return [.emotions, .communication, .conflict, .intimacy, .growth, .past]
+        case (.couples, .honest, .deepDive):
+            return [.intimacy, .conflict, .emotions, .past, .values, .growth]
+
+        case (.couples, .unfiltered, .warmUp):
+            return [.identity, .emotions, .conflict, .communication, .sex, .past]
+        case (.couples, .unfiltered, .realTalk):
+            return [.sex, .conflict, .intimacy, .emotions, .identity, .communication]
+        case (.couples, .unfiltered, .deepDive):
+            return [.sex, .intimacy, .emotions, .conflict, .past, .identity]
+
+        case (.friends, .light, .warmUp):
+            return [.appreciation, .dailyLife, .past, .identity, .growth, .values]
+        case (.friends, .light, .realTalk):
+            return [.growth, .appreciation, .past, .communication, .identity, .values]
+        case (.friends, .light, .deepDive):
+            return [.intimacy, .values, .appreciation, .past, .growth, .communication]
+
+        case (.friends, .honest, .warmUp):
+            return [.communication, .emotions, .growth, .identity, .conflict, .past]
+        case (.friends, .honest, .realTalk):
+            return [.identity, .growth, .emotions, .communication, .conflict, .past]
+        case (.friends, .honest, .deepDive):
+            return [.conflict, .past, .intimacy, .growth, .values, .emotions]
+
+        case (.friends, .unfiltered, .warmUp):
+            return [.identity, .emotions, .conflict, .values, .past, .communication]
+        case (.friends, .unfiltered, .realTalk):
+            return [.conflict, .emotions, .identity, .values, .dailyLife, .past]
+        case (.friends, .unfiltered, .deepDive):
+            return [.past, .conflict, .identity, .emotions, .values, .dailyLife]
+
+        case (.family, .light, .warmUp):
+            return [.past, .appreciation, .dailyLife, .values, .communication, .growth]
+        case (.family, .light, .realTalk):
+            return [.appreciation, .past, .values, .growth, .communication, .intimacy]
+        case (.family, .light, .deepDive):
+            return [.values, .intimacy, .appreciation, .past, .growth, .communication]
+
+        case (.family, .honest, .warmUp):
+            return [.communication, .emotions, .identity, .growth, .past, .appreciation]
+        case (.family, .honest, .realTalk):
+            return [.past, .communication, .values, .emotions, .dailyLife, .identity]
+        case (.family, .honest, .deepDive):
+            return [.past, .intimacy, .growth, .dailyLife, .values, .emotions]
+
+        case (.family, .unfiltered, .warmUp):
+            return [.communication, .emotions, .identity, .conflict, .past, .growth]
+        case (.family, .unfiltered, .realTalk):
+            return [.communication, .dailyLife, .past, .identity, .emotions, .conflict]
+        case (.family, .unfiltered, .deepDive):
+            return [.past, .emotions, .communication, .identity, .dailyLife, .conflict]
+
+        case (.soloReflection, .light, .warmUp):
+            return [.dailyLife, .appreciation, .growth, .emotions, .identity, .past]
+        case (.soloReflection, .light, .realTalk):
+            return [.values, .growth, .emotions, .past, .identity, .appreciation]
+        case (.soloReflection, .light, .deepDive):
+            return [.values, .growth, .appreciation, .identity, .past, .emotions]
+
+        case (.soloReflection, .honest, .warmUp):
+            return [.emotions, .growth, .identity, .communication, .values, .dailyLife]
+        case (.soloReflection, .honest, .realTalk):
+            return [.growth, .identity, .emotions, .values, .past, .conflict]
+        case (.soloReflection, .honest, .deepDive):
+            return [.growth, .past, .values, .identity, .emotions]
+
+        case (.soloReflection, .unfiltered, .warmUp):
+            return [.emotions, .identity, .growth, .past, .values, .communication]
+        case (.soloReflection, .unfiltered, .realTalk):
+            return [.identity, .growth, .emotions, .past, .dailyLife, .conflict]
+        case (.soloReflection, .unfiltered, .deepDive):
+            return [.identity, .emotions, .past, .values, .conflict, .growth]
+        }
     }
 
     /// Reads the avoid-repeats preference from UserDefaults.

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -313,6 +313,22 @@ final class SessionManager {
         favorites.remove(id: id)
     }
 
+    func toggleExperienceFavorite(_ experience: ShareExperience) {
+        favorites.toggleExperience(experience)
+    }
+
+    func isExperienceFavorited(_ experience: ShareExperience) -> Bool {
+        favorites.containsExperience(id: experience.id)
+    }
+
+    func toggleFallInLoveFavorite(_ prompt: FallInLovePrompt) {
+        favorites.toggleFallInLovePrompt(prompt, mode: selectedMode ?? .couples)
+    }
+
+    func isFallInLoveFavorited(_ prompt: FallInLovePrompt) -> Bool {
+        favorites.containsFallInLovePrompt(order: prompt.order)
+    }
+
     func endSession() {
         finalizeCurrentPromptTiming()
         isSessionActive = false
@@ -717,8 +733,12 @@ struct FavoritesStore: Codable {
         let depth: DepthLevel
         let followUps: [FollowUp]
         let date: Date
+        /// Nil for session prompts; "shareExperience" for Share Experience entries.
+        let source: String?
+        /// Original ShareExperience.id for lookup. Nil for session prompts.
+        let sourceID: String?
 
-        init(promptID: UUID, promptText: String, mode: Mode, intensity: Intensity = .honest, depth: DepthLevel = .warmUp, followUps: [FollowUp] = [], date: Date = .now) {
+        init(promptID: UUID, promptText: String, mode: Mode, intensity: Intensity = .honest, depth: DepthLevel = .warmUp, followUps: [FollowUp] = [], date: Date = .now, source: String? = nil, sourceID: String? = nil) {
             self.id = promptID
             self.promptText = promptText
             self.mode = mode
@@ -726,6 +746,8 @@ struct FavoritesStore: Codable {
             self.depth = depth
             self.followUps = followUps
             self.date = date
+            self.source = source
+            self.sourceID = sourceID
         }
 
         init(from decoder: Decoder) throws {
@@ -737,6 +759,8 @@ struct FavoritesStore: Codable {
             depth = try container.decodeIfPresent(DepthLevel.self, forKey: .depth) ?? .warmUp
             followUps = try container.decode([FollowUp].self, forKey: .followUps)
             date = try container.decode(Date.self, forKey: .date)
+            source = try container.decodeIfPresent(String.self, forKey: .source)
+            sourceID = try container.decodeIfPresent(String.self, forKey: .sourceID)
         }
     }
 
@@ -768,6 +792,76 @@ struct FavoritesStore: Codable {
             remove(id: prompt.id)
         } else {
             add(prompt)
+        }
+    }
+
+    // MARK: - ShareExperience Support
+
+    mutating func addExperience(_ experience: ShareExperience) {
+        guard !containsExperience(id: experience.id) else { return }
+        let entry = FavoriteEntry(
+            promptID: UUID(),
+            promptText: experience.text,
+            mode: .soloReflection,
+            intensity: experience.intensity,
+            followUps: [],
+            source: "shareExperience",
+            sourceID: experience.id
+        )
+        entries.append(entry)
+        save()
+    }
+
+    mutating func removeExperience(id: String) {
+        entries.removeAll { $0.sourceID == id }
+        save()
+    }
+
+    func containsExperience(id: String) -> Bool {
+        entries.contains { $0.sourceID == id }
+    }
+
+    mutating func toggleExperience(_ experience: ShareExperience) {
+        if containsExperience(id: experience.id) {
+            removeExperience(id: experience.id)
+        } else {
+            addExperience(experience)
+        }
+    }
+
+    // MARK: - FallInLove Support
+
+    mutating func addFallInLovePrompt(_ prompt: FallInLovePrompt, mode: Mode) {
+        let sourceID = "fil_\(prompt.order)"
+        guard !entries.contains(where: { $0.sourceID == sourceID }) else { return }
+        let entry = FavoriteEntry(
+            promptID: UUID(),
+            promptText: prompt.text,
+            mode: mode,
+            intensity: prompt.intensity,
+            depth: prompt.depth,
+            followUps: [],
+            source: "fallInLove",
+            sourceID: sourceID
+        )
+        entries.append(entry)
+        save()
+    }
+
+    mutating func removeFallInLovePrompt(order: Int) {
+        entries.removeAll { $0.sourceID == "fil_\(order)" }
+        save()
+    }
+
+    func containsFallInLovePrompt(order: Int) -> Bool {
+        entries.contains { $0.sourceID == "fil_\(order)" }
+    }
+
+    mutating func toggleFallInLovePrompt(_ prompt: FallInLovePrompt, mode: Mode) {
+        if containsFallInLovePrompt(order: prompt.order) {
+            removeFallInLovePrompt(order: prompt.order)
+        } else {
+            addFallInLovePrompt(prompt, mode: mode)
         }
     }
 

--- a/Connections/Views/FallInLoveIntroView.swift
+++ b/Connections/Views/FallInLoveIntroView.swift
@@ -27,18 +27,18 @@ struct FallInLoveIntroView: View {
 
                 VStack(spacing: 24) {
                     Text(isFriends ? "Get closer" : "Fall in love again")
-                        .font(.system(size: 32, weight: .regular, design: .serif))
+                        .font(AppFont.screenTitle())
                         .multilineTextAlignment(.center)
 
                     Text(isFriends
                          ? "Some conversations create clarity, trust, and unexpected connection.\n\nThese questions are designed to help two people move past surface-level talk and into something more honest, open, and real."
                          : "Not by chance — but through attention, honesty, and shared moments.\n\nA series of thoughtfully designed questions can deepen connection, spark curiosity, and bring you closer — one conversation at a time.")
-                        .font(.system(size: 17))
+                        .font(AppFont.subtitle())
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .lineSpacing(5)
                 }
-                .padding(.horizontal, 36)
+                .padding(.horizontal, AppSpacing.buttonHorizontal)
 
                 Spacer()
 
@@ -46,6 +46,7 @@ struct FallInLoveIntroView: View {
 
                 VStack(spacing: 14) {
                     Button {
+                        HapticsManager.lightImpact()
                         if dontShowAgain {
                             if isFriends {
                                 settings.skipFallInLoveIntroFriends = true
@@ -59,7 +60,7 @@ struct FallInLoveIntroView: View {
                             .font(.system(size: 17, weight: .semibold))
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 18)
-                            .foregroundColor(.white)
+                            .foregroundStyle(.white)
                             .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                     }
 
@@ -70,26 +71,28 @@ struct FallInLoveIntroView: View {
                             .secondaryButtonStyle()
                     }
                 }
-                .padding(.horizontal, 36)
+                .padding(.horizontal, AppSpacing.buttonHorizontal)
 
                 // MARK: - Don't Show Again
 
                 Button {
                     dontShowAgain.toggle()
+                    HapticsManager.lightImpact()
                 } label: {
                     HStack(spacing: 8) {
                         Image(systemName: dontShowAgain ? "checkmark.square.fill" : "square")
-                            .font(.system(size: 16))
-                            .foregroundStyle(dontShowAgain ? .primary : .tertiary)
+                            .font(.system(size: 15))
+                            .foregroundStyle(dontShowAgain ? .secondary : .tertiary)
+                            .animation(.easeOut(duration: 0.15), value: dontShowAgain)
 
                         Text("Don't show this again")
-                            .font(.system(size: 14))
-                            .foregroundStyle(.secondary)
+                            .font(AppFont.detail())
+                            .foregroundStyle(.tertiary)
                     }
                 }
                 .buttonStyle(.plain)
                 .padding(.top, 20)
-                .padding(.bottom, 52)
+                .padding(.bottom, AppSpacing.bottomPadding)
             }
         }
         .navigationBarBackButtonHidden(true)
@@ -120,7 +123,7 @@ private struct WhyThisWorksSheet: View {
                 .frame(height: 48)
 
             Text("Why this works")
-                .font(.system(size: 28, weight: .regular, design: .serif))
+                .font(AppFont.promptText())
                 .padding(.bottom, 24)
 
             if isFriends {
@@ -130,14 +133,14 @@ private struct WhyThisWorksSheet: View {
                     BulletPoint("Shared attention deepens connection")
                     BulletPoint("Honest conversation changes how people see each other")
                 }
-                .padding(.horizontal, 36)
+                .padding(.horizontal, AppSpacing.buttonHorizontal)
 
                 Text("Some connections grow gradually.\nThis gives them room to.")
-                    .font(.system(size: 17))
+                    .font(AppFont.subtitle())
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
-                    .padding(.horizontal, 36)
+                    .padding(.horizontal, AppSpacing.buttonHorizontal)
                     .padding(.top, 28)
             } else {
                 VStack(alignment: .leading, spacing: 14) {
@@ -146,14 +149,14 @@ private struct WhyThisWorksSheet: View {
                     BulletPoint("Shared attention strengthens bonds")
                     BulletPoint("Small moments, repeated, create lasting connection")
                 }
-                .padding(.horizontal, 36)
+                .padding(.horizontal, AppSpacing.buttonHorizontal)
 
                 Text("You don't fall in love all at once.\nYou build it — moment by moment.")
-                    .font(.system(size: 17))
+                    .font(AppFont.subtitle())
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
                     .lineSpacing(5)
-                    .padding(.horizontal, 36)
+                    .padding(.horizontal, AppSpacing.buttonHorizontal)
                     .padding(.top, 28)
             }
 
@@ -166,11 +169,11 @@ private struct WhyThisWorksSheet: View {
                     .font(.system(size: 17, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 18)
-                    .foregroundColor(.white)
+                    .foregroundStyle(.white)
                     .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
             }
-            .padding(.horizontal, 36)
-            .padding(.bottom, 52)
+            .padding(.horizontal, AppSpacing.buttonHorizontal)
+            .padding(.bottom, AppSpacing.bottomPadding)
         }
         .presentationDragIndicator(.visible)
     }
@@ -186,11 +189,12 @@ private struct BulletPoint: View {
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
             Text("•")
-                .font(.system(size: 17, weight: .medium))
-                .foregroundStyle(.secondary)
+                .font(AppFont.subtitle())
+                .fontWeight(.medium)
+                .foregroundStyle(.tertiary)
 
             Text(text)
-                .font(.system(size: 17))
+                .font(AppFont.subtitle())
                 .foregroundStyle(.secondary)
                 .lineSpacing(4)
         }

--- a/Connections/Views/FallInLoveIntroView.swift
+++ b/Connections/Views/FallInLoveIntroView.swift
@@ -128,14 +128,14 @@ private struct WhyThisWorksSheet: View {
 
             if isFriends {
                 VStack(alignment: .leading, spacing: 14) {
-                    BulletPoint("Meaningful questions build closeness")
-                    BulletPoint("Vulnerability increases trust")
-                    BulletPoint("Shared attention deepens connection")
-                    BulletPoint("Honest conversation changes how people see each other")
+                    BulletPoint("When one person shares something real, others tend to match that openness — without being asked")
+                    BulletPoint("Asking a genuine question and actually listening is one of the simplest ways to deepen a friendship")
+                    BulletPoint("Trust grows in small moments — when someone feels heard, not just talked to")
+                    BulletPoint("Most friendships stay at the surface not because people don't care, but because no one goes first")
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
 
-                Text("Some connections grow gradually.\nThis gives them room to.")
+                Text("The deepest friendships aren't found.\nThey're built — one real conversation at a time.")
                     .font(AppFont.subtitle())
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -144,14 +144,14 @@ private struct WhyThisWorksSheet: View {
                     .padding(.top, 28)
             } else {
                 VStack(alignment: .leading, spacing: 14) {
-                    BulletPoint("Meaningful questions create emotional closeness")
-                    BulletPoint("Vulnerability builds trust over time")
-                    BulletPoint("Shared attention strengthens bonds")
-                    BulletPoint("Small moments, repeated, create lasting connection")
+                    BulletPoint("When two people take turns answering honest questions, they naturally match each other's openness")
+                    BulletPoint("Feeling genuinely listened to — not just heard — is one of the strongest drivers of closeness")
+                    BulletPoint("Vulnerability doesn't just build trust. It signals that trust already exists.")
+                    BulletPoint("The conversations that deepen a relationship are rarely dramatic. They're the ones where someone feels met.")
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
 
-                Text("You don't fall in love all at once.\nYou build it — moment by moment.")
+                Text("You don't fall in love all at once.\nYou build it — one honest moment at a time.")
                     .font(AppFont.subtitle())
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -35,14 +35,19 @@ struct FallInLovePlayView: View {
 
                     Spacer()
 
-                    Menu {
-                        Button("Start Over") {
-                            showResetConfirmation = true
+                    if !manager.isComplete {
+                        Menu {
+                            Button("Start Over") {
+                                showResetConfirmation = true
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
+                                .foregroundStyle(.tertiary)
                         }
-                    } label: {
-                        Image(systemName: "ellipsis.circle")
-                            .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
-                            .foregroundStyle(.secondary)
+                    } else {
+                        // Balance the close button during completion
+                        Color.clear.frame(width: AppIcon.navSize, height: AppIcon.navSize)
                     }
                 }
                 .padding(.horizontal, AppSpacing.screenHorizontal)
@@ -101,32 +106,38 @@ struct FallInLovePlayView: View {
                                 .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                         }
 
-                        if manager.canGoBack {
-                            Button {
-                                guard !isTransitioning else { return }
-                                isTransitioning = true
-                                let generation = transitionGeneration
-                                HapticsManager.lightImpact()
-                                withAnimation(.easeOut(duration: 0.2)) {
-                                    promptVisible = false
-                                }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                                    guard transitionGeneration == generation else { return }
-                                    manager.goBack()
-                                    promptTransitionID = UUID()
-                                    isTransitioning = false
-                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
-                                        promptVisible = true
+                        HStack {
+                            if manager.canGoBack {
+                                Button {
+                                    guard !isTransitioning else { return }
+                                    isTransitioning = true
+                                    let generation = transitionGeneration
+                                    HapticsManager.lightImpact()
+                                    withAnimation(.easeOut(duration: 0.2)) {
+                                        promptVisible = false
                                     }
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                        guard transitionGeneration == generation else { return }
+                                        manager.goBack()
+                                        promptTransitionID = UUID()
+                                        isTransitioning = false
+                                        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                            promptVisible = true
+                                        }
+                                    }
+                                } label: {
+                                    Text("Previous")
+                                        .font(.system(size: 14, weight: .medium))
+                                        .foregroundStyle(.tertiary)
                                 }
-                            } label: {
-                                Text("Previous")
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundStyle(.tertiary)
+                                .buttonStyle(.plain)
                             }
-                            .buttonStyle(.plain)
-                            .padding(.top, 14)
+
+                            Spacer()
+
+                            heartButton
                         }
+                        .padding(.top, 14)
                     }
                     .padding(.horizontal, AppSpacing.contentHorizontal)
                     .padding(.bottom, 48)
@@ -192,6 +203,24 @@ struct FallInLovePlayView: View {
         .onAppear {
             manager.resume()
         }
+    }
+
+    // MARK: - Heart Button
+
+    private var heartButton: some View {
+        let prompt = manager.currentPrompt
+        let isFavorited = prompt.map { session.isFallInLoveFavorited($0) } ?? false
+        return Button {
+            guard !isTransitioning, let prompt = manager.currentPrompt else { return }
+            HapticsManager.lightImpact()
+            session.toggleFallInLoveFavorite(prompt)
+        } label: {
+            Image(systemName: isFavorited ? "heart.fill" : "heart")
+                .font(.system(size: 18))
+                .foregroundStyle(isFavorited ? Color.red : Color.secondary.opacity(0.4))
+                .animation(.spring(response: 0.25, dampingFraction: 0.6), value: isFavorited)
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Complete Content

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -8,142 +8,186 @@ import SwiftUI
 struct FallInLovePlayView: View {
     @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     @State private var manager = FallInLoveManager()
 
     private var isFriends: Bool { session.selectedMode == .friends }
     @State private var promptTransitionID = UUID()
     @State private var promptVisible = true
+    @State private var isTransitioning = false
+    @State private var transitionGeneration: UInt = 0
     @State private var showResetConfirmation = false
 
     var body: some View {
         ZStack {
             AtmosphericBackground(intensity: .honest)
 
-        VStack(spacing: 0) {
+            VStack(spacing: 0) {
 
-            // MARK: - Top Bar
+                // MARK: - Top Bar
 
-            HStack {
-                CloseButton { dismiss() }
+                HStack {
+                    CloseButton { dismiss() }
 
-                Spacer()
+                    Spacer()
 
-                TopBarLabel(text: isFriends ? "Get Closer" : "Fall in Love")
+                    TopBarLabel(text: isFriends ? "Get Closer" : "Fall in Love")
 
-                Spacer()
+                    Spacer()
 
-                Menu {
-                    Button("Start Over") {
-                        showResetConfirmation = true
-                    }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
-                        .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
-                        .foregroundStyle(.secondary)
-                }
-            }
-            .padding(.horizontal, AppSpacing.screenHorizontal)
-            .padding(.top, AppSpacing.topBarTop)
-
-            // MARK: - Progress
-
-            if !manager.isComplete {
-                SessionProgressBar(
-                    progress: manager.progress,
-                    depthLabel: manager.depthLabel,
-                    positionLabel: "Question \(manager.currentIndex + 1) of \(manager.totalPrompts)"
-                )
-            }
-
-            // MARK: - Content
-
-            Spacer()
-
-            if manager.isComplete {
-                completeContent
-            } else if let prompt = manager.currentPrompt {
-                Text(prompt.text)
-                    .promptTextStyle()
-                    .id(promptTransitionID)
-                    .opacity(promptVisible ? 1 : 0)
-                    .offset(y: promptVisible ? 0 : 10)
-                    .animation(.easeInOut(duration: 0.24), value: promptVisible)
-            }
-
-            Spacer()
-
-            // MARK: - Actions
-
-            if manager.isComplete {
-                VStack(spacing: 12) {
-                    Button {
-                        showResetConfirmation = true
+                    Menu {
+                        Button("Start Over") {
+                            showResetConfirmation = true
+                        }
                     } label: {
-                        Text("Start Over")
-                            .secondaryButtonStyle()
-                    }
-
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Done")
-                            .primaryButtonStyle()
+                        Image(systemName: "ellipsis.circle")
+                            .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
+                            .foregroundStyle(.secondary)
                     }
                 }
-                .padding(.horizontal, AppSpacing.buttonHorizontal)
-                .padding(.bottom, AppSpacing.bottomPadding)
-            } else {
-                HStack(spacing: 12) {
-                    if manager.canGoBack {
+                .padding(.horizontal, AppSpacing.screenHorizontal)
+                .padding(.top, AppSpacing.topBarTop)
+
+                if !manager.isComplete {
+
+                    // MARK: - Progress
+
+                    SessionProgressBar(
+                        progress: manager.progress,
+                        depthLabel: manager.depthLabel,
+                        positionLabel: "\(manager.currentIndex + 1) of \(manager.totalPrompts)"
+                    )
+
+                    // MARK: - Prompt
+
+                    Spacer(minLength: 40)
+
+                    if let prompt = manager.currentPrompt {
+                        Text(prompt.text)
+                            .promptTextStyle()
+                            .id(promptTransitionID)
+                            .opacity(promptVisible ? 1 : 0)
+                            .offset(y: promptVisible ? 0 : 12)
+                    }
+
+                    Spacer()
+
+                    // MARK: - Actions
+
+                    VStack(spacing: 0) {
                         Button {
+                            guard !isTransitioning else { return }
+                            isTransitioning = true
+                            let generation = transitionGeneration
                             HapticsManager.lightImpact()
-                            withAnimation(.easeOut(duration: 0.16)) { promptVisible = false }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                                manager.goBack()
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                promptVisible = false
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                guard transitionGeneration == generation else { return }
+                                manager.advance()
                                 promptTransitionID = UUID()
-                                promptVisible = true
+                                isTransitioning = false
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    promptVisible = true
+                                }
                             }
                         } label: {
-                            Text("Previous")
-                                .font(AppFont.buttonSecondary())
-                                .foregroundStyle(.primary)
+                            Text("Next")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundStyle(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 16)
-                                .background(AppColor.surfaceElevated, in: .capsule)
+                                .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                         }
+
+                        if manager.canGoBack {
+                            Button {
+                                guard !isTransitioning else { return }
+                                isTransitioning = true
+                                let generation = transitionGeneration
+                                HapticsManager.lightImpact()
+                                withAnimation(.easeOut(duration: 0.2)) {
+                                    promptVisible = false
+                                }
+                                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                    guard transitionGeneration == generation else { return }
+                                    manager.goBack()
+                                    promptTransitionID = UUID()
+                                    isTransitioning = false
+                                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                        promptVisible = true
+                                    }
+                                }
+                            } label: {
+                                Text("Previous")
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            .buttonStyle(.plain)
+                            .padding(.top, 14)
+                        }
+                    }
+                    .padding(.horizontal, AppSpacing.contentHorizontal)
+                    .padding(.bottom, 48)
+                    .animation(.easeOut(duration: 0.2), value: manager.canGoBack)
+
+                } else {
+
+                    // MARK: - Completion
+
+                    ScrollView(.vertical, showsIndicators: false) {
+                        completeContent
+                            .padding(.top, 32)
+                            .padding(.bottom, 16)
                     }
 
-                    Button {
-                        HapticsManager.lightImpact()
-                        withAnimation(.easeOut(duration: 0.16)) { promptVisible = false }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                            manager.advance()
-                            promptTransitionID = UUID()
-                            promptVisible = true
+                    VStack(spacing: 0) {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text("Done")
+                                .font(.system(size: 17, weight: .semibold))
+                                .foregroundStyle(.white)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 18)
+                                .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                         }
-                    } label: {
-                        Text("Next")
-                            .primaryButtonStyle()
+
+                        Button {
+                            showResetConfirmation = true
+                        } label: {
+                            Text("Start Over")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.top, 14)
                     }
+                    .padding(.horizontal, AppSpacing.buttonHorizontal)
+                    .padding(.bottom, AppSpacing.bottomPadding)
                 }
-                .padding(.horizontal, AppSpacing.buttonHorizontal)
-                .padding(.bottom, AppSpacing.bottomPadding)
-                .animation(AppAnimation.standard, value: manager.canGoBack)
             }
-        }
         } // ZStack
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .alert("Start Over?", isPresented: $showResetConfirmation) {
             Button("Reset", role: .destructive) {
+                transitionGeneration &+= 1
                 manager.reset()
-                withAnimation(AppAnimation.transition) {
-                    promptTransitionID = UUID()
+                isTransitioning = false
+                promptTransitionID = UUID()
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                    promptVisible = true
                 }
             }
             Button("Cancel", role: .cancel) { }
         } message: {
             Text("This will reset your progress back to Question 1. This is useful when starting with a new person.")
+        }
+        .animation(.easeInOut(duration: 0.4), value: manager.isComplete)
+        .onChange(of: manager.isComplete) { _, complete in
+            if complete { HapticsManager.success() }
         }
         .onAppear {
             manager.resume()
@@ -153,16 +197,21 @@ struct FallInLovePlayView: View {
     // MARK: - Complete Content
 
     private var completeContent: some View {
-        VStack(spacing: 16) {
-            Text("You've completed all 36 questions")
-                .font(AppFont.promptText())
+        VStack(spacing: 12) {
+            Text(isFriends ? "Something shifted" : "Something was built here")
+                .font(.system(size: 28, weight: .regular, design: .serif))
                 .multilineTextAlignment(.center)
+
+            Text("You stayed for all 36 questions")
+                .font(.system(size: 15))
+                .foregroundStyle(.tertiary)
 
             Text(isFriends
                  ? "You made space for a deeper kind of conversation."
                  : "Take a moment to appreciate the connection you've built.")
-                .font(AppFont.subtitle())
+                .font(.system(size: 15, weight: .regular, design: .serif))
                 .foregroundStyle(.secondary)
+                .italic()
                 .multilineTextAlignment(.center)
         }
         .padding(.horizontal, AppSpacing.promptHorizontal)

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -18,6 +18,8 @@ struct FavoritesPlayView: View {
     @State private var goDeeperPressed = false
     @State private var promptVisible = true
     @State private var followUpVisible = true
+    @State private var justUnfavorited = false
+    @State private var isTransitioning = false
 
     private var currentEntry: FavoritesStore.FavoriteEntry? {
         guard !localFavorites.isEmpty, currentIndex < localFavorites.count else { return nil }
@@ -46,49 +48,41 @@ struct FavoritesPlayView: View {
                     // MARK: - Top Bar
 
                     HStack {
-                        Button {
-                            dismiss()
-                        } label: {
-                            Image(systemName: "xmark")
-                                .font(.system(size: 15, weight: .medium))
-                        }
-                        .tint(.secondary)
+                        CloseButton { dismiss() }
 
                         Spacer()
 
-                        Text("Favorites")
-                            .font(.system(size: 13))
-                            .foregroundStyle(.secondary)
+                        TopBarLabel(text: "Favorites")
 
                         Spacer()
 
                         heartButton
                     }
-                    .padding(.horizontal, 24)
-                    .padding(.top, 12)
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
+                    .padding(.top, AppSpacing.topBarTop)
 
                     // MARK: - Progress
 
-                    VStack(spacing: 6) {
+                    VStack(spacing: 4) {
                         ProgressView(value: progress)
-                            .tint(currentEntry?.intensity.toneColor ?? AppColor.primaryButtonBg(colorScheme))
+                            .tint(currentEntry?.intensity.toneColor.opacity(0.45) ?? Color.primary.opacity(0.12))
 
                         HStack {
                             if let entry = currentEntry {
                                 Text("\(entry.mode.rawValue) · \(entry.intensity.rawValue) · \(entry.depth.title)")
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.secondary)
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.tertiary)
                             }
 
                             Spacer()
 
-                            Text("Card \(currentIndex + 1) of \(localFavorites.count)")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
+                            Text("\(currentIndex + 1) of \(localFavorites.count)")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.tertiary)
                         }
                     }
-                    .padding(.horizontal, 28)
-                    .padding(.top, 16)
+                    .padding(.horizontal, AppSpacing.progressHorizontal)
+                    .padding(.top, 10)
 
                     // MARK: - Content Area
 
@@ -121,12 +115,11 @@ struct FavoritesPlayView: View {
                     .font(.system(size: 28, weight: .regular, design: .serif))
                     .multilineTextAlignment(.center)
                     .lineSpacing(8)
-                    .padding(.horizontal, 28)
+                    .padding(.horizontal, AppSpacing.contentHorizontal)
                     .padding(.vertical, 44)
                     .id(promptTransitionID)
                     .opacity(promptVisible ? 1 : 0)
-                    .offset(y: promptVisible ? 0 : 10)
-                    .animation(.easeInOut(duration: 0.2), value: promptVisible)
+                    .offset(y: promptVisible ? 0 : 12)
 
                 if !shownFollowUps.isEmpty {
                     VStack(spacing: 8) {
@@ -142,11 +135,10 @@ struct FavoritesPlayView: View {
                                 )
                         }
                     }
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+                    .transition(.opacity.combined(with: .offset(y: 8)))
                     .padding(.bottom, 24)
                     .opacity(followUpVisible ? 1 : 0)
                     .offset(y: followUpVisible ? 0 : 8)
-                    .animation(.easeInOut(duration: 0.2), value: followUpVisible)
                 }
             }
         }
@@ -156,37 +148,48 @@ struct FavoritesPlayView: View {
 
     private var heartButton: some View {
         Button {
-            guard let entry = currentEntry else { return }
+            guard !justUnfavorited, !isTransitioning, let entry = currentEntry else { return }
+            isTransitioning = true
+            justUnfavorited = true
             HapticsManager.lightImpact()
 
-            withAnimation(.easeOut(duration: 0.16)) {
-                promptVisible = false
-                followUpVisible = false
+            // Prompt fades out after a beat
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    promptVisible = false
+                    followUpVisible = false
+                }
             }
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                session.removeFavorite(id: entry.id)
-                localFavorites.removeAll { $0.id == entry.id }
-                shownFollowUps = []
-                showGoDeeperHint = true
+            // Remove and advance
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                withAnimation(.easeOut(duration: 0.3)) {
+                    session.removeFavorite(id: entry.id)
+                    localFavorites.removeAll { $0.id == entry.id }
+                    shownFollowUps = []
+                    showGoDeeperHint = true
+                    justUnfavorited = false
+                }
 
-                if localFavorites.isEmpty {
-                    // allow empty state to render
-                } else if currentIndex >= localFavorites.count {
-                    currentIndex = max(0, localFavorites.count - 1)
+                isTransitioning = false
+
+                if !localFavorites.isEmpty {
+                    if currentIndex >= localFavorites.count {
+                        currentIndex = localFavorites.count - 1
+                    }
                     promptTransitionID = UUID()
-                    promptVisible = true
-                    followUpVisible = true
-                } else {
-                    promptTransitionID = UUID()
-                    promptVisible = true
-                    followUpVisible = true
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                        promptVisible = true
+                        followUpVisible = true
+                    }
                 }
             }
         } label: {
-            Image(systemName: "heart.fill")
+            Image(systemName: justUnfavorited ? "heart" : "heart.fill")
                 .font(.system(size: 22))
-                .foregroundColor(.red)
+                .foregroundStyle(justUnfavorited ? Color.primary.opacity(0.2) : .red)
+                .scaleEffect(justUnfavorited ? 0.85 : 1.0)
+                .animation(.spring(response: 0.25, dampingFraction: 0.6), value: justUnfavorited)
         }
         .buttonStyle(.plain)
     }
@@ -196,132 +199,123 @@ struct FavoritesPlayView: View {
     private var actionButtons: some View {
         VStack(spacing: 0) {
 
-            // MARK: Follow-up questions
-
+            // Go deeper
             if hasMoreFollowUps {
-                VStack(spacing: 6) {
-                    Button {
-                        goDeeperPressed = true
-                        HapticsManager.mediumImpact()
-                        withAnimation(.easeOut(duration: 0.12)) {
-                            followUpVisible = false
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                            revealNextFollowUp()
-                            withAnimation(.easeIn(duration: 0.2)) {
-                                followUpVisible = true
-                            }
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                            goDeeperPressed = false
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "sparkles")
-                                .font(.system(size: 13, weight: .semibold))
-                            Text("Go deeper")
-                                .font(.system(size: 15, weight: .semibold))
-                        }
-                        .foregroundStyle(.primary)
-                        .padding(.horizontal, 22)
-                        .padding(.vertical, 12)
-                        .background(
-                            Capsule()
-                                .fill((currentEntry?.intensity.cardTint ?? Color.primary).opacity(0.18))
-                        )
-                        .overlay(
-                            Capsule()
-                                .strokeBorder((currentEntry?.intensity.cardTint ?? Color.primary).opacity(0.35), lineWidth: 1)
-                        )
-                        .scaleEffect(goDeeperPressed ? 0.95 : 1.0)
-                        .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
+                Button {
+                    guard !isTransitioning else { return }
+                    goDeeperPressed = true
+                    HapticsManager.mediumImpact()
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        followUpVisible = false
                     }
-                    .buttonStyle(.plain)
-
-                    if showGoDeeperHint {
-                        Text("Adds deeper follow-up questions")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        revealNextFollowUp()
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+                            followUpVisible = true
+                        }
                     }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        goDeeperPressed = false
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 12))
+                        Text("Go deeper")
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(
+                        Capsule()
+                            .fill(currentEntry?.intensity.cardTint.opacity(0.12) ?? Color.primary.opacity(0.06))
+                    )
+                    .scaleEffect(goDeeperPressed ? 0.96 : 1.0)
+                    .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
                 }
-                .padding(.bottom, 20)
+                .buttonStyle(.plain)
+                .padding(.bottom, 16)
                 .transition(.opacity)
             }
 
-            // MARK: Back / Next / Done
-
-            HStack(spacing: 12) {
-                if currentIndex > 0 {
-                    Button {
-                        HapticsManager.lightImpact()
-
-                        withAnimation(.easeOut(duration: 0.16)) {
-                            promptVisible = false
-                            followUpVisible = false
-                        }
-
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                            currentIndex -= 1
-                            shownFollowUps = []
-                            showGoDeeperHint = true
-                            promptTransitionID = UUID()
+            // Next / Done
+            if currentIndex < localFavorites.count - 1 {
+                Button {
+                    guard !isTransitioning else { return }
+                    isTransitioning = true
+                    HapticsManager.lightImpact()
+                    if !shownFollowUps.isEmpty { showGoDeeperHint = false }
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        promptVisible = false
+                        followUpVisible = false
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        currentIndex += 1
+                        shownFollowUps = []
+                        showGoDeeperHint = true
+                        promptTransitionID = UUID()
+                        isTransitioning = false
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                             promptVisible = true
                             followUpVisible = true
                         }
-                    } label: {
-                        Text("Back")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                            .background(AppColor.surface(colorScheme), in: .capsule)
                     }
+                } label: {
+                    Text("Next")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                 }
-
-                if currentIndex < localFavorites.count - 1 {
-                    Button {
-                        HapticsManager.lightImpact()
-                        if !shownFollowUps.isEmpty { showGoDeeperHint = false }
-
-                        withAnimation(.easeOut(duration: 0.16)) {
-                            promptVisible = false
-                            followUpVisible = false
-                        }
-
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                            currentIndex += 1
-                            shownFollowUps = []
-                            showGoDeeperHint = true
-                            promptTransitionID = UUID()
-                            promptVisible = true
-                            followUpVisible = true
-                        }
-                    } label: {
-                        Text("Next")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
-                    }
-                } else {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Text("Done")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
-                    }
+            } else {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Done")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                 }
             }
 
+            // Back
+            if currentIndex > 0 {
+                Button {
+                    guard !isTransitioning else { return }
+                    isTransitioning = true
+                    HapticsManager.lightImpact()
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        promptVisible = false
+                        followUpVisible = false
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        currentIndex -= 1
+                        shownFollowUps = []
+                        showGoDeeperHint = true
+                        promptTransitionID = UUID()
+                        isTransitioning = false
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                            promptVisible = true
+                            followUpVisible = true
+                        }
+                    }
+                } label: {
+                    Text("Back")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .padding(.top, 14)
+            }
         }
-        .padding(.horizontal, 28)
+        .padding(.horizontal, AppSpacing.contentHorizontal)
         .padding(.bottom, 48)
         .animation(.easeOut(duration: 0.2), value: shownFollowUps.count)
+        .animation(.easeOut(duration: 0.2), value: currentIndex > 0)
     }
 
     // MARK: - Empty State
@@ -336,7 +330,7 @@ struct FavoritesPlayView: View {
                 .font(.system(size: 28, weight: .regular, design: .serif))
 
             Text("Tap the heart on any prompt to save it here for later.")
-                .font(.system(size: 15))
+                .font(AppFont.caption())
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
 
@@ -371,6 +365,5 @@ struct FavoritesPlayView: View {
     NavigationStack {
         FavoritesPlayView()
             .environment(SessionManager())
-
     }
 }

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -69,7 +69,7 @@ struct FavoritesPlayView: View {
 
                         HStack {
                             if let entry = currentEntry {
-                                Text("\(entry.mode.rawValue) · \(entry.intensity.rawValue) · \(entry.depth.title)")
+                                Text(contextLabel(for: entry))
                                     .font(.system(size: 11, weight: .medium))
                                     .foregroundStyle(.tertiary)
                             }
@@ -350,6 +350,17 @@ struct FavoritesPlayView: View {
     }
 
     // MARK: - Helpers
+
+    private func contextLabel(for entry: FavoritesStore.FavoriteEntry) -> String {
+        switch entry.source {
+        case "shareExperience":
+            return "Share Experience · \(entry.intensity.rawValue)"
+        case "fallInLove":
+            return "36 Questions · \(entry.depth.title)"
+        default:
+            return "\(entry.mode.rawValue) · \(entry.intensity.rawValue) · \(entry.depth.title)"
+        }
+    }
 
     private func revealNextFollowUp() {
         guard let entry = currentEntry else { return }

--- a/Connections/Views/FeelingCheckInView.swift
+++ b/Connections/Views/FeelingCheckInView.swift
@@ -13,10 +13,10 @@ struct FeelingCheckInView: View {
     @State private var displayedMessage: String?
 
     var body: some View {
-        VStack(spacing: 28) {
+        VStack(spacing: 32) {
 
             Text("How did that feel?")
-                .font(.system(size: 22, weight: .regular, design: .serif))
+                .font(.system(size: 24, weight: .regular, design: .serif))
                 .foregroundStyle(.primary)
 
             HStack(spacing: 20) {

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
                         .font(AppFont.heroTitle())
                         .tracking(1)
 
-                    Text("Guided prompts for meaningful conversation")
+                    Text("Conversations that bring you closer")
                         .font(AppFont.subtitle())
                         .foregroundStyle(.secondary)
                 }
@@ -35,9 +35,9 @@ struct HomeView: View {
 
                 VStack(spacing: 16) {
                     NavigationLink {
-                        ModeSelectionView()
+                        SessionBuilderView()
                     } label: {
-                        Text("Start Session")
+                        Text("Start a session")
                             .primaryButtonStyle()
                     }
 
@@ -60,6 +60,12 @@ struct HomeView: View {
                     }
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
+
+                Text("Choose a tone. Follow the prompts.\nSee where it goes.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+                    .padding(.top, 16)
 
                 // MARK: - Secondary
 

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 
 struct HomeView: View {
     @Environment(SessionManager.self) private var session
-    @State private var navigateToFavorites = false
     @State private var navigateToSettings = false
 
     var body: some View {
@@ -50,14 +49,6 @@ struct HomeView: View {
                         }
                     }
 
-                    if !session.favorites.allFavorites.isEmpty {
-                        Button {
-                            navigateToFavorites = true
-                        } label: {
-                            Text("Play Favorites (\(session.favorites.allFavorites.count))")
-                                .secondaryButtonStyle()
-                        }
-                    }
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
 
@@ -80,9 +71,6 @@ struct HomeView: View {
                 .foregroundStyle(.secondary)
                 .padding(.top, 24)
                 .padding(.bottom, max(geo.safeAreaInsets.bottom + 16, AppSpacing.bottomPadding))
-            }
-            .navigationDestination(isPresented: $navigateToFavorites) {
-                FavoritesPlayView()
             }
             .navigationDestination(isPresented: $navigateToSettings) {
                 SettingsView()

--- a/Connections/Views/OnboardingView.swift
+++ b/Connections/Views/OnboardingView.swift
@@ -19,20 +19,20 @@ struct OnboardingView: View {
 
     private let pages: [OnboardingPage] = [
         OnboardingPage(
-            title: "Go deeper",
-            body: "Most conversations stay on the surface.\nThis helps you move into something more honest, meaningful, and real."
+            title: "Go beyond small talk",
+            body: "Some conversations stay on the surface.\nThis helps you get to something more real."
         ),
         OnboardingPage(
             title: "Built for connection",
-            body: "Thoughtful questions help you slow down, open up, and discover what's underneath the usual answers."
+            body: "Thoughtful prompts help people slow down, open up, and understand each other more honestly."
         ),
         OnboardingPage(
             title: "Simple by design",
-            body: "Choose a mode\nSet the tone\nAnswer honestly\nGo deeper when it feels right"
+            body: "Choose who it's for.\nSet the tone.\nStart talking."
         ),
         OnboardingPage(
             title: "Start where you are",
-            body: "With a partner, a friend, family — or just yourself.\nThere's no right way to begin."
+            body: "With a partner, a friend, your family, or just yourself.\nThere's no perfect way to begin."
         )
     ]
 
@@ -60,31 +60,40 @@ struct OnboardingView: View {
 
                 // MARK: - Pages
 
-                TabView(selection: $currentPage) {
-                    ForEach(Array(pages.enumerated()), id: \.offset) { index, page in
-                        VStack(spacing: 0) {
-                            Spacer()
+                ZStack {
+                    VStack(spacing: 20) {
+                        Text(pages[currentPage].title)
+                            .font(.system(size: 32, weight: .regular, design: .serif))
+                            .multilineTextAlignment(.center)
 
-                            VStack(spacing: 24) {
-                                Text(page.title)
-                                    .font(.system(size: 32, weight: .regular, design: .serif))
-                                    .multilineTextAlignment(.center)
-
-                                Text(page.body)
-                                    .font(.system(size: 17))
-                                    .foregroundStyle(.secondary)
-                                    .multilineTextAlignment(.center)
-                                    .lineSpacing(5)
-                                    .padding(.horizontal, 36)
-                            }
-                            .frame(maxWidth: 520)
-
-                            Spacer()
-                        }
-                        .tag(index)
+                        Text(pages[currentPage].body)
+                            .font(.system(size: 17))
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                            .padding(.horizontal, 40)
                     }
+                    .frame(maxWidth: 520)
+                    .id(currentPage)
+                    .transition(.asymmetric(
+                        insertion: .opacity.combined(with: .offset(y: 12)),
+                        removal: .opacity
+                    ))
                 }
-                .tabViewStyle(.page(indexDisplayMode: .never))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 30, coordinateSpace: .local)
+                        .onEnded { value in
+                            withAnimation(.easeOut(duration: 0.4)) {
+                                if value.translation.width < -50, currentPage < pages.count - 1 {
+                                    currentPage += 1
+                                } else if value.translation.width > 50, currentPage > 0 {
+                                    currentPage -= 1
+                                }
+                            }
+                        }
+                )
 
                 // MARK: - Page Indicators
 
@@ -106,14 +115,15 @@ struct OnboardingView: View {
 
                 Button {
                     if currentPage < pages.count - 1 {
-                        withAnimation(.easeInOut(duration: 0.25)) {
+                        withAnimation(.easeOut(duration: 0.4)) {
                             currentPage += 1
                         }
                     } else {
                         settings.hasSeenOnboarding = true
                     }
                 } label: {
-                    Text(currentPage < pages.count - 1 ? "Next" : "Start")
+                    Text(currentPage < pages.count - 1 ? "Next" : "Begin")
+                        .contentTransition(.interpolate)
                         .font(.system(size: 17, weight: .semibold))
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 18)

--- a/Connections/Views/OnboardingView.swift
+++ b/Connections/Views/OnboardingView.swift
@@ -27,12 +27,12 @@ struct OnboardingView: View {
             body: "Thoughtful prompts help people slow down, open up, and understand each other more honestly."
         ),
         OnboardingPage(
-            title: "Simple by design",
-            body: "Choose who it's for.\nSet the tone.\nStart talking."
-        ),
-        OnboardingPage(
             title: "Start where you are",
             body: "With a partner, a friend, your family, or just yourself.\nThere's no perfect way to begin."
+        ),
+        OnboardingPage(
+            title: "Simple by design",
+            body: "Choose who it's for.\nSet the tone.\nStart talking."
         )
     ]
 

--- a/Connections/Views/SessionBuilderView.swift
+++ b/Connections/Views/SessionBuilderView.swift
@@ -1,0 +1,642 @@
+//
+//  SessionBuilderView.swift
+//  Connections
+//
+
+import SwiftUI
+
+struct SessionBuilderView: View {
+    @Environment(SessionManager.self) private var session
+    @Environment(SettingsStore.self) private var settings
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    // MARK: - Stage
+
+    private enum SetupStage: Int, Comparable {
+        case mode, intensity, details
+        static func < (lhs: SetupStage, rhs: SetupStage) -> Bool {
+            lhs.rawValue < rhs.rawValue
+        }
+    }
+
+    @State private var currentStage: SetupStage = .mode
+    @Namespace private var cardNamespace
+
+    // MARK: - Detail State
+
+    @State private var selectedLength: SessionLength = .medium
+    @State private var selectedTopic: Topic? = nil
+    @State private var followUps: Bool = true
+    @State private var didApplyDefaults = false
+    @State private var hasCustomizedLength = false
+    @State private var hasCustomizedTopic = false
+    @State private var hasCustomizedFollowUps = false
+
+    // MARK: - Navigation
+
+    @State private var navigateToSession = false
+    @State private var navigateToFallInLove = false
+    @State private var navigateToFallInLoveIntro = false
+    @State private var navigateToShare = false
+
+    // MARK: - Alerts
+
+    @State private var showAgeConfirmation = false
+    @State private var ageConfirmed = false
+
+    // MARK: - Animation
+
+    private let stageSpring = Animation.spring(response: 0.42, dampingFraction: 0.86)
+
+    // MARK: - Computed
+
+    private var availableTopics: [Topic] {
+        guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
+            return Topic.allCases.map { $0 }
+        }
+        return PromptBank.shared.availableTopics(for: mode, intensity: intensity)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            AtmosphericBackground(intensity: session.selectedIntensity)
+                .animation(.easeInOut(duration: 0.5), value: session.selectedIntensity)
+
+            VStack(spacing: 0) {
+                headerSection
+                summarySection
+
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        stageContent
+
+                        if currentStage == .details {
+                            Spacer().frame(height: 188)
+                        }
+                    }
+                }
+                .safeAreaInset(edge: .bottom) {
+                    if currentStage == .details {
+                        startButton
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+            }
+        }
+        .animation(stageSpring, value: currentStage)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    switch currentStage {
+                    case .mode:
+                        dismiss()
+                    case .intensity:
+                        withAnimation(stageSpring) {
+                            currentStage = .mode
+                            session.selectedMode = nil
+                            session.selectedIntensity = nil
+                        }
+                    case .details:
+                        withAnimation(stageSpring) {
+                            currentStage = .intensity
+                            session.selectedIntensity = nil
+                        }
+                    }
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.leading, 4)
+            }
+        }
+        .navigationDestination(isPresented: $navigateToSession) {
+            SessionPlayView()
+        }
+        .navigationDestination(isPresented: $navigateToFallInLove) {
+            FallInLovePlayView()
+        }
+        .navigationDestination(isPresented: $navigateToFallInLoveIntro) {
+            FallInLoveIntroView()
+        }
+        .navigationDestination(isPresented: $navigateToShare) {
+            ShareExperiencePlayView()
+        }
+        .alert("Age Confirmation", isPresented: $showAgeConfirmation) {
+            Button("I'm 18 or older") {
+                ageConfirmed = true
+                selectedTopic = .sex
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Sex prompts contain mature content. Please confirm you are 18 years or older to continue.")
+        }
+        .onAppear {
+            if !didApplyDefaults {
+                selectedLength = settings.defaultSessionLength
+                followUps = settings.followUpsByDefault
+                didApplyDefaults = true
+                resetBuilderState()
+            }
+        }
+        .onChange(of: session.selectedMode) { _, _ in selectedTopic = nil }
+        .onChange(of: session.selectedIntensity) { _, _ in selectedTopic = nil }
+    }
+
+    // MARK: - Header
+
+    @ViewBuilder
+    private var headerSection: some View {
+        VStack(spacing: 6) {
+            Text(headerTitle)
+                .font(.system(size: 28, weight: .regular, design: .serif))
+                .contentTransition(.interpolate)
+                .id(headerTitle)
+
+            if !headerSubtitle.isEmpty {
+                Text(headerSubtitle)
+                    .font(.system(size: 15))
+                    .foregroundStyle(.secondary)
+                    .contentTransition(.interpolate)
+                    .id(headerSubtitle)
+            }
+        }
+        .padding(.top, 44)
+        .padding(.bottom, summarySectionVisible ? 16 : 32)
+    }
+
+    private var headerTitle: String {
+        switch currentStage {
+        case .mode: return "Choose a mode"
+        case .intensity: return "Set the tone"
+        case .details: return "Your session"
+        }
+    }
+
+    private var headerSubtitle: String {
+        switch currentStage {
+        case .mode: return "Who is this session for?"
+        case .intensity: return "How deep do you want to go?"
+        case .details: return ""
+        }
+    }
+
+    @ViewBuilder
+    private var summarySection: some View {
+        if summarySectionVisible {
+            VStack(spacing: 8) {
+                if let mode = session.selectedMode, currentStage != .mode {
+                    SummaryRow(
+                        icon: mode.iconName,
+                        title: mode.rawValue,
+                        subtitle: mode.description
+                    ) {
+                        withAnimation(stageSpring) {
+                            currentStage = .mode
+                            session.selectedMode = nil
+                            session.selectedIntensity = nil
+                            selectedTopic = nil
+                        }
+                    }
+                    .matchedGeometryEffect(id: "mode-\(mode.rawValue)", in: cardNamespace)
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.94).combined(with: .opacity),
+                        removal: .scale(scale: 0.98).combined(with: .opacity)
+                    ))
+                }
+
+                if let intensity = session.selectedIntensity, currentStage == .details {
+                    SummaryRow(
+                        icon: nil,
+                        title: intensity.rawValue,
+                        subtitle: intensity.description,
+                        tintColor: intensity.toneColor
+                    ) {
+                        withAnimation(stageSpring) {
+                            currentStage = .intensity
+                            session.selectedIntensity = nil
+                            selectedTopic = nil
+                        }
+                    }
+                    .matchedGeometryEffect(id: "intensity-\(intensity.rawValue)", in: cardNamespace)
+                    .transition(.asymmetric(
+                        insertion: .scale(scale: 0.94).combined(with: .opacity),
+                        removal: .scale(scale: 0.98).combined(with: .opacity)
+                    ))
+                }
+            }
+            .padding(.horizontal, AppSpacing.screenHorizontal)
+            .padding(.bottom, 16)
+        }
+    }
+
+    @ViewBuilder
+    private var stageContent: some View {
+        switch currentStage {
+        case .mode:
+            modeSection
+        case .intensity:
+            intensitySection
+        case .details:
+            detailsSection
+        }
+    }
+
+    private var summarySectionVisible: Bool {
+        currentStage != .mode
+    }
+
+    // MARK: - Mode Section
+
+    @ViewBuilder
+    private var modeSection: some View {
+        VStack(spacing: AppSpacing.cardSpacing) {
+            if currentStage == .mode {
+                ForEach(Mode.allCases) { mode in
+                    SelectionCard(title: mode.rawValue, subtitle: mode.description) {
+                        session.selectedMode = mode
+                        hasCustomizedLength = false
+                        hasCustomizedTopic = false
+                        hasCustomizedFollowUps = false
+                        HapticsManager.lightImpact()
+                        withAnimation(stageSpring) {
+                            currentStage = .intensity
+                        }
+                    }
+                    .matchedGeometryEffect(id: "mode-\(mode.rawValue)", in: cardNamespace)
+                    .transition(.opacity.combined(with: .scale(scale: 0.96)))
+                }
+
+                SelectionCard(title: "Share", subtitle: "Take turns sharing real experiences") {
+                    navigateToShare = true
+                }
+                .transition(.opacity)
+            }
+        }
+        .padding(.horizontal, AppSpacing.screenHorizontal)
+        .id(SetupStage.mode)
+    }
+
+    // MARK: - Intensity Section
+
+    @ViewBuilder
+    private var intensitySection: some View {
+        VStack(spacing: AppSpacing.cardSpacing) {
+            ForEach(Intensity.allCases) { intensity in
+                SelectionCard(
+                    title: intensity.rawValue,
+                    subtitle: intensity.description,
+                    tintColor: intensity.toneColor,
+                    isSelected: session.selectedIntensity == intensity,
+                    glassEffect: true
+                ) {
+                    session.selectedIntensity = intensity
+                    hasCustomizedLength = false
+                    hasCustomizedTopic = false
+                    hasCustomizedFollowUps = false
+                    applyRecommendedDetails()
+                    HapticsManager.lightImpact()
+                    withAnimation(stageSpring) {
+                        currentStage = .details
+                    }
+                }
+                .matchedGeometryEffect(id: "intensity-\(intensity.rawValue)", in: cardNamespace)
+                .transition(.opacity.combined(with: .scale(scale: 0.96)))
+            }
+        }
+        .padding(.horizontal, AppSpacing.screenHorizontal)
+        .transition(.asymmetric(
+            insertion: .offset(y: 20).combined(with: .opacity),
+            removal: .opacity
+        ))
+        .id(SetupStage.intensity)
+    }
+
+    // MARK: - Details Section
+
+    @ViewBuilder
+    private var detailsSection: some View {
+        if currentStage == .details {
+            VStack(spacing: 0) {
+                compositionBlock
+                refinementsSection
+            }
+            .padding(.top, 4)
+            .transition(.asymmetric(
+                insertion: .offset(y: 16).combined(with: .opacity),
+                removal: .opacity
+            ))
+            .id(SetupStage.details)
+        }
+    }
+
+    // MARK: - Composition Block
+
+    private var compositionBlock: some View {
+        VStack(spacing: 10) {
+            VStack(spacing: 4) {
+                if selectedTopic == .fallInLove {
+                    Text("Guided session")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
+                        .tracking(0.5)
+
+                    Text("36 questions")
+                        .font(.system(size: 20, weight: .medium, design: .serif))
+
+                    Text("designed to build closeness")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                } else {
+                    HStack(spacing: 0) {
+                        Text("\(selectedLength.rawValue)")
+                            .contentTransition(.numericText())
+                        Text(" prompts")
+                    }
+                    .font(.system(size: 20, weight: .medium, design: .serif))
+
+                    Text(compositionSubline)
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+                        .contentTransition(.interpolate)
+                        .id(compositionSubline)
+                }
+            }
+            .multilineTextAlignment(.center)
+
+            if selectedTopic != .fallInLove {
+                HStack(spacing: 8) {
+                    ForEach(SessionLength.allCases) { length in
+                        Button {
+                            selectedLength = length
+                            hasCustomizedLength = true
+                        } label: {
+                            VStack(spacing: 3) {
+                                Text("\(length.rawValue)")
+                                    .font(.system(size: 15, weight: selectedLength == length ? .semibold : .regular))
+                                    .foregroundStyle(selectedLength == length ? .white : .primary)
+
+                                if recommendedLength == length {
+                                    Circle()
+                                        .fill(selectedLength == length ? Color.white.opacity(0.7) : Color.secondary.opacity(0.35))
+                                        .frame(width: 4, height: 4)
+                                }
+                            }
+                            .frame(width: 52, height: 36)
+                            .padding(.vertical, 2)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                        .fill(selectedLength == length
+                                            ? AppColor.primaryButtonBg(colorScheme)
+                                            : AppColor.surface(colorScheme))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .animation(.easeOut(duration: 0.15), value: selectedLength)
+                    }
+                }
+            } else {
+                Text("Your progress is saved between sessions")
+                    .font(.system(size: 13))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .padding(.horizontal, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(compositionFill)
+        )
+        .padding(.horizontal, AppSpacing.screenHorizontal)
+        .animation(.easeInOut(duration: 0.2), value: selectedLength)
+        .animation(.easeInOut(duration: 0.2), value: followUps)
+    }
+
+    private var compositionSubline: String {
+        var parts: [String] = []
+        if let topic = selectedTopic {
+            parts.append(topic.displayName(for: session.selectedMode))
+        } else {
+            parts.append("All topics")
+        }
+        if followUps {
+            parts.append("follow-ups included")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private var compositionFill: Color {
+        if let intensity = session.selectedIntensity {
+            return intensity.toneColor.opacity(colorScheme == .dark ? 0.10 : 0.07)
+        }
+        return AppColor.surface(colorScheme)
+    }
+
+    // MARK: - Refinements
+
+    private var refinementsSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 14) {
+                TopicSelector(
+                    selectedTopic: $selectedTopic,
+                    availableTopics: availableTopics,
+                    mode: session.selectedMode,
+                    onSelectTopic: { topic in
+                        if topic == .sex && !ageConfirmed {
+                            showAgeConfirmation = true
+                            return
+                        }
+                        selectedTopic = topic
+                        hasCustomizedTopic = true
+                    }
+                )
+
+                if selectedTopic != .fallInLove {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Follow-up questions")
+                                .font(.system(size: 15, weight: .medium))
+
+                            Text("Adds gentle prompts to help you go deeper.")
+                                .font(.system(size: 13))
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        Toggle("", isOn: $followUps)
+                            .labelsHidden()
+                            .tint(AppColor.toggleTint)
+                            .onChange(of: followUps) { _, _ in
+                                hasCustomizedFollowUps = true
+                            }
+                    }
+                }
+            }
+            .padding(.horizontal, 18)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(AppColor.surface(colorScheme))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.05), lineWidth: 0.5)
+            )
+            .padding(.horizontal, AppSpacing.screenHorizontal)
+        }
+        .padding(.top, 16)
+        .padding(.bottom, 16)
+    }
+
+    // MARK: - Start Button
+
+    @ViewBuilder
+    private var startButton: some View {
+        VStack(spacing: 0) {
+            Button {
+                HapticsManager.mediumImpact()
+                if selectedTopic == .fallInLove {
+                    let skip = session.selectedMode == .friends
+                        ? settings.skipFallInLoveIntroFriends
+                        : settings.skipFallInLoveIntroCouples
+                    if skip {
+                        navigateToFallInLove = true
+                    } else {
+                        navigateToFallInLoveIntro = true
+                    }
+                } else {
+                    session.selectedSessionLength = selectedLength
+                    session.selectedTopic = selectedTopic
+                    session.followUpsEnabled = followUps
+                    session.startSession()
+                    navigateToSession = true
+                }
+            } label: {
+                Text(selectedTopic == .fallInLove ? "Begin" : "Start Session")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .foregroundColor(.white)
+                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+            }
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 10)
+        .padding(.bottom, 10)
+        .background(.ultraThinMaterial)
+    }
+
+    private func resetBuilderState() {
+        currentStage = .mode
+        session.selectedMode = nil
+        session.selectedIntensity = nil
+        session.selectedSessionLength = nil
+        session.selectedTopic = nil
+        session.followUpsEnabled = settings.followUpsByDefault
+        selectedLength = settings.defaultSessionLength
+        followUps = settings.followUpsByDefault
+        selectedTopic = nil
+        ageConfirmed = false
+        hasCustomizedLength = false
+        hasCustomizedTopic = false
+        hasCustomizedFollowUps = false
+    }
+
+    private var recommendedLength: SessionLength {
+        guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
+            return settings.defaultSessionLength
+        }
+
+        switch (mode, intensity) {
+        case (.couples, .light), (.friends, .light), (.family, .light):
+            return .medium
+        case (.couples, .honest), (.friends, .honest), (.family, .honest):
+            return .medium
+        case (.soloReflection, .light):
+            return .medium
+        case (.soloReflection, .honest), (.soloReflection, .unfiltered):
+            return .short
+        case (_, .unfiltered):
+            return .short
+        }
+    }
+
+    private var recommendedFollowUps: Bool {
+        guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
+            return settings.followUpsByDefault
+        }
+
+        switch (mode, intensity) {
+        case (.friends, .light), (.family, .light):
+            return false
+        case (.soloReflection, .light):
+            return false
+        case (.soloReflection, .honest), (.soloReflection, .unfiltered):
+            return true
+        case (_, .honest), (_, .unfiltered), (.couples, .light):
+            return true
+        }
+    }
+
+    private var recommendationNote: String {
+        guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
+            return "These defaults are designed to work well."
+        }
+
+        switch (mode, intensity) {
+        case (.couples, .light):
+            return "A steady pace with room to warm up and get closer."
+        case (.couples, .honest):
+            return "Enough room to open up without it feeling heavy."
+        case (.couples, .unfiltered):
+            return "Shorter keeps it brave without becoming exhausting."
+        case (.friends, .light):
+            return "Low pressure, natural rhythm."
+        case (.friends, .honest):
+            return "Room to get real without losing ease."
+        case (.friends, .unfiltered):
+            return "Short and direct works best here."
+        case (.family, .light):
+            return "Room for stories to unfold naturally."
+        case (.family, .honest):
+            return "A little structure, a little patience."
+        case (.family, .unfiltered):
+            return "Shorter keeps it direct and usable."
+        case (.soloReflection, .light):
+            return "A gentle stretch of reflection."
+        case (.soloReflection, .honest):
+            return "Focused, with room to go deeper."
+        case (.soloReflection, .unfiltered):
+            return "Short and honest. Easier to sit with."
+        }
+    }
+
+    private func applyRecommendedDetails() {
+        if !hasCustomizedLength {
+            selectedLength = recommendedLength
+        }
+        if !hasCustomizedFollowUps {
+            followUps = recommendedFollowUps
+        }
+        if !hasCustomizedTopic {
+            selectedTopic = nil
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        SessionBuilderView()
+            .environment(SessionManager())
+            .environment(SettingsStore())
+    }
+}

--- a/Connections/Views/SessionBuilderView.swift
+++ b/Connections/Views/SessionBuilderView.swift
@@ -39,6 +39,8 @@ struct SessionBuilderView: View {
     @State private var navigateToFallInLove = false
     @State private var navigateToFallInLoveIntro = false
     @State private var navigateToShare = false
+    @State private var navigateToFavorites = false
+    @State private var navigateToSettings = false
 
     // MARK: - Alerts
 
@@ -113,6 +115,18 @@ struct SessionBuilderView: View {
                 }
                 .padding(.leading, 4)
             }
+
+            if currentStage == .mode {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        navigateToSettings = true
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
         }
         .navigationDestination(isPresented: $navigateToSession) {
             SessionPlayView()
@@ -125,6 +139,12 @@ struct SessionBuilderView: View {
         }
         .navigationDestination(isPresented: $navigateToShare) {
             ShareExperiencePlayView()
+        }
+        .navigationDestination(isPresented: $navigateToFavorites) {
+            FavoritesPlayView()
+        }
+        .navigationDestination(isPresented: $navigateToSettings) {
+            SettingsView()
         }
         .alert("Age Confirmation", isPresented: $showAgeConfirmation) {
             Button("I'm 18 or older") {
@@ -275,6 +295,16 @@ struct SessionBuilderView: View {
                     navigateToShare = true
                 }
                 .transition(.opacity)
+
+                if !session.favorites.allFavorites.isEmpty {
+                    SelectionCard(
+                        title: "Play Favorites",
+                        subtitle: "\(session.favorites.allFavorites.count) saved prompts from past sessions"
+                    ) {
+                        navigateToFavorites = true
+                    }
+                    .transition(.opacity)
+                }
             }
         }
         .padding(.horizontal, AppSpacing.screenHorizontal)

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -1,7 +1,7 @@
 //
 //  SessionPlayView.swift
 //  Connections
-//  Animation setup
+//
 
 import SwiftUI
 
@@ -14,129 +14,126 @@ struct SessionPlayView: View {
     @State private var goDeeperPressed = false
     @State private var promptVisible = true
     @State private var followUpVisible = true
+
     var body: some View {
         ZStack {
             AtmosphericBackground(intensity: session.selectedIntensity)
 
-        VStack(spacing: 0) {
+            VStack(spacing: 0) {
 
-            // MARK: - Top Bar
+                // MARK: - Top Bar
 
-            HStack {
-                Button {
-                    session.endSession()
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 15, weight: .medium))
-                }
-                .tint(.secondary)
-
-                Spacer()
-
-                if let mode = session.selectedMode, let intensity = session.selectedIntensity {
-                    Text("\(mode.rawValue) · \(intensity.rawValue)")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                }
-
-                Spacer()
-
-                HStack(spacing: 14) {
-                    if session.connectionTracker.checkInCount > 0 {
-                        ConnectionHeartView(fillAmount: session.connectionTracker.fillAmount, size: 16)
+                HStack {
+                    Button {
+                        session.endSession()
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 15, weight: .medium))
                     }
+                    .tint(.secondary)
 
-                    if let prompt = session.currentPrompt, !session.isSessionComplete {
-                        ShareLink(item: prompt.text) {
-                            Image(systemName: "square.and.arrow.up")
-                                .font(.system(size: 14, weight: .medium))
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
+                    Spacer()
 
-            // MARK: - Progress
-
-            if !session.isSessionComplete {
-                VStack(spacing: 6) {
-                    ProgressView(value: session.sessionProgress)
-                        .tint(session.selectedIntensity?.toneColor ?? AppColor.primaryButtonBg(colorScheme))
-
-                    HStack {
-                        Text(session.currentDepth.title)
+                    if let mode = session.selectedMode, let intensity = session.selectedIntensity {
+                        Text("\(mode.rawValue) · \(intensity.rawValue)")
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(.secondary)
-
-                        Spacer()
-
-                        Text("Card \(min(session.promptsShown + 1, session.totalPrompts)) of \(session.totalPrompts)")
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(.tertiary)
                     }
-                }
-                .padding(.horizontal, 28)
-                .padding(.top, 12)
-            }
 
-            // MARK: - Content Area
+                    Spacer()
 
-            Spacer(minLength: 40)
+                    HStack(spacing: 14) {
+                        if session.connectionTracker.checkInCount > 0 {
+                            ConnectionHeartView(fillAmount: session.connectionTracker.fillAmount, size: 16)
+                        }
 
-            if session.isSessionComplete {
-                // Session complete
-                sessionCompleteContent
-            } else if session.showFeelingCheckIn {
-                // Feeling check-in interstitial
-                FeelingCheckInView { feeling in
-                    session.recordFeeling(feeling)
-                    // Brief pause before next prompt for a moment of reflection
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                        withAnimation(.easeInOut(duration: 0.25)) {
-                            promptTransitionID = UUID()
+                        if let prompt = session.currentPrompt, !session.isSessionComplete {
+                            ShareLink(item: prompt.text) {
+                                Image(systemName: "square.and.arrow.up")
+                                    .font(.system(size: 13, weight: .medium))
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
                     }
                 }
-                .transition(.opacity)
-            } else if let prompt = session.currentPrompt {
-                // Active prompt
-                promptContent(prompt)
-            }
+                .padding(.horizontal, 24)
+                .padding(.top, 12)
 
-            Spacer()
+                // MARK: - Session Content
 
-            // MARK: - Actions
+                if !session.isSessionComplete {
 
-            if session.currentPrompt != nil && !session.showFeelingCheckIn && !session.isSessionComplete {
-                actionButtons
-            }
+                    // Progress
+                    VStack(spacing: 4) {
+                        ProgressView(value: session.sessionProgress)
+                            .tint(session.selectedIntensity?.toneColor.opacity(0.45) ?? Color.primary.opacity(0.12))
 
-            // MARK: - Complete Actions
+                        HStack {
+                            Text(session.currentDepth.title)
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.tertiary)
 
-            if session.isSessionComplete {
-                Button {
-                    session.endSession()
-                    dismiss()
-                } label: {
-                    Text("Done")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 18)
-                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                            Spacer()
+
+                            Text("\(min(session.promptsShown + 1, session.totalPrompts)) of \(session.totalPrompts)")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.tertiary)
+                        }
+                    }
+                    .padding(.horizontal, 28)
+                    .padding(.top, 10)
+
+                    Spacer(minLength: 40)
+
+                    if session.showFeelingCheckIn {
+                        FeelingCheckInView { feeling in
+                            session.recordFeeling(feeling)
+                        }
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .offset(y: 10)),
+                            removal: .opacity
+                        ))
+                    } else if let prompt = session.currentPrompt {
+                        promptContent(prompt)
+                    }
+
+                    Spacer()
+
+                    if session.currentPrompt != nil && !session.showFeelingCheckIn {
+                        actionButtons
+                    }
+
+                } else {
+
+                    // MARK: Completion
+
+                    ScrollView(.vertical, showsIndicators: false) {
+                        sessionCompleteContent
+                            .padding(.top, 32)
+                            .padding(.bottom, 16)
+                    }
+
+                    Button {
+                        session.endSession()
+                        dismiss()
+                    } label: {
+                        Text("Close")
+                            .font(.system(size: 17, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 18)
+                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                    }
+                    .padding(.horizontal, 36)
+                    .padding(.bottom, 52)
                 }
-                .padding(.horizontal, 36)
-                .padding(.bottom, 52)
             }
-        }
         } // ZStack
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
-        .animation(.easeInOut(duration: 0.3), value: session.showFeelingCheckIn)
-        .animation(.easeInOut(duration: 0.3), value: session.isSessionComplete)
+        .animation(.easeOut(duration: 0.45), value: session.showFeelingCheckIn)
+        .animation(.easeInOut(duration: 0.4), value: session.isSessionComplete)
         .onChange(of: session.isSessionComplete) { _, complete in
             if complete { HapticsManager.success() }
         }
@@ -155,8 +152,7 @@ struct SessionPlayView: View {
                 .padding(.vertical, 44)
                 .id(promptTransitionID)
                 .opacity(promptVisible ? 1 : 0)
-                .offset(y: promptVisible ? 0 : 10)
-                .animation(.easeInOut(duration: 0.2), value: promptVisible)
+                .offset(y: promptVisible ? 0 : 12)
 
             if !session.shownFollowUps.isEmpty && session.followUpsEnabled {
                 VStack(spacing: 8) {
@@ -172,11 +168,10 @@ struct SessionPlayView: View {
                             )
                     }
                 }
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .transition(.opacity.combined(with: .offset(y: 8)))
                 .padding(.bottom, 24)
                 .opacity(followUpVisible ? 1 : 0)
                 .offset(y: followUpVisible ? 0 : 8)
-                .animation(.easeInOut(duration: 0.2), value: followUpVisible)
             }
         }
     }
@@ -186,144 +181,127 @@ struct SessionPlayView: View {
     private var actionButtons: some View {
         VStack(spacing: 0) {
 
-            // MARK: Follow-up questions (above primary actions, with breathing room)
-
+            // Go deeper — contextual invitation, close to the conversational layer
             if session.followUpsEnabled && session.hasMoreFollowUps {
-                VStack(spacing: 6) {
-                    Button {
-                        goDeeperPressed = true
-                        HapticsManager.mediumImpact()
-                        session.recordGoDeeper()
-                        withAnimation(.easeOut(duration: 0.12)) {
-                            followUpVisible = false
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                            session.revealNextFollowUp()
-                            withAnimation(.easeIn(duration: 0.2)) {
-                                followUpVisible = true
-                            }
-                        }
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                            goDeeperPressed = false
-                        }
-                    } label: {
-                        HStack(spacing: 6) {
-                            Image(systemName: "sparkles")
-                                .font(.system(size: 13, weight: .semibold))
-                            Text("Go deeper")
-                                .font(.system(size: 15, weight: .semibold))
-                        }
-                        .foregroundStyle(.primary)
-                        .padding(.horizontal, 22)
-                        .padding(.vertical, 12)
-                        .background(
-                            Capsule()
-                                .fill(session.selectedIntensity?.cardTint.opacity(0.18) ?? Color.primary.opacity(0.1))
-                        )
-                        .overlay(
-                            Capsule()
-                                .strokeBorder(session.selectedIntensity?.cardTint.opacity(0.35) ?? Color.primary.opacity(0.2), lineWidth: 1)
-                        )
-                        .scaleEffect(goDeeperPressed ? 0.95 : 1.0)
-                        .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
+                Button {
+                    goDeeperPressed = true
+                    HapticsManager.mediumImpact()
+                    session.recordGoDeeper()
+                    withAnimation(.easeOut(duration: 0.15)) {
+                        followUpVisible = false
                     }
-                    .buttonStyle(.plain)
-
-
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        session.revealNextFollowUp()
+                        withAnimation(.spring(response: 0.4, dampingFraction: 0.82)) {
+                            followUpVisible = true
+                        }
+                    }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        goDeeperPressed = false
+                    }
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 12))
+                        Text("Go deeper")
+                            .font(.system(size: 14, weight: .medium))
+                    }
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 10)
+                    .background(
+                        Capsule()
+                            .fill(session.selectedIntensity?.cardTint.opacity(0.12) ?? Color.primary.opacity(0.06))
+                    )
+                    .scaleEffect(goDeeperPressed ? 0.96 : 1.0)
+                    .animation(.easeOut(duration: 0.15), value: goDeeperPressed)
                 }
-                .padding(.bottom, 20)
+                .buttonStyle(.plain)
+                .padding(.bottom, 16)
                 .transition(.opacity)
             }
 
-            // MARK: Back / Next
-
-            HStack(spacing: 12) {
-                if session.canGoBack {
-                    Button {
-                        HapticsManager.lightImpact()
-
-                        withAnimation(.easeOut(duration: 0.16)) {
-                            promptVisible = false
-                            followUpVisible = false
-                        }
-
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                            session.goBack()
-                            promptTransitionID = UUID()
-                            promptVisible = true
-                            followUpVisible = true
-                        }
-                    } label: {
-                        Text("Back")
-                            .font(.system(size: 15, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 16)
-                            .background(AppColor.surface(colorScheme), in: .capsule)
-                    }
+            // Next — primary forward action
+            Button {
+                HapticsManager.lightImpact()
+                withAnimation(.easeOut(duration: 0.2)) {
+                    promptVisible = false
+                    followUpVisible = false
                 }
-
-                Button {
-                    HapticsManager.lightImpact()
-                    withAnimation(.easeOut(duration: 0.16)) {
-                        promptVisible = false
-                        followUpVisible = false
-                    }
-
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.16) {
-                        session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
-                        promptTransitionID = UUID()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                    session.continuePrompt(isFavorited: session.isCurrentPromptFavorited())
+                    promptTransitionID = UUID()
+                    withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
                         promptVisible = true
                         followUpVisible = true
                     }
-                } label: {
-                    Text("Next")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
                 }
+            } label: {
+                Text("Next")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
             }
 
-            // MARK: Favorite + Check in (post-follow-up)
-
-            HStack(spacing: 28) {
-                Button {
-                    if !session.isCurrentPromptFavorited() {
-                        HapticsManager.lightImpact()
-                    }
-                    session.toggleFavoriteCurrentPrompt()
-                } label: {
-                    Image(systemName: session.isCurrentPromptFavorited() ? "heart.fill" : "heart")
-                        .font(.system(size: 22))
-                        .foregroundColor(session.isCurrentPromptFavorited() ? .red : .gray)
-                        .scaleEffect(session.isCurrentPromptFavorited() ? 1.15 : 1.0)
-                        .animation(.spring(response: 0.25, dampingFraction: 0.6), value: session.isCurrentPromptFavorited())
-                }
-                .buttonStyle(.plain)
-
-                if session.followUpsEnabled && !session.shownFollowUps.isEmpty && !session.hasMoreFollowUps {
+            // Secondary — Back, Check in, Favorite
+            HStack {
+                if session.canGoBack {
                     Button {
-                        session.recordGoDeeper()
-                        session.triggerCheckInFromGoDeeper()
-                    } label: {
-                        HStack(spacing: 5) {
-                            Image(systemName: "arrow.down.circle")
-                                .font(.system(size: 13, weight: .medium))
-                            Text("Check in")
-                                .font(.system(size: 13, weight: .medium))
+                        HapticsManager.lightImpact()
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            promptVisible = false
+                            followUpVisible = false
                         }
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(Capsule().fill(AppColor.primaryButtonBg(colorScheme)))
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            session.goBack()
+                            promptTransitionID = UUID()
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                promptVisible = true
+                                followUpVisible = true
+                            }
+                        }
+                    } label: {
+                        Text("Back")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.tertiary)
                     }
                     .buttonStyle(.plain)
-                    .transition(.opacity)
+                }
+
+                Spacer()
+
+                HStack(spacing: 20) {
+                    if session.followUpsEnabled && !session.shownFollowUps.isEmpty && !session.hasMoreFollowUps {
+                        Button {
+                            session.recordGoDeeper()
+                            session.triggerCheckInFromGoDeeper()
+                        } label: {
+                            Text("Check in")
+                                .font(.system(size: 13, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                        .transition(.opacity)
+                    }
+
+                    Button {
+                        if !session.isCurrentPromptFavorited() {
+                            HapticsManager.lightImpact()
+                        }
+                        session.toggleFavoriteCurrentPrompt()
+                    } label: {
+                        Image(systemName: session.isCurrentPromptFavorited() ? "heart.fill" : "heart")
+                            .font(.system(size: 18))
+                            .foregroundColor(session.isCurrentPromptFavorited() ? .red : Color.primary.opacity(0.2))
+                            .scaleEffect(session.isCurrentPromptFavorited() ? 1.1 : 1.0)
+                            .animation(.spring(response: 0.25, dampingFraction: 0.6), value: session.isCurrentPromptFavorited())
+                    }
+                    .buttonStyle(.plain)
                 }
             }
-            .padding(.top, 16)
+            .padding(.top, 14)
         }
         .padding(.horizontal, 28)
         .padding(.bottom, 48)
@@ -333,7 +311,7 @@ struct SessionPlayView: View {
     // MARK: - Session Complete Content
 
     private var sessionCompleteContent: some View {
-        VStack(spacing: 24) {
+        VStack(spacing: 28) {
             if session.connectionTracker.checkInCount > 0 {
                 ConnectionHeartLargeView(
                     fillAmount: session.connectionTracker.fillAmount,
@@ -341,28 +319,28 @@ struct SessionPlayView: View {
                 )
             }
 
-            Text("Something was shared here")
-                .font(.system(size: 28, weight: .regular, design: .serif))
+            VStack(spacing: 12) {
+                Text("Something was shared here")
+                    .font(.system(size: 28, weight: .regular, design: .serif))
+                    .multilineTextAlignment(.center)
 
-            VStack(spacing: 6) {
-                Text("\(session.responses.filter { $0.action == .continued }.count) prompts answered")
+                Text("You stayed for \(session.responses.filter { $0.action == .continued }.count) prompts")
                     .font(.system(size: 15))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.tertiary)
 
                 if session.connectionTracker.checkInCount > 0 {
                     Text(session.connectionTracker.connectionLevel.completionMessage)
-                        .font(.system(size: 14, weight: .regular, design: .serif))
+                        .font(.system(size: 15, weight: .regular, design: .serif))
                         .foregroundStyle(.secondary)
                         .italic()
-                        .padding(.top, 4)
                 }
             }
 
             // Session Summary
             if let summary = session.generateSummary() {
-                VStack(spacing: 12) {
+                VStack(spacing: 10) {
                     Text(summary.title)
-                        .font(.system(size: 18, weight: .medium, design: .serif))
+                        .font(.system(size: 17, weight: .medium, design: .serif))
 
                     VStack(spacing: 4) {
                         ForEach(summary.reflectionLines, id: \.self) { line in
@@ -375,44 +353,37 @@ struct SessionPlayView: View {
 
                     if let nextStep = summary.nextStep {
                         Text(nextStep)
-                            .font(.system(size: 13, weight: .regular, design: .serif))
-                            .foregroundStyle(.secondary)
+                            .font(.system(size: 14, weight: .regular, design: .serif))
+                            .foregroundStyle(.tertiary)
                             .italic()
-                            .padding(.top, 4)
+                            .padding(.top, 2)
                     }
                 }
                 .padding(.horizontal, 32)
-                .padding(.top, 8)
             }
 
             // Standout Prompts
             let standout = session.standoutPromptInteractions(limit: 3)
-
             if !standout.isEmpty {
-                VStack(alignment: .leading, spacing: 12) {
+                VStack(spacing: 12) {
                     Text("Moments you stayed with")
-                        .font(.system(size: 18, weight: .medium, design: .serif))
+                        .font(.system(size: 16, weight: .medium, design: .serif))
 
-                    Text("You spent more time on these questions or chose to go deeper.")
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-
-                    VStack(alignment: .leading, spacing: 8) {
+                    VStack(spacing: 10) {
                         ForEach(standout, id: \.promptID) { interaction in
-                            Text("• \(interaction.promptText)")
-                                .font(.system(size: 14))
+                            Text(interaction.promptText)
+                                .font(.system(size: 14, design: .serif))
                                 .foregroundStyle(.secondary)
-                                .fixedSize(horizontal: false, vertical: true)
+                                .multilineTextAlignment(.center)
+                                .italic()
                         }
                     }
                 }
                 .padding(.horizontal, 32)
-                .padding(.top, 16)
             }
         }
+        .padding(.horizontal, 4)
     }
-
-
 }
 
 #Preview {

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -211,7 +211,7 @@ struct SessionSetupView: View {
 
 // MARK: - Length Option
 
-private struct LengthOption: View {
+struct LengthOption: View {
     @Environment(\.colorScheme) private var colorScheme
     let label: String
     let isSelected: Bool
@@ -236,7 +236,7 @@ private struct LengthOption: View {
 
 // MARK: - Topic Selector
 
-private struct TopicSelector: View {
+struct TopicSelector: View {
     @Binding var selectedTopic: Topic?
     let availableTopics: [Topic]
     var mode: Mode? = nil
@@ -292,11 +292,11 @@ private struct TopicSelector: View {
 
 // MARK: - Topic Chip
 
-private enum TopicChipState {
+enum TopicChipState {
     case selected, available, locked
 }
 
-private struct TopicChip: View {
+struct TopicChip: View {
     @Environment(\.colorScheme) private var colorScheme
     let label: String
     let state: TopicChipState
@@ -347,7 +347,7 @@ private struct TopicChip: View {
 
 // MARK: - Flow Layout
 
-private struct FlowLayout: Layout {
+struct FlowLayout: Layout {
     var spacing: CGFloat = 8
 
     func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {

--- a/Connections/Views/ShareExperiencePlayView.swift
+++ b/Connections/Views/ShareExperiencePlayView.swift
@@ -7,118 +7,144 @@ import SwiftUI
 
 struct ShareExperiencePlayView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
 
     @State private var selectedIntensity: Intensity?
     @State private var currentExperience: ShareExperience?
     @State private var experienceHistory: [ShareExperience] = []
-    @State private var transitionID = UUID()
+    @State private var promptTransitionID = UUID()
+    @State private var promptVisible = true
+    @State private var isTransitioning = false
 
     private let bank = ShareExperienceBank.shared
 
     var body: some View {
-        VStack(spacing: 0) {
+        ZStack {
+            AtmosphericBackground(intensity: selectedIntensity)
 
-            // MARK: - Top Bar
+            VStack(spacing: 0) {
 
-            HStack {
-                Button {
-                    dismiss()
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 15, weight: .medium))
+                // MARK: - Top Bar
+
+                HStack {
+                    CloseButton { dismiss() }
+
+                    Spacer()
+
+                    TopBarLabel(text: "Share an Experience")
+
+                    Spacer()
+
+                    // Balance the close button width
+                    Color.clear.frame(width: AppIcon.navSize, height: AppIcon.navSize)
                 }
-                .tint(.secondary)
+                .padding(.horizontal, AppSpacing.screenHorizontal)
+                .padding(.top, AppSpacing.topBarTop)
 
-                Spacer()
+                // MARK: - Intensity Filter
 
-                Text("Share an Experience")
-                    .font(.system(size: 13))
-                    .foregroundStyle(.tertiary)
-
-                Spacer()
-
-                Color.clear.frame(width: 15, height: 15)
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 12)
-
-            // MARK: - Intensity Filter
-
-            HStack(spacing: 10) {
-                filterPill(label: "All", intensity: nil)
-                ForEach(Intensity.allCases) { intensity in
-                    filterPill(label: intensity.rawValue, intensity: intensity)
-                }
-            }
-            .padding(.top, 24)
-
-            // MARK: - Experience Card
-
-            Spacer()
-
-            if let experience = currentExperience {
-                VStack(spacing: 16) {
-                    Text("Share an experience that was...")
-                        .font(.system(size: 15))
-                        .foregroundStyle(.secondary)
-
-                    Text(experience.text)
-                        .font(.system(size: 32, weight: .regular, design: .serif))
-                        .multilineTextAlignment(.center)
-                        .lineSpacing(6)
-                        .padding(.horizontal, 32)
-                        .id(transitionID)
-                        .transition(.opacity)
-
-                    Text(experience.topic.displayName)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 4)
-                }
-                .padding(.horizontal, 24)
-            } else {
-                Text("No experiences match this filter")
-                    .font(.system(size: 17))
-                    .foregroundStyle(.secondary)
-            }
-
-            Spacer()
-
-            // MARK: - Back / Next
-
-            HStack(spacing: 12) {
-                if !experienceHistory.isEmpty {
-                    Button {
-                        goBackExperience()
-                    } label: {
-                        Text("Back")
-                            .font(.system(size: 17, weight: .medium))
-                            .foregroundStyle(.secondary)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 18)
-                            .background(Color.primary.opacity(0.04), in: .capsule)
+                HStack(spacing: 10) {
+                    filterPill(label: "All", intensity: nil)
+                    ForEach(Intensity.allCases) { intensity in
+                        filterPill(label: intensity.rawValue, intensity: intensity)
                     }
                 }
+                .padding(.top, 24)
 
-                Button {
-                    nextExperience()
-                } label: {
-                    Text("Next")
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(.white)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 18)
-                        .background(Color(.darkGray), in: .capsule)
+                // MARK: - Experience Content
+
+                Spacer()
+
+                if let experience = currentExperience {
+                    VStack(spacing: 16) {
+                        Text("Share an experience that was...")
+                            .font(AppFont.caption())
+                            .foregroundStyle(.secondary)
+
+                        Text(experience.text)
+                            .font(.system(size: 32, weight: .regular, design: .serif))
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(6)
+                            .padding(.horizontal, AppSpacing.promptHorizontal)
+
+                        Text(experience.topic.displayName)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.tertiary)
+                            .padding(.top, 4)
+                    }
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
+                    .id(promptTransitionID)
+                    .opacity(promptVisible ? 1 : 0)
+                    .offset(y: promptVisible ? 0 : 12)
+                } else {
+                    Text("No experiences match this filter")
+                        .font(AppFont.subtitle())
+                        .foregroundStyle(.secondary)
                 }
+
+                Spacer()
+
+                // MARK: - Actions
+
+                VStack(spacing: 0) {
+                    Button {
+                        guard !isTransitioning else { return }
+                        isTransitioning = true
+                        HapticsManager.lightImpact()
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            promptVisible = false
+                        }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            advanceExperience()
+                            promptTransitionID = UUID()
+                            isTransitioning = false
+                            withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                promptVisible = true
+                            }
+                        }
+                    } label: {
+                        Text("Next")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 16)
+                            .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                    }
+
+                    if !experienceHistory.isEmpty {
+                        Button {
+                            guard !isTransitioning else { return }
+                            isTransitioning = true
+                            HapticsManager.lightImpact()
+                            withAnimation(.easeOut(duration: 0.2)) {
+                                promptVisible = false
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                goBackExperience()
+                                promptTransitionID = UUID()
+                                isTransitioning = false
+                                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                                    promptVisible = true
+                                }
+                            }
+                        } label: {
+                            Text("Back")
+                                .font(.system(size: 14, weight: .medium))
+                                .foregroundStyle(.tertiary)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.top, 14)
+                    }
+                }
+                .padding(.horizontal, AppSpacing.contentHorizontal)
+                .padding(.bottom, 48)
+                .animation(.easeOut(duration: 0.2), value: experienceHistory.isEmpty)
             }
-            .padding(.horizontal, 36)
-            .padding(.bottom, 52)
         }
-        .background((selectedIntensity?.backgroundTint ?? Color.clear).ignoresSafeArea())
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
         .onAppear {
-            nextExperience()
+            currentExperience = bank.getRandomExperience(intensity: selectedIntensity)
         }
     }
 
@@ -127,9 +153,22 @@ struct ShareExperiencePlayView: View {
     private func filterPill(label: String, intensity: Intensity?) -> some View {
         let isSelected = selectedIntensity == intensity
         return Button {
-            selectedIntensity = intensity
-            experienceHistory = []
-            nextExperience()
+            guard selectedIntensity != intensity, !isTransitioning else { return }
+            isTransitioning = true
+            HapticsManager.lightImpact()
+            withAnimation(.easeOut(duration: 0.2)) {
+                promptVisible = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                selectedIntensity = intensity
+                experienceHistory = []
+                currentExperience = bank.getRandomExperience(intensity: intensity)
+                promptTransitionID = UUID()
+                isTransitioning = false
+                withAnimation(.spring(response: 0.4, dampingFraction: 0.85)) {
+                    promptVisible = true
+                }
+            }
         } label: {
             Text(label)
                 .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
@@ -140,30 +179,25 @@ struct ShareExperiencePlayView: View {
                     Capsule()
                         .fill(isSelected
                               ? (intensity?.selectedTint ?? Color.primary.opacity(0.10))
-                              : Color.primary.opacity(0.04))
+                              : AppColor.surface(colorScheme))
                 )
+                .animation(.easeOut(duration: 0.2), value: selectedIntensity?.rawValue)
         }
         .buttonStyle(.plain)
     }
 
     // MARK: - Helpers
 
-    private func nextExperience() {
+    private func advanceExperience() {
         if let current = currentExperience {
             experienceHistory.append(current)
         }
-        withAnimation(.easeInOut(duration: 0.25)) {
-            currentExperience = bank.getRandomExperience(intensity: selectedIntensity)
-            transitionID = UUID()
-        }
+        currentExperience = bank.getRandomExperience(intensity: selectedIntensity)
     }
 
     private func goBackExperience() {
         guard let previous = experienceHistory.popLast() else { return }
-        withAnimation(.easeInOut(duration: 0.25)) {
-            currentExperience = previous
-            transitionID = UUID()
-        }
+        currentExperience = previous
     }
 }
 

--- a/Connections/Views/ShareExperiencePlayView.swift
+++ b/Connections/Views/ShareExperiencePlayView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 
 struct ShareExperiencePlayView: View {
+    @Environment(SessionManager.self) private var session
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
 
@@ -15,6 +16,7 @@ struct ShareExperiencePlayView: View {
     @State private var promptTransitionID = UUID()
     @State private var promptVisible = true
     @State private var isTransitioning = false
+    @State private var showAboutSheet = false
 
     private let bank = ShareExperienceBank.shared
 
@@ -35,8 +37,17 @@ struct ShareExperiencePlayView: View {
 
                     Spacer()
 
-                    // Balance the close button width
-                    Color.clear.frame(width: AppIcon.navSize, height: AppIcon.navSize)
+                    HStack(spacing: 16) {
+                        Button {
+                            showAboutSheet = true
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .font(.system(size: AppIcon.navSize, weight: AppIcon.navWeight))
+                                .foregroundStyle(.tertiary)
+                        }
+
+                        heartButton
+                    }
                 }
                 .padding(.horizontal, AppSpacing.screenHorizontal)
                 .padding(.top, AppSpacing.topBarTop)
@@ -143,9 +154,29 @@ struct ShareExperiencePlayView: View {
         }
         .navigationBarBackButtonHidden(true)
         .toolbar(.hidden, for: .navigationBar)
+        .sheet(isPresented: $showAboutSheet) {
+            ShareExperienceAboutSheet()
+        }
         .onAppear {
             currentExperience = bank.getRandomExperience(intensity: selectedIntensity)
         }
+    }
+
+    // MARK: - Heart Button
+
+    private var heartButton: some View {
+        let isFavorited = currentExperience.map { session.isExperienceFavorited($0) } ?? false
+        return Button {
+            guard !isTransitioning, let experience = currentExperience else { return }
+            HapticsManager.lightImpact()
+            session.toggleExperienceFavorite(experience)
+        } label: {
+            Image(systemName: isFavorited ? "heart.fill" : "heart")
+                .font(.system(size: 18))
+                .foregroundStyle(isFavorited ? Color.red : Color.secondary.opacity(0.4))
+                .animation(.spring(response: 0.25, dampingFraction: 0.6), value: isFavorited)
+        }
+        .buttonStyle(.plain)
     }
 
     // MARK: - Filter Pill
@@ -201,8 +232,81 @@ struct ShareExperiencePlayView: View {
     }
 }
 
+// MARK: - About Sheet
+
+private struct ShareExperienceAboutSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Spacer()
+                .frame(height: 48)
+
+            Text("About this mode")
+                .font(AppFont.promptText())
+                .padding(.bottom, 24)
+
+            VStack(alignment: .leading, spacing: 14) {
+                BulletPoint("These prompts follow a structured progression — starting with lighter sharing and moving gradually toward deeper vulnerability — designed to build closeness naturally between two people")
+                BulletPoint("This format is based on a well-studied model of interpersonal closeness that has shown consistent results in increasing connection, even between people who have just met")
+                BulletPoint("It works because closeness isn't random — it follows from mutual honesty, genuine attention, and a willingness to be present with each other")
+                BulletPoint("The deeper prompts can be unexpectedly powerful. Approach them with care and intention — this works best when both people feel safe enough to be honest")
+            }
+            .padding(.horizontal, AppSpacing.buttonHorizontal)
+
+            Text("This isn't small talk.\nTreat it like it matters, and it will.")
+                .font(AppFont.subtitle())
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineSpacing(5)
+                .padding(.horizontal, AppSpacing.buttonHorizontal)
+                .padding(.top, 28)
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Text("Got it")
+                    .font(.system(size: 17, weight: .semibold))
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 18)
+                    .foregroundStyle(.white)
+                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+            }
+            .padding(.horizontal, AppSpacing.buttonHorizontal)
+            .padding(.bottom, AppSpacing.bottomPadding)
+        }
+        .presentationDragIndicator(.visible)
+    }
+}
+
+private struct BulletPoint: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text("•")
+                .font(AppFont.subtitle())
+                .fontWeight(.medium)
+                .foregroundStyle(.tertiary)
+
+            Text(text)
+                .font(AppFont.subtitle())
+                .foregroundStyle(.secondary)
+                .lineSpacing(4)
+        }
+    }
+}
+
 #Preview {
     NavigationStack {
         ShareExperiencePlayView()
+            .environment(SessionManager())
     }
 }


### PR DESCRIPTION
## Summary
- **Session Builder**: Replace the 3-screen setup flow (Mode → Intensity → Details) with a single progressive view where selections collapse into summary rows as new sections reveal below, with spring animations and matched geometry transitions
- **Secondary screen modernization**: Bring ShareExperiencePlayView, FallInLovePlayView, FavoritesPlayView, and FallInLoveIntroView up to the current design language — AtmosphericBackground, fade-out → spring-in transitions, consistent top bars, AppFont/AppSpacing tokens, haptics
- **Guided flow favorites**: Extend FavoritesStore with `source`/`sourceID` fields so prompts from Share Experience and 36 Questions can be saved and reviewed in FavoritesPlayView with proper context labels
- **Transition safety**: Add `isTransitioning` guards and `transitionGeneration` counters to prevent rapid-tap corruption and reset-race conditions across all play views
- **Copy refinements**: Research-informed rewrites for FallInLoveIntroView "Why This Works" sheet and ShareExperiencePlayView about sheet

## Files changed (13 files, +2137 / −838)
- `SessionBuilderView.swift` — New unified setup view
- `SummaryRow.swift` — Compact row component for collapsed selections
- `HomeView.swift` — Point "Start Session" at SessionBuilderView
- `SessionSetupView.swift` — Promote shared components to internal access
- `SessionManager.swift` — FavoritesStore cross-surface support, new convenience methods
- `ShareExperiencePlayView.swift` — Full modernization + favorites + about sheet
- `FallInLovePlayView.swift` — Full modernization + favorites + generation counter
- `FavoritesPlayView.swift` — Full modernization + multi-source context labels
- `FallInLoveIntroView.swift` — Token cleanup + copy rewrite
- `SessionPlayView.swift` — Polish pass (live session refinements)
- `OnboardingView.swift` — Refinements
- `FeelingCheckInView.swift` — Minor adjustments
- `PromptBank.swift` — Prompt coverage updates

## Test plan
- [ ] Home → Start Session opens the Session Builder (not ModeSelectionView)
- [ ] Mode cards → tap one → collapses to summary row, intensity cards reveal with spring animation
- [ ] Tap "Change" on mode summary → reverts to mode selection, intensity disappears
- [ ] Intensity → tap one → collapses, details section reveals, background tint shifts
- [ ] Details: question count, topics, follow-ups toggle all function correctly
- [ ] "Sex" topic triggers age confirmation alert
- [ ] "Fall in Love" hides count/follow-ups, button says "Begin", navigates correctly
- [ ] Share Experience: favorites heart toggles, about sheet opens with copy, transitions are smooth
- [ ] Fall in Love: favorites heart toggles, menu works, Start Over uses generation counter safely
- [ ] Favorites: multi-source entries show correct context labels (session / Share Experience / 36 Questions)
- [ ] All play views: rapid tapping does not corrupt navigation or prompt state

🤖 Generated with [Claude Code](https://claude.com/claude-code)