### PR TITLE
Increase share icon size on prompt screens

### DIFF
--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -114,7 +114,7 @@ enum AppRadius {
 
 enum AppIcon {
     static let navWeight: Font.Weight = .medium
-    static let navSize: CGFloat = 15
+    static let navSize: CGFloat = 20
 }
 
 enum AppAnimation {


### PR DESCRIPTION
## Summary
- Increases nav icon size from 15pt to 20pt (1/3 larger) for better visibility and tap target
- Applies to the share button on all prompt screens: SessionPlayView, LifeStoryPlayView, FallInLovePlayView, and ShareExperiencePlayView

## Test plan
- [ ] Verify share icon is visibly larger on session play screen
- [ ] Confirm icon still looks balanced with surrounding UI elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)