### PR TITLE
Add Mixed tone option to session setup flow

### DIFF
--- a/Connections/Components/AtmosphericBackground.swift
+++ b/Connections/Components/AtmosphericBackground.swift
@@ -94,6 +94,29 @@ struct AtmosphericBackground: View {
                 Color.black.opacity(0.02)
             }
 
+        case .mixed:
+            ZStack {
+                Color(red: 0.96, green: 0.97, blue: 0.96)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.97, green: 0.97, blue: 0.96),
+                        Color(red: 0.92, green: 0.93, blue: 0.92)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.93, green: 0.96, blue: 0.94).opacity(0.08),
+                        Color.white.opacity(0.0)
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+                Color.black.opacity(0.02)
+            }
+
         default:
             Color(red: 0.99, green: 0.96, blue: 0.90)
         }
@@ -162,6 +185,28 @@ struct AtmosphericBackground: View {
                 RadialGradient(
                     colors: [
                         Color(red: 0.13, green: 0.10, blue: 0.16).opacity(0.25),
+                        Color.clear
+                    ],
+                    center: .top,
+                    startRadius: 0,
+                    endRadius: 500
+                )
+            }
+
+        case .mixed:
+            ZStack {
+                Color(red: 0.08, green: 0.08, blue: 0.08)
+                LinearGradient(
+                    colors: [
+                        Color(red: 0.09, green: 0.09, blue: 0.09),
+                        Color(red: 0.07, green: 0.07, blue: 0.07)
+                    ],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+                RadialGradient(
+                    colors: [
+                        Color(red: 0.10, green: 0.13, blue: 0.11).opacity(0.25),
                         Color.clear
                     ],
                     center: .top,

--- a/Connections/Data/PromptBank.swift
+++ b/Connections/Data/PromptBank.swift
@@ -24,9 +24,19 @@ struct PromptBank {
         prompts.filter { $0.mode == mode && $0.intensity == intensity && $0.depthLevel <= depthLevel }
     }
 
+    /// Returns prompts for the given mode across multiple intensities up to the unlocked depth.
+    func prompts(for mode: Mode, intensities: [Intensity], unlockedThrough depthLevel: DepthLevel) -> [Prompt] {
+        let set = Set(intensities)
+        return prompts.filter { $0.mode == mode && set.contains($0.intensity) && $0.depthLevel <= depthLevel }
+    }
+
     /// Returns topics that have at least one prompt for the given mode and intensity,
     /// plus any guided-flow topics available for that mode.
     func availableTopics(for mode: Mode, intensity: Intensity) -> [Topic] {
+        if intensity == .mixed {
+            let present = Set(prompts.filter { $0.mode == mode && Intensity.concrete.contains($0.intensity) }.map(\.topic))
+            return Topic.availableFor(mode: mode).filter { $0.isGuidedFlow || present.contains($0) }
+        }
         let present = Set(prompts.filter { $0.mode == mode && $0.intensity == intensity }.map(\.topic))
         return Topic.availableFor(mode: mode).filter { $0.isGuidedFlow || present.contains($0) }
     }

--- a/Connections/Models/IntensityTone.swift
+++ b/Connections/Models/IntensityTone.swift
@@ -14,6 +14,7 @@ extension Intensity {
         case .light:      return Color(red: 0.95, green: 0.78, blue: 0.42)
         case .honest:     return Color(red: 0.42, green: 0.62, blue: 0.78)
         case .unfiltered: return Color(red: 0.52, green: 0.40, blue: 0.72)
+        case .mixed:      return Color(red: 0.52, green: 0.60, blue: 0.55)
         }
     }
 

--- a/Connections/Models/Models.swift
+++ b/Connections/Models/Models.swift
@@ -38,6 +38,7 @@ enum Intensity: String, CaseIterable, Identifiable, Codable {
     case light = "Light"
     case honest = "Honest"
     case unfiltered = "Unfiltered"
+    case mixed = "Mixed"
 
     var id: String { rawValue }
 
@@ -46,14 +47,19 @@ enum Intensity: String, CaseIterable, Identifiable, Codable {
         case .light: return "Easy and low-pressure"
         case .honest: return "Meaningful and reflective"
         case .unfiltered: return "Deep and emotionally revealing"
+        case .mixed: return "A natural blend of tones"
         }
     }
+
+    /// The three concrete (non-mixed) intensities.
+    static let concrete: [Intensity] = [.light, .honest, .unfiltered]
 
     var next: Intensity? {
         switch self {
         case .light: return .honest
         case .honest: return .unfiltered
         case .unfiltered: return nil
+        case .mixed: return nil
         }
     }
 
@@ -62,6 +68,7 @@ enum Intensity: String, CaseIterable, Identifiable, Codable {
         case .light: return nil
         case .honest: return .light
         case .unfiltered: return .honest
+        case .mixed: return nil
         }
     }
 }

