### PR TITLE
Rebrand, share icon fix, and screenshot tooling

### DIFF
--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -114,7 +114,7 @@ enum AppRadius {
 
 enum AppIcon {
     static let navWeight: Font.Weight = .medium
-    static let navSize: CGFloat = 15
+    static let navSize: CGFloat = 20
 }
 
 enum AppAnimation {

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -19,13 +19,17 @@ struct HomeView: View {
                 // MARK: - Header
 
                 VStack(spacing: 16) {
-                    Text("Connections")
+                    Text("Deeper Conversations")
                         .font(AppFont.heroTitle())
                         .tracking(1)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, alignment: .center)
 
-                    Text("Deeper conversations")
+                    Text("Questions that bring you closer")
                         .font(AppFont.subtitle())
                         .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, alignment: .center)
                 }
                 .padding(.horizontal, 40)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Connections/Views/PremiumPaywallView.swift
+++ b/Connections/Views/PremiumPaywallView.swift
@@ -69,7 +69,7 @@ struct PremiumPaywallView: View {
             }
             .padding(.top, 8)
 
-            Text("A one-time unlock for the most intimate, reflective, and meaningful parts of Connections.")
+            Text("A one-time unlock for the most intimate, reflective, and meaningful parts of Deeper Conversations.")
                 .font(.system(size: 14))
                 .foregroundStyle(.tertiary)
                 .multilineTextAlignment(.center)

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,2 +1,2 @@
-title: Connections
+title: Deeper Conversations
 theme: minima

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Connections
+title: Deeper Conversations
 ---
 
-# Connections (Layers)
+# Deeper Conversations
 
 - [Privacy Policy](privacy)

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,16 +5,16 @@ title: Privacy Policy
 
 # Privacy Policy
 
-**Connections (Layers)**
+**Deeper Conversations**
 Last updated: April 24, 2026
 
 ## Overview
 
-Connections is designed to help people have more meaningful conversations. Your privacy is simple: we don't collect your data.
+Deeper Conversations is designed to help people have more meaningful conversations. Your privacy is simple: we don't collect your data.
 
 ## What we collect
 
-Nothing. Connections does not collect, transmit, or share any personal information.
+Nothing. Deeper Conversations does not collect, transmit, or share any personal information.
 
 ## What is stored on your device
 
@@ -29,23 +29,23 @@ This data never leaves your device. It is not sent to us, to Apple, or to any th
 
 ## Accounts and sign-in
 
-Connections does not require or support user accounts. There is no sign-in, no email collection, and no registration.
+Deeper Conversations does not require or support user accounts. There is no sign-in, no email collection, and no registration.
 
 ## Analytics and tracking
 
-Connections does not include any analytics, tracking, or advertising frameworks. We do not use cookies, device fingerprints, or identifiers of any kind.
+Deeper Conversations does not include any analytics, tracking, or advertising frameworks. We do not use cookies, device fingerprints, or identifiers of any kind.
 
 ## In-app purchases
 
-Connections offers a one-time in-app purchase to unlock additional features. This transaction is processed entirely by Apple through the App Store. We do not receive or store any payment information.
+Deeper Conversations offers a one-time in-app purchase to unlock additional features. This transaction is processed entirely by Apple through the App Store. We do not receive or store any payment information.
 
 ## Third-party services
 
-Connections does not integrate with any third-party services, APIs, or SDKs beyond Apple's own frameworks (StoreKit for purchases and the native App Store review prompt).
+Deeper Conversations does not integrate with any third-party services, APIs, or SDKs beyond Apple's own frameworks (StoreKit for purchases and the native App Store review prompt).
 
 ## Children's privacy
 
-Connections is not directed at children under 13. Some content within the app (such as the Sex topic) is intended for adults. We do not knowingly collect any information from anyone, including children.
+Deeper Conversations is not directed at children under 13. Some content within the app (such as the Sex topic) is intended for adults. We do not knowingly collect any information from anyone, including children.
 
 ## Data deletion
 


### PR DESCRIPTION
## Summary
- Rebrands app copy from "Connections" to "Deeper Conversations" across home screen, paywall, privacy policy, and GitHub Pages docs site
- Increases share icon size on prompt screens by 1/3 (15pt → 20pt) for better visibility and tap target
- Adds Fastlane screenshot lane, Snapfile config, and UI test infrastructure (ScreenshotTests + SnapshotHelper) for automated App Store screenshot capture

## Test plan
- [ ] Verify home screen shows "Deeper Conversations" title and updated subtitle
- [ ] Verify share icon on session play screens is noticeably larger
- [ ] Verify privacy policy page reflects new branding
- [ ] Confirm paywall copy references "Deeper Conversations"

🤖 Generated with [Claude Code](https://claude.com/claude-code)