### PR TITLE
Add Spanish privacy policy page for GitHub Pages

### DIFF
--- a/docs/privacy-es.md
+++ b/docs/privacy-es.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Política de Privacidad
+---
+
+# Política de Privacidad
+
+**Deeper Conversations**  
+Última actualización: 24 de abril de 2026
+
+## Resumen
+
+Deeper Conversations está diseñada para ayudar a las personas a tener conversaciones más significativas. Tu privacidad es simple: no recopilamos tus datos.
+
+## Qué recopilamos
+
+Nada. Deeper Conversations no recopila, transmite ni comparte información personal.
+
+## Qué se almacena en tu dispositivo
+
+La app almacena los siguientes datos localmente en tu dispositivo para admitir sus funciones:
+
+- Tus preferencias (configuración predeterminada de sesiones y ajustes)
+- Prompts favoritos
+- Progreso en experiencias guiadas (Fall in Love, Life Story)
+- Conteos básicos de uso para determinar cuándo mostrar una solicitud opcional de reseña en App Store
+
+Estos datos nunca salen de tu dispositivo. No se envían a nosotros, a Apple ni a ningún tercero.
+
+## Cuentas e inicio de sesión
+
+Deeper Conversations no requiere ni admite cuentas de usuario. No hay inicio de sesión, recopilación de correo electrónico ni registro.
+
+## Analíticas y seguimiento
+
+Deeper Conversations no incluye analíticas, seguimiento ni frameworks publicitarios. No usamos cookies, huellas digitales del dispositivo ni identificadores de ningún tipo.
+
+## Compras dentro de la app
+
+Deeper Conversations ofrece una compra única dentro de la app para desbloquear funciones adicionales. Esta transacción es procesada completamente por Apple a través de App Store. No recibimos ni almacenamos información de pago.
+
+## Servicios de terceros
+
+Deeper Conversations no se integra con servicios, API ni SDK de terceros más allá de los frameworks propios de Apple (StoreKit para compras y la solicitud nativa de reseña en App Store).
+
+## Privacidad de menores
+
+Deeper Conversations no está dirigida a niños menores de 13 años. Parte del contenido dentro de la app (como el tema Sexo) está destinado a adultos. No recopilamos deliberadamente información de ninguna persona, incluidos niños.
+
+## Eliminación de datos
+
+Como todos los datos se almacenan localmente en tu dispositivo, puedes eliminarlos en cualquier momento borrando la app. No existe ningún dato del lado del servidor que debamos eliminar.
+
+## Cambios a esta política
+
+Si actualizamos esta política, cambiaremos la fecha en la parte superior de esta página. Como no recopilamos información de contacto, no podemos notificar directamente a los usuarios. Te recomendamos revisar esta página periódicamente.
+
+## Contacto
+
+Si tienes preguntas sobre esta política de privacidad, puedes escribirnos a:
+
+oldmandevs@gmail.com


### PR DESCRIPTION
## Summary

- Adds `docs/privacy-es.md` served at `https://skytan4.github.io/Connections/privacy-es`
- Required for the Privacy Policy row in Settings, which routes Spanish users to this URL when `Bundle.main.preferredLocalizations.first` starts with `"es"`
- The routing logic is already in `SettingsView` on the `Spanish_Localization` branch

## Test plan

- [ ] Visit https://skytan4.github.io/Connections/privacy-es after merge and confirm the Spanish privacy policy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)