--- a/Connections/Services/EntitlementStore.swift
+++ b/Connections/Services/EntitlementStore.swift
@@ -46,4 +46,8 @@ final class EntitlementStore {
     var canUseFallInLove: Bool { isPremium }
     var canUseShareExperience: Bool { isPremium }
     var canUseLifeStory: Bool { isPremium }
+
+    var mixedIntensities: [Intensity] {
+        isPremium ? [.light, .honest, .unfiltered] : [.light, .honest]
+    }
 }

--- a/Connections/Services/SessionManager.swift
+++ b/Connections/Services/SessionManager.swift
@@ -37,6 +37,9 @@ final class SessionManager {
     /// Session-only setting — reset each time a new session starts.
     var followUpsEnabled: Bool = true
 
+    /// Concrete intensities used when selectedIntensity is .mixed. Set by the view before starting.
+    var mixedIntensities: [Intensity] = [.light, .honest]
+
     // MARK: - Active Session State
 
     private(set) var currentPrompt: Prompt?
@@ -67,6 +70,9 @@ final class SessionManager {
 
     /// Lightweight topic history to reduce clumping and create a smoother session rhythm.
     private var recentTopics: [Topic] = []
+
+    /// Lightweight intensity history for mixed sessions to avoid clumping into one tone.
+    private var recentPromptIntensities: [Intensity] = []
 
     /// Session-wide topic counts so we can gently reward variety over repetition.
     private var shownTopicCounts: [Topic: Int] = [:]
@@ -132,6 +138,7 @@ final class SessionManager {
         shownPromptIDs = []
         promptHistory = []
         recentTopics = []
+        recentPromptIntensities = []
         shownTopicCounts = [:]
         goDeeperCount = 0
         interactions = [:]
@@ -307,6 +314,7 @@ final class SessionManager {
         shownPromptIDs = []
         promptHistory = []
         recentTopics = []
+        recentPromptIntensities = []
         shownTopicCounts = [:]
         continuedAtCurrentDepth = 0
         goDeeperCount = 0
@@ -510,8 +518,14 @@ final class SessionManager {
     private func nextPrompt() -> Prompt? {
         guard let mode = selectedMode, let intensity = selectedIntensity else { return nil }
 
-        let all = PromptBank.shared
-            .prompts(for: mode, intensity: intensity, unlockedThrough: currentDepth)
+        let all: [Prompt]
+        if intensity == .mixed {
+            all = PromptBank.shared
+                .prompts(for: mode, intensities: mixedIntensities, unlockedThrough: currentDepth)
+        } else {
+            all = PromptBank.shared
+                .prompts(for: mode, intensity: intensity, unlockedThrough: currentDepth)
+        }
 
         // Filter out already-shown prompts when avoid repeats is enabled.
         var available = avoidRepeats ? all.filter { !shownPromptIDs.contains($0.id) } : all
@@ -538,6 +552,13 @@ final class SessionManager {
             recentTopics.removeFirst(recentTopics.count - 3)
         }
         shownTopicCounts[chosen.topic, default: 0] += 1
+
+        if intensity == .mixed {
+            recentPromptIntensities.append(chosen.intensity)
+            if recentPromptIntensities.count > 3 {
+                recentPromptIntensities.removeFirst(recentPromptIntensities.count - 3)
+            }
+        }
         return chosen
     }
 
@@ -595,6 +616,15 @@ final class SessionManager {
             }
         }
 
+        // For mixed sessions, discourage consecutive same-intensity prompts.
+        if selectedIntensity == .mixed {
+            if prompt.intensity == recentPromptIntensities.last {
+                score -= 3
+            }
+            let recentIntensityMatches = recentPromptIntensities.filter { $0 == prompt.intensity }.count
+            score -= recentIntensityMatches
+        }
+
         return score
     }
 
@@ -602,7 +632,8 @@ final class SessionManager {
     private func topicAffinityScore(for prompt: Prompt) -> Int {
         guard let mode = selectedMode, let intensity = selectedIntensity else { return 0 }
 
-        let preferredTopics = preferredTopics(for: mode, intensity: intensity, depth: prompt.depthLevel)
+        let lookupIntensity = intensity == .mixed ? prompt.intensity : intensity
+        let preferredTopics = preferredTopics(for: mode, intensity: lookupIntensity, depth: prompt.depthLevel)
         guard let index = preferredTopics.firstIndex(of: prompt.topic) else { return -2 }
 
         // Earlier-listed topics are a stronger fit for that mode/intensity/depth slice.
@@ -612,8 +643,9 @@ final class SessionManager {
     /// Follow-up pacing by tone/depth so "Go deeper" feels guided instead of random.
     private func preferredFollowUpStyles(for prompt: Prompt, revealIndex: Int) -> [FollowUpStyle] {
         let stagedOrder: [FollowUpStyle]
+        let resolvedIntensity = prompt.intensity == .mixed ? Intensity.honest : prompt.intensity
 
-        switch (prompt.intensity, prompt.depthLevel, revealIndex) {
+        switch (resolvedIntensity, prompt.depthLevel, revealIndex) {
         case (.light, .warmUp, _):
             stagedOrder = [.origin, .meaning, .impact, .need, .tension]
 
@@ -656,6 +688,9 @@ final class SessionManager {
             stagedOrder = [.need, .meaning, .tension, .impact, .origin]
         case (.unfiltered, .deepDive, _):
             stagedOrder = [.tension, .need, .meaning, .impact, .origin]
+
+        case (.mixed, _, _):
+            stagedOrder = [.meaning, .origin, .impact, .need, .tension]
         }
 
         return stagedOrder
@@ -663,7 +698,8 @@ final class SessionManager {
 
     /// Topic ordering by mode/intensity/depth. This keeps sessions feeling guided without making them deterministic.
     private func preferredTopics(for mode: Mode, intensity: Intensity, depth: DepthLevel) -> [Topic] {
-        switch (mode, intensity, depth) {
+        let resolvedIntensity = intensity == .mixed ? Intensity.honest : intensity
+        switch (mode, resolvedIntensity, depth) {
         case (.couples, .light, .warmUp):
             return [.appreciation, .dailyLife, .communication, .identity, .parenting, .past, .values]
         case (.couples, .light, .realTalk):
@@ -747,6 +783,9 @@ final class SessionManager {
             return [.identity, .growth, .emotions, .past, .dailyLife, .conflict]
         case (.soloReflection, .unfiltered, .deepDive):
             return [.identity, .emotions, .past, .values, .conflict, .growth]
+
+        case (_, .mixed, _):
+            return [.emotions, .growth, .communication, .identity, .values, .past]
         }
     }
 

--- a/Connections/Views/SessionBuilderView.swift
+++ b/Connections/Views/SessionBuilderView.swift
@@ -347,7 +347,7 @@ struct SessionBuilderView: View {
     @ViewBuilder
     private var intensitySection: some View {
         VStack(spacing: AppSpacing.cardSpacing) {
-            ForEach(Intensity.allCases) { intensity in
+            ForEach(Intensity.concrete) { intensity in
                 SelectionCard(
                     title: intensity.rawValue,
                     subtitle: intensity.description,
@@ -372,6 +372,26 @@ struct SessionBuilderView: View {
                 .matchedGeometryEffect(id: "intensity-\(intensity.rawValue)", in: cardNamespace)
                 .transition(.opacity.combined(with: .scale(scale: 0.96)))
             }
+
+            SelectionCard(
+                title: Intensity.mixed.rawValue,
+                subtitle: Intensity.mixed.description,
+                tintColor: Intensity.mixed.toneColor,
+                isSelected: session.selectedIntensity == .mixed,
+                glassEffect: true
+            ) {
+                session.selectedIntensity = .mixed
+                hasCustomizedLength = false
+                hasCustomizedTopic = false
+                hasCustomizedFollowUps = false
+                applyRecommendedDetails()
+                HapticsManager.lightImpact()
+                withAnimation(stageSpring) {
+                    currentStage = .details
+                }
+            }
+            .matchedGeometryEffect(id: "intensity-Mixed", in: cardNamespace)
+            .transition(.opacity.combined(with: .scale(scale: 0.96)))
         }
         .padding(.horizontal, AppSpacing.screenHorizontal)
         .transition(.asymmetric(
@@ -596,6 +616,9 @@ struct SessionBuilderView: View {
                     session.selectedSessionLength = selectedLength
                     session.selectedTopic = selectedTopic
                     session.followUpsEnabled = followUps
+                    if session.selectedIntensity == .mixed {
+                        session.mixedIntensities = entitlements.mixedIntensities
+                    }
                     session.startSession()
                     navigateToSession = true
                 }
@@ -645,6 +668,8 @@ struct SessionBuilderView: View {
             return .medium
         case (.soloReflection, .honest), (.soloReflection, .unfiltered):
             return .short
+        case (_, .mixed):
+            return .medium
         case (_, .unfiltered):
             return .short
         }
@@ -661,6 +686,8 @@ struct SessionBuilderView: View {
         case (.soloReflection, .light):
             return false
         case (.soloReflection, .honest), (.soloReflection, .unfiltered):
+            return true
+        case (_, .mixed):
             return true
         case (_, .honest), (_, .unfiltered), (.couples, .light):
             return true
@@ -679,24 +706,32 @@ struct SessionBuilderView: View {
             return "Enough room to open up without it feeling heavy."
         case (.couples, .unfiltered):
             return "Shorter keeps it brave without becoming exhausting."
+        case (.couples, .mixed):
+            return "Room for the conversation to find its own depth."
         case (.friends, .light):
             return "Low pressure, natural rhythm."
         case (.friends, .honest):
             return "Room to get real without losing ease."
         case (.friends, .unfiltered):
             return "Short and direct works best here."
+        case (.friends, .mixed):
+            return "A blend of tones — see where it takes you."
         case (.family, .light):
             return "Room for stories to unfold naturally."
         case (.family, .honest):
             return "A little structure, a little patience."
         case (.family, .unfiltered):
             return "Shorter keeps it direct and usable."
+        case (.family, .mixed):
+            return "A gentle mix with room to go deeper."
         case (.soloReflection, .light):
             return "A gentle stretch of reflection."
         case (.soloReflection, .honest):
             return "Focused, with room to go deeper."
         case (.soloReflection, .unfiltered):
             return "Short and honest. Easier to sit with."
+        case (.soloReflection, .mixed):
+            return "A varied pace for reflection."
         }
     }
 

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -503,6 +503,9 @@ struct SessionPlayView: View {
         session.selectedTopic = rec.topic
         session.selectedSessionLength = rec.sessionLength
         session.followUpsEnabled = rec.followUpsEnabled
+        if rec.intensity == .mixed {
+            session.mixedIntensities = entitlements.mixedIntensities
+        }
 
         recommendation = nil
         promptTransitionID = UUID()

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -169,6 +169,9 @@ struct SessionSetupView: View {
                     session.selectedSessionLength = selectedLength
                     session.selectedTopic = selectedTopic
                     session.followUpsEnabled = followUps
+                    if session.selectedIntensity == .mixed {
+                        session.mixedIntensities = entitlements.mixedIntensities
+                    }
                     session.startSession()
                     navigateToSession = true
                 }

--- a/Connections/Views/SettingsView.swift
+++ b/Connections/Views/SettingsView.swift
@@ -9,6 +9,7 @@ struct SettingsView: View {
     @Environment(SettingsStore.self) private var settings
     @Environment(EntitlementStore.self) private var entitlements
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.openURL) private var openURL
     @Environment(\.colorScheme) private var colorScheme
 
     @State private var showInstructions = false
@@ -110,6 +111,13 @@ struct SettingsView: View {
 
                             SettingsNavRow(title: "Why this matters") {
                                 showWhyThisMatters = true
+                            }
+
+                            Divider().padding(.leading, 16)
+
+                            SettingsNavRow(title: "Privacy Policy") {
+                                guard let url = URL(string: "https://skytan4.github.io/Connections/privacy") else { return }
+                                openURL(url)
                             }
                         }
                     }

--- a/Connections/Views/ShareExperiencePlayView.swift
+++ b/Connections/Views/ShareExperiencePlayView.swift
@@ -56,7 +56,7 @@ struct ShareExperiencePlayView: View {
 
                 HStack(spacing: 10) {
                     filterPill(label: "All", intensity: nil)
-                    ForEach(Intensity.allCases) { intensity in
+                    ForEach(Intensity.concrete) { intensity in
                         filterPill(label: intensity.rawValue, intensity: intensity)
                     }
                 }

--- a/ConnectionsTests/PromptBankTests.swift
+++ b/ConnectionsTests/PromptBankTests.swift
@@ -9,9 +9,10 @@ final class PromptBankTests: XCTestCase {
         for mode in Mode.allCases {
             for intensity in Intensity.allCases {
                 let topics = PromptBank.shared.availableTopics(for: mode, intensity: intensity)
+                let searchIntensities: [Intensity] = intensity == .mixed ? Intensity.concrete : [intensity]
                 for topic in topics where !topic.isGuidedFlow {
                     let count = PromptBank.shared.prompts.filter {
-                        $0.mode == mode && $0.intensity == intensity && $0.topic == topic
+                        $0.mode == mode && searchIntensities.contains($0.intensity) && $0.topic == topic
                     }.count
                     XCTAssertGreaterThan(
                         count, 0,

--- a/Tests/ConnectionsTests/PromptBankTests.swift
+++ b/Tests/ConnectionsTests/PromptBankTests.swift
@@ -9,9 +9,10 @@ final class PromptBankTests: XCTestCase {
         for mode in Mode.allCases {
             for intensity in Intensity.allCases {
                 let topics = PromptBank.shared.availableTopics(for: mode, intensity: intensity)
+                let searchIntensities: [Intensity] = intensity == .mixed ? Intensity.concrete : [intensity]
                 for topic in topics where !topic.isGuidedFlow {
                     let count = PromptBank.shared.prompts.filter {
-                        $0.mode == mode && $0.intensity == intensity && $0.topic == topic
+                        $0.mode == mode && searchIntensities.contains($0.intensity) && $0.topic == topic
                     }.count
                     XCTAssertGreaterThan(
                         count, 0,


### PR DESCRIPTION
## Summary

- Adds **Mixed** as a fourth tone option alongside Light, Honest, and Unfiltered
- Free users get Light + Honest prompts; premium adds Unfiltered to the mix
- Mixed is not premium-gated — available to all users
- Distinct sage-green visual treatment, intensity clumping prevention in session composition
- Updated tests for mixed-aware prompt bank queries

## Test plan

- [ ] Select Mixed in the session builder and verify the card appears with sage styling
- [ ] Start a Mixed session as free user — confirm only Light + Honest prompts appear
- [ ] Start a Mixed session as premium user — confirm all three tones appear
- [ ] Verify tone variety within a Mixed session (no long runs of one tone)
- [ ] Complete a Mixed session and check the recommendation screen renders cleanly
- [ ] Confirm Share Experience filter pills still show only Light/Honest/Unfiltered (no Mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)