### PR TITLE
Add Polish (pl) localization

### DIFF
--- a/Connections/Data/fall_in_love_pl.json
+++ b/Connections/Data/fall_in_love_pl.json
@@ -1,0 +1,258 @@
+{
+  "schemaVersion": 1,
+  "language": "pl",
+  "prompts": [
+    {
+      "id": "fil_01",
+      "text": "Gdyby dało się zaprosić kogokolwiek na świecie na kolację — kogo chcesz wybrać?",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "order": 1
+    },
+    {
+      "id": "fil_02",
+      "text": "Czy chcesz być sławny? W jaki sposób?",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "order": 2
+    },
+    {
+      "id": "fil_03",
+      "text": "Czy zdarza ci się próbować w głowie, co powiesz, zanim zadzwonisz? Dlaczego?",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "order": 3
+    },
+    {
+      "id": "fil_04",
+      "text": "Jak wyglądałby twój idealny dzień?",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "order": 4
+    },
+    {
+      "id": "fil_05",
+      "text": "Kiedy ostatnio śpiewałeś — do siebie albo do kogoś?",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "order": 5
+    },
+    {
+      "id": "fil_06",
+      "text": "Gdyby dało się dożyć dziewięćdziesiątki i zachować przy tym albo sprawny umysł, albo młode ciało — co chcesz wybrać?",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 6
+    },
+    {
+      "id": "fil_07",
+      "text": "Czy masz jakieś przeczucie, jak możesz umrzeć?",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 7
+    },
+    {
+      "id": "fil_08",
+      "text": "Co według ciebie możemy mieć ze sobą wspólnego? Wymień trzy rzeczy.",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 8
+    },
+    {
+      "id": "fil_09",
+      "text": "Za co w tej chwili jesteś najbardziej wdzięczny?",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 9
+    },
+    {
+      "id": "fil_10",
+      "text": "Gdyby dało się coś zmienić w swoim dzieciństwie — co by to było?",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 10
+    },
+    {
+      "id": "fil_11",
+      "text": "Opowiedz historię swojego życia w kilku minutach",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 11
+    },
+    {
+      "id": "fil_12",
+      "text": "Gdyby dało się rano wstać z nową umiejętnością — jaką chcesz wybrać?",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "order": 12
+    },
+    {
+      "id": "fil_13",
+      "text": "Gdyby dało się poznać przyszłość — co chcesz wiedzieć?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 13
+    },
+    {
+      "id": "fil_14",
+      "text": "Co od zawsze chcesz zrobić, a jeszcze ci się to nie udało?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 14
+    },
+    {
+      "id": "fil_15",
+      "text": "Z jakiego osiągnięcia jesteś najbardziej dumny?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 15
+    },
+    {
+      "id": "fil_16",
+      "text": "Co najbardziej cenisz w przyjaźni?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 16
+    },
+    {
+      "id": "fil_17",
+      "text": "Jakie jest jedno z twoich najważniejszych wspomnień?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 17
+    },
+    {
+      "id": "fil_18",
+      "text": "Jakie jest jedno z twoich najtrudniejszych wspomnień?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 18
+    },
+    {
+      "id": "fil_19",
+      "text": "Gdyby okazało się, że masz przed sobą tylko rok — chcesz coś zmienić w swoim życiu?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 19
+    },
+    {
+      "id": "fil_20",
+      "text": "Co przyjaźń dla ciebie znaczy?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 20
+    },
+    {
+      "id": "fil_21",
+      "text": "Jaką rolę odgrywają miłość i czułość w twoim życiu?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 21
+    },
+    {
+      "id": "fil_22",
+      "text": "Powiedz, co w tej osobie doceniasz",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 22
+    },
+    {
+      "id": "fil_23",
+      "text": "Jaka była twoja rodzina, kiedy dorastałeś?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 23
+    },
+    {
+      "id": "fil_24",
+      "text": "Jak czujesz się ze swoją relacją z mamą?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 24
+    },
+    {
+      "id": "fil_25",
+      "text": "Ułóż trzy zdania zaczynające się od słowa „My…” — o was obojgu",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 25
+    },
+    {
+      "id": "fil_26",
+      "text": "Dokończ: Żałuję, że nie mam z kim podzielić się ____",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 26
+    },
+    {
+      "id": "fil_27",
+      "text": "Co warto wiedzieć o tobie, kiedy stajemy się sobie bliscy?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 27
+    },
+    {
+      "id": "fil_28",
+      "text": "Powiedz mi coś, co naprawdę cenisz w tej osobie",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 28
+    },
+    {
+      "id": "fil_29",
+      "text": "Opowiedz o jakimś wstydliwym momencie",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 29
+    },
+    {
+      "id": "fil_30",
+      "text": "Kiedy ostatnio płakałeś — przy kimś albo w pojedynkę?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 30
+    },
+    {
+      "id": "fil_31",
+      "text": "Powiedz mi coś, co już teraz lubisz w tej osobie",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 31
+    },
+    {
+      "id": "fil_32",
+      "text": "Z czego nie wypada żartować?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 32
+    },
+    {
+      "id": "fil_33",
+      "text": "Gdyby to była twoja ostatnia noc — czego żałujesz, że jeszcze nie powiedziałeś?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 33
+    },
+    {
+      "id": "fil_34",
+      "text": "Co zabierasz z płonącego domu — i dlaczego właśnie to?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 34
+    },
+    {
+      "id": "fil_35",
+      "text": "Czyja śmierć dotknęłaby cię najbardziej i dlaczego?",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 35
+    },
+    {
+      "id": "fil_36",
+      "text": "Opowiedz o osobistym problemie, który cię trapi — a twój partner niech powtórzy własnymi słowami to, co usłyszał",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "order": 36
+    }
+  ]
+}

--- a/Connections/Data/life_story_pl.json
+++ b/Connections/Data/life_story_pl.json
@@ -1,0 +1,406 @@
+{
+  "schemaVersion": 1,
+  "language": "pl",
+  "prompts": [
+    {
+      "id": "ls_childhood_001",
+      "text": "Co najbardziej dawało ci radość w byciu dzieckiem?",
+      "chapter": "childhood",
+      "order": 1,
+      "followUp1": "Co z tamtego czasu zostało w tobie do dziś?",
+      "followUp2": "Czy myślisz, że ta część dzieciństwa gdzieś w tobie wciąż żyje?"
+    },
+    {
+      "id": "ls_childhood_002",
+      "text": "Jaka zabawa sprawiała ci największą radość w dzieciństwie?",
+      "chapter": "childhood",
+      "order": 2,
+      "followUp1": "Co ta zabawa dawała ci poczuć?",
+      "followUp2": "Czy myślisz, że tamta część ciebie wciąż gdzieś się odzywa?"
+    },
+    {
+      "id": "ls_childhood_003",
+      "text": "Co najwyraźniej pamiętasz z domu, w którym dorastałeś?",
+      "chapter": "childhood",
+      "order": 3,
+      "followUp1": "Jakie uczucie wraca pierwsze, kiedy go sobie wyobrażasz?",
+      "followUp2": "Co ten dom ci dał — i czego ci nie dał?"
+    },
+    {
+      "id": "ls_childhood_004",
+      "text": "Kto z rodziny dawał ci poczucie największego bezpieczeństwa w dzieciństwie?",
+      "chapter": "childhood",
+      "order": 4,
+      "followUp1": "Co sprawiało, że czułeś się przy tej osobie bezpiecznie?",
+      "followUp2": "Czy myślisz, że ta osoba wiedziała, czym była dla ciebie?"
+    },
+    {
+      "id": "ls_childhood_005",
+      "text": "Jak wyglądało zwykłe popołudnie w twoim dzieciństwie?",
+      "chapter": "childhood",
+      "order": 5,
+      "followUp1": "Jakie szczegóły wracają najłatwiej?",
+      "followUp2": "Czy jest coś z tamtego rytmu życia, za czym tęsknisz?"
+    },
+    {
+      "id": "ls_childhood_006",
+      "text": "Czego się bałeś jako dziecko?",
+      "chapter": "childhood",
+      "order": 6,
+      "followUp1": "Czy ktoś wiedział, jak bardzo się bałeś?",
+      "followUp2": "Czy myślisz, że tamten strach ukształtował cię w jakiś sposób, który trwa do dziś?"
+    },
+    {
+      "id": "ls_childhood_007",
+      "text": "Jak wyobrażałeś sobie dorosłość?",
+      "chapter": "childhood",
+      "order": 7,
+      "followUp1": "Co z tych wyobrażeń okazało się trafne?",
+      "followUp2": "Co okazało się zupełnie inne?"
+    },
+    {
+      "id": "ls_childhood_008",
+      "text": "Kto nauczył cię wiązać buty — i pamiętasz, jak to było?",
+      "chapter": "childhood",
+      "order": 8,
+      "followUp1": "Co pamiętasz z tej osoby?",
+      "followUp2": "Jaką małą rzecz cię nauczyła, która została z tobą dłużej, niż pewnie się spodziewała?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_009",
+      "text": "Jak szło ci w szkole?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 9,
+      "followUp1": "Co ludzie zauważali w tobie pierwsze?",
+      "followUp2": "Czy myślisz, że to był prawdziwy ty, czy tylko jedna z twoich odsłon?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_010",
+      "text": "Którego nauczyciela wciąż pamiętasz — i dlaczego?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 10,
+      "followUp1": "Co w tobie dostrzegł albo co w tobie obudził?",
+      "followUp2": "Czy zmienił to, jak siebie postrzegałeś?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_011",
+      "text": "Jakich przyjaciół miałeś, dorastając?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 11,
+      "followUp1": "Co te przyjaźnie dawały ci w tamtym czasie?",
+      "followUp2": "Co według ciebie mówiły o tym, kim się wtedy stawałeś?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_012",
+      "text": "Kim wyobrażało ci się, że zostaniesz w dorosłości?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 12,
+      "followUp1": "Która część tamtego marzenia pozostała z tobą?",
+      "followUp2": "Która część musiała się zmienić, kiedy życie stało się prawdziwe?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_013",
+      "text": "Co najbardziej dawało ci radość w byciu młodym?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 13,
+      "followUp1": "Za jakim uczuciem z tamtego czasu wciąż tęsknisz?",
+      "followUp2": "Czy odnalazłeś jakąś jego wersję później w życiu?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_014",
+      "text": "Co było najtrudniejsze w dorastaniu?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 14,
+      "followUp1": "Czy ktoś naprawdę rozumiał to wtedy?",
+      "followUp2": "Czego wymagało od ciebie za wcześnie?"
+    },
+    {
+      "id": "ls_schoolAndGrowingUp_015",
+      "text": "Jak radziło się z konfliktami między rodzeństwem lub przyjaciółmi, kiedy dorastałeś?",
+      "chapter": "schoolAndGrowingUp",
+      "order": 15,
+      "followUp1": "Czego to cię nauczyło wtedy o konfliktach?",
+      "followUp2": "Czy myślisz, że wciąż radzisz sobie z konfliktami w podobny sposób?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_016",
+      "text": "Jaka była twoja pierwsza praca?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 16,
+      "followUp1": "Czego nauczyła cię o ludziach albo o odpowiedzialności?",
+      "followUp2": "Jak to było zarabiać po raz pierwszy na siebie?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_017",
+      "text": "Która praca nauczyła cię najwięcej o ludziach?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 17,
+      "followUp1": "Co ci pokazała, co zostało z tobą na zawsze?",
+      "followUp2": "Czy zmieniła też to, jak postrzegałeś siebie?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_018",
+      "text": "Jaka odpowiedzialność weszła w twoje życie wcześniej, niż dało się na nią przygotować?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 18,
+      "followUp1": "Jak ją niosłeś?",
+      "followUp2": "Co — jak myślisz — zmieniła w tobie?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_019",
+      "text": "Co było przełomem w twoim wczesnym dorosłym życiu?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 19,
+      "followUp1": "Czy wiedziałeś wtedy, że to przełom?",
+      "followUp2": "Jak życie podzieliło się na przed i po?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_020",
+      "text": "Co praca znaczyła dla ciebie na różnych etapach życia?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 20,
+      "followUp1": "Czy oznaczała przeżycie, dumę, obowiązek, tożsamość — czy coś jeszcze innego?",
+      "followUp2": "Jak to znaczenie zmieniało się z czasem?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_021",
+      "text": "Czy zdarzyło ci się lubić jakąś pracę bardziej, niż ktokolwiek by się spodziewał?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 21,
+      "followUp1": "Co sprawiało, że była dla ciebie ważna?",
+      "followUp2": "Czy myślisz, że ta praca ujawniała coś prawdziwego o tobie?"
+    },
+    {
+      "id": "ls_workAndEarlyAdulthood_022",
+      "text": "Jeśli służyłeś w wojsku, co chcesz, żeby ludzie rozumieli z tamtego okresu twojego życia?",
+      "chapter": "workAndEarlyAdulthood",
+      "order": 22,
+      "followUp1": "Czego wymagało od ciebie to doświadczenie?",
+      "followUp2": "Jak — twoim zdaniem — zostało z tobą później?"
+    },
+    {
+      "id": "ls_loveAndPartnership_023",
+      "text": "Jak poznałeś swojego partnera lub partnerkę?",
+      "chapter": "loveAndPartnership",
+      "order": 23,
+      "followUp1": "Jakie było twoje pierwsze prawdziwe wrażenie o tej osobie?",
+      "followUp2": "Kiedy poczułeś, że ten związek naprawdę coś znaczy?"
+    },
+    {
+      "id": "ls_loveAndPartnership_024",
+      "text": "Czym była dla ciebie miłość w młodości?",
+      "chapter": "loveAndPartnership",
+      "order": 24,
+      "followUp1": "Jak to rozumienie zmieniało się z wiekiem?",
+      "followUp2": "Czego nauczyła cię miłość, czego nic innego nie potrafiło?"
+    },
+    {
+      "id": "ls_loveAndPartnership_025",
+      "text": "Co ułatwiało wasz związek lub małżeństwo?",
+      "chapter": "loveAndPartnership",
+      "order": 25,
+      "followUp1": "Jakie nawyki lub cechy pomagały najbardziej?",
+      "followUp2": "Co — jak myślisz — trzymało was razem w trudnych momentach?"
+    },
+    {
+      "id": "ls_loveAndPartnership_026",
+      "text": "Co sprawiało, że było trudniej?",
+      "chapter": "loveAndPartnership",
+      "order": 26,
+      "followUp1": "Co rozumiesz teraz, czego wtedy nie było łatwo zobaczyć?",
+      "followUp2": "Co chcesz, żeby młodsi ludzie wiedzieli o trwałej miłości?"
+    },
+    {
+      "id": "ls_loveAndPartnership_027",
+      "text": "Co najpierw podziwiałeś w osobie, z którą postanowiłeś budować życie?",
+      "chapter": "loveAndPartnership",
+      "order": 27,
+      "followUp1": "Czy ten podziw z czasem się zmienił, czy może się pogłębił?",
+      "followUp2": "Co ta osoba wydobyła w tobie?"
+    },
+    {
+      "id": "ls_parentingAndFamilyLife_028",
+      "text": "Co najbardziej cię zaskoczyło w zostaniu rodzicem?",
+      "chapter": "parentingAndFamilyLife",
+      "order": 28,
+      "followUp1": "Co zmieniło cię najbardziej?",
+      "followUp2": "Czego nie da się zrozumieć, dopóki się tego nie przeżyje?"
+    },
+    {
+      "id": "ls_parentingAndFamilyLife_029",
+      "text": "Która część rodzicielstwa dawała ci najwięcej radości?",
+      "chapter": "parentingAndFamilyLife",
+      "order": 29,
+      "followUp1": "Jakie chwile zostają w tobie najsilniej teraz?",
+      "followUp2": "Co te momenty mówiły ci o tobie?"
+    },
+    {
+      "id": "ls_parentingAndFamilyLife_030",
+      "text": "Która część rodzicielstwa była najbardziej samotna albo najtrudniejsza?",
+      "chapter": "parentingAndFamilyLife",
+      "order": 30,
+      "followUp1": "Czy ktoś w twoim otoczeniu rozumiał ten ciężar?",
+      "followUp2": "Czego brakowało ci wtedy najbardziej?"
+    },
+    {
+      "id": "ls_parentingAndFamilyLife_031",
+      "text": "Czy jest coś, co chcesz, żebyś zrobił inaczej jako rodzic?",
+      "chapter": "parentingAndFamilyLife",
+      "order": 31,
+      "followUp1": "Co rozumiesz w tej kwestii teraz?",
+      "followUp2": "Co chcesz, żeby twoje dzieci rozumiały o tobie — także w tym?"
+    },
+    {
+      "id": "ls_parentingAndFamilyLife_032",
+      "text": "Co, twoim zdaniem, twoje dzieci dobrze rozumiały w tobie, a co mogły przeoczyć?",
+      "chapter": "parentingAndFamilyLife",
+      "order": 32,
+      "followUp1": "Co chcesz, żeby widziały wyraźniej?",
+      "followUp2": "Czy myślisz, że teraz lepiej to rozumieją?"
+    },
+    {
+      "id": "ls_hardshipAndResilience_033",
+      "text": "Jaki był jeden z najtrudniejszych okresów twojego życia?",
+      "chapter": "hardshipAndResilience",
+      "order": 33,
+      "followUp1": "Co cię przez to przeprowadziło, gdy nie wiedziałeś nawet, jak dasz radę?",
+      "followUp2": "Czego ten czas od ciebie zażądał?"
+    },
+    {
+      "id": "ls_hardshipAndResilience_034",
+      "text": "Czy była jakaś strata, która zmieniła cię na stałe?",
+      "chapter": "hardshipAndResilience",
+      "order": 34,
+      "followUp1": "Jak ukształtowała sposób, w jaki żyjesz albo kochasz teraz?",
+      "followUp2": "Co ta strata wciąż od ciebie wymaga?"
+    },
+    {
+      "id": "ls_hardshipAndResilience_035",
+      "text": "Jaką ofiarę złożyłeś, której ludzie w pełni nie dostrzegli?",
+      "chapter": "hardshipAndResilience",
+      "order": 35,
+      "followUp1": "Czy czułeś, że została wystarczająco uznana?",
+      "followUp2": "Czy ta ofiara byłaby warta ponownego złożenia?"
+    },
+    {
+      "id": "ls_hardshipAndResilience_036",
+      "text": "Co sprawiało, że szłeś dalej, gdy wszystko wydawało się bardzo ciężkie?",
+      "chapter": "hardshipAndResilience",
+      "order": 36,
+      "followUp1": "Czy to był obowiązek, miłość, wiara, upór, nadzieja — czy coś innego?",
+      "followUp2": "Czy myślisz, że ta siła cię zmieniła?"
+    },
+    {
+      "id": "ls_beliefsAndValues_037",
+      "text": "Jakie wartości najbardziej prowadziły twoje życie?",
+      "chapter": "beliefsAndValues",
+      "order": 37,
+      "followUp1": "Skąd, twoim zdaniem, pochodzi ta wartość?",
+      "followUp2": "Jak kształtowała wybory, które podejmowałeś?"
+    },
+    {
+      "id": "ls_beliefsAndValues_038",
+      "text": "Jakie przekonanie musiałeś z czasem puścić?",
+      "chapter": "beliefsAndValues",
+      "order": 38,
+      "followUp1": "Co je zmieniło?",
+      "followUp2": "Co stało się możliwe, gdy je puściłeś?"
+    },
+    {
+      "id": "ls_beliefsAndValues_039",
+      "text": "Co, twoim zdaniem, czyni kogoś dobrym człowiekiem?",
+      "chapter": "beliefsAndValues",
+      "order": 39,
+      "followUp1": "Czy twoja odpowiedź zmieniła się z wiekiem?",
+      "followUp2": "Co nauczyło cię tego najgłębiej?"
+    },
+    {
+      "id": "ls_beliefsAndValues_040",
+      "text": "W co wierzysz teraz, czego twoje młodsze ja może nie rozumiało?",
+      "chapter": "beliefsAndValues",
+      "order": 40,
+      "followUp1": "Czego twoje młodsze ja nie chciałoby słyszeć?",
+      "followUp2": "Dlaczego to teraz wydaje ci się prawdą?"
+    },
+    {
+      "id": "ls_beliefsAndValues_041",
+      "text": "Czego nauczyli cię twoi rodzice albo dziadkowie i co zostało w tobie najdłużej?",
+      "chapter": "beliefsAndValues",
+      "order": 41,
+      "followUp1": "Czy to było coś, co mówili, czy raczej coś, co pokazywali?",
+      "followUp2": "Czy myślisz, że ty też to przekazałeś dalej?"
+    },
+    {
+      "id": "ls_lookingBack_042",
+      "text": "Czy jest coś, co warto by było zapytać rodziców, zanim odeszli?",
+      "chapter": "lookingBack",
+      "order": 42,
+      "followUp1": "Czego tak naprawdę chcesz się dowiedzieć?",
+      "followUp2": "Czy ten brak wciąż w tobie jest?"
+    },
+    {
+      "id": "ls_lookingBack_043",
+      "text": "Czego chcesz, żebyś wiedział wcześniej w życiu?",
+      "chapter": "lookingBack",
+      "order": 43,
+      "followUp1": "Czy gdybyś wiedział wcześniej, to naprawdę coś by zmieniło?",
+      "followUp2": "Jak w końcu się tego nauczyłeś?"
+    },
+    {
+      "id": "ls_lookingBack_044",
+      "text": "Co chcesz, żebyś miał odwagę zrobić?",
+      "chapter": "lookingBack",
+      "order": 44,
+      "followUp1": "Co cię wtedy powstrzymało?",
+      "followUp2": "Jak się z tym czujesz teraz?"
+    },
+    {
+      "id": "ls_lookingBack_045",
+      "text": "Z jakiej decyzji jesteś dumny?",
+      "chapter": "lookingBack",
+      "order": 45,
+      "followUp1": "Co ta decyzja chroniła albo tworzyła?",
+      "followUp2": "Jak ukształtowała życie, które po niej nastąpiło?"
+    },
+    {
+      "id": "ls_lookingBack_046",
+      "text": "Jakie pytanie chcesz, żeby ktoś zadał ci wcześniej w życiu?",
+      "chapter": "lookingBack",
+      "order": 46,
+      "followUp1": "Dlaczego, twoim zdaniem, nikt go nie zadał?",
+      "followUp2": "Co staje się możliwe, gdy ktoś w końcu je zadaje?"
+    },
+    {
+      "id": "ls_legacy_047",
+      "text": "Co chcesz, żeby ludzie pamiętali o tym, jak kochałeś?",
+      "chapter": "legacy",
+      "order": 47,
+      "followUp1": "Co w tej pamięci znaczy dla ciebie najwięcej?",
+      "followUp2": "Czy myślisz, że osoby tobie najbliższe już to wiedzą?"
+    },
+    {
+      "id": "ls_legacy_048",
+      "text": "Co chcesz, żeby przeżyło cię dłużej niż ty?",
+      "chapter": "legacy",
+      "order": 48,
+      "followUp1": "Czy to coś, co zbudowałeś, nauczyłeś, dałeś, czy ucieleśniałeś?",
+      "followUp2": "Gdzie chcesz, żeby to żyło dalej?"
+    },
+    {
+      "id": "ls_legacy_049",
+      "text": "Jaką lekcję chcesz, żeby twoja rodzina niosła ze sobą?",
+      "chapter": "legacy",
+      "order": 49,
+      "followUp1": "Co nauczyło cię tej lekcji?",
+      "followUp2": "Dlaczego tak wiele dla ciebie znaczy?"
+    },
+    {
+      "id": "ls_legacy_050",
+      "text": "Gdyby ktoś z twojej rodziny naprawdę wsłuchał się w twoje życie, co chcesz, żeby zrozumiał przede wszystkim?",
+      "chapter": "legacy",
+      "order": 50,
+      "followUp1": "Czego w swoim człowieczeństwie nie chcesz, żeby przeoczył?",
+      "followUp2": "Co by to dla ciebie oznaczało — być tak naprawdę zrozumianym?"
+    }
+  ]
+}

--- a/Connections/Data/prompts_pl.json
+++ b/Connections/Data/prompts_pl.json
@@ -1,0 +1,11966 @@
+{
+  "schemaVersion": 1,
+  "language": "pl",
+  "prompts": [
+    {
+      "id": "p_couples_light_warmUp_dailyLife_001",
+      "text": "Gdyby dało się poznać jedną rzecz o swojej przyszłości, czego najbardziej chcesz się dowiedzieć?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_001_fu_1",
+          "text": "Dlaczego akurat to?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_001_fu_2",
+          "text": "Jak myślisz, jak ta wiedza zmieniłaby twoje obecne życie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_identity_001",
+      "text": "O czym jesteś nieracjonalnie uparty?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_identity_001_fu_1",
+          "text": "Co sprawia, że tak trudno ci się tu ugięć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_identity_001_fu_2",
+          "text": "Jak myślisz, co to w tobie chroni?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_identity_002",
+      "text": "O czym wiesz, że jesteś zupełnie irracjonalny?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_identity_002_fu_1",
+          "text": "Co zwykle wywołuje w tobie taką reakcję?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_identity_002_fu_2",
+          "text": "Czy uważasz, że wiąże się to z czymś dawnym albo głębszym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_002",
+      "text": "Jaka drobna osobista preferencja wzbudza w tobie zaskakująco silne uczucia?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_002_fu_1",
+          "text": "Jak myślisz, dlaczego właśnie ta rzecz tak bardzo ci zależy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_002_fu_2",
+          "text": "Co to zdradza o tym, jak lubisz, żeby twoje życie wyglądało?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_003",
+      "text": "Na co chętnie wydajesz dużo pieniędzy i ani trochę tego nie żałujesz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_003_fu_1",
+          "text": "Co daje ci to wydawanie, poza samą rzeczą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_003_fu_2",
+          "text": "Co byłoby trudne do zastąpienia, gdyby tego w twoim życiu zabrakło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_communication_001",
+      "text": "Z czego ekscytujesz się bardziej, niż pewnie powinieneś?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_communication_001_fu_1",
+          "text": "Czego to dotyczy w tobie, że czujesz to tak mocno?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_communication_001_fu_2",
+          "text": "Co ta ekscytacja zdaje się w tobie budzić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_004",
+      "text": "Na co chcesz móc wydawać pieniądze swobodniej?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_004_fu_1",
+          "text": "Jak by to zmieniło twoje życie albo codzienność?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_004_fu_2",
+          "text": "Jakiego uczucia chcesz mieć więcej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_005",
+      "text": "Wolisz przyjmować gości czy być gościem?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_005_fu_1",
+          "text": "Co jest dla ciebie w tej roli najbardziej naturalne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_005_fu_2",
+          "text": "Co ta rola ci ułatwia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_006",
+      "text": "Wyobraź sobie kilka miesięcy w domu bez możliwości wyjścia. Jakie trzy rzeczy byłyby ci absolutnie niezbędne?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_006_fu_1",
+          "text": "Co te wybory mówią o tym, co sprawia, że czujesz się stabilnie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_006_fu_2",
+          "text": "Bez której z nich byłoby ci najtrudniej i dlaczego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_007",
+      "text": "Jaka jest twoja ulubiona nocna przekąska?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_007_fu_1",
+          "text": "W jakim jesteś zwykle nastroju, kiedy masz na nią ochotę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_007_fu_2",
+          "text": "Co ten wybór mówi o tym, po jaki rodzaj komfortu sięgasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_intimacy_001",
+      "text": "Kim lub czym ostatnio po cichu się fascynujesz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_intimacy_001_fu_1",
+          "text": "Co w tej osobie lub rzeczy cię przyciąga?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_intimacy_001_fu_2",
+          "text": "Czy to cię energetyzuje, uspokaja, czy po prostu wciąga?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_008",
+      "text": "Jaka jest twoja najbardziej katastrofalna randka w historii?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_008_fu_1",
+          "text": "Co sprawiło, że tak szybko poszło nie tak?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_008_fu_2",
+          "text": "Czego cię to nauczyło o sobie lub o randkowaniu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_intimacy_002",
+      "text": "Jaka jest twoja ulubiona prawdziwa historia miłosna — wasza czy kogoś innego?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_intimacy_002_fu_1",
+          "text": "Która część tej historii porusza cię najbardziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_intimacy_002_fu_2",
+          "text": "Widzisz w nas coś z tego rodzaju miłości?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_communication_002",
+      "text": "Czego najbardziej potrzebujesz ode mnie, gdy źle się czujesz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_communication_002_fu_1",
+          "text": "Co sprawia, że czujesz się zadbany, a nie tylko pilnowany?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_communication_002_fu_2",
+          "text": "Co łatwo mi przegapić w takich chwilach, a co by ci pomogło poczuć się lepiej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_009",
+      "text": "Co w tobie wymaga trochę więcej uwagi i troski?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_009_fu_1",
+          "text": "Co sprawia, że to dodatkowe zaangażowanie jest dla ciebie tego warte?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_009_fu_2",
+          "text": "Chodzi ci bardziej o komfort, kontrolę czy poczucie, że ktoś o ciebie dba?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_identity_003",
+      "text": "Gdzie lubisz mieć dużo kontroli?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_identity_003_fu_1",
+          "text": "Co czujesz, że jest zagrożone, kiedy nie masz kontroli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_identity_003_fu_2",
+          "text": "Dlaczego myślisz, że tak bardzo potrzebujesz jej właśnie tam?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_communication_003",
+      "text": "Z czego absolutnie nie lubisz być żartowany?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_communication_003_fu_1",
+          "text": "Co jest w tym takiego, że zawsze to źle trafia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_communication_003_fu_2",
+          "text": "Czy to dotyka czegoś dawniejszego albo bardziej czułego w tobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_communication_004",
+      "text": "Komu lub czemu praktycznie nie możesz odmówić?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_communication_004_fu_1",
+          "text": "To wstydliwa przyjemność, słaby punkt czy coś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_communication_004_fu_2",
+          "text": "Czy czujesz presję, żeby zawsze mówić tak?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_appreciation_001",
+      "text": "Co odkrywasz na nowo w swoim partnerze — coś, w czym znowu się zakochujesz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_appreciation_001_fu_1",
+          "text": "Co było w tym momencie takiego, że tak mocno cię dotknął?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_appreciation_001_fu_2",
+          "text": "Co ci to przypomniało o tym, dlaczego właśnie tę osobę wybrałeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_sex_001",
+      "text": "Jaka uwaga z mojej strony sprawia, że czujesz się najbardziej zmysłowo?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_sex_001_fu_1",
+          "text": "Co pomaga, żeby ta uwaga docierała do ciebie przez ciało, a nie tylko przez głowę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_sex_001_fu_2",
+          "text": "Czy jest coś, co robię, co zwykle oddala cię od tego uczucia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_sex_002",
+      "text": "Jaka uwaga z mojej strony sprawia, że czujesz się najbardziej atrakcyjnie?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_sex_002_fu_1",
+          "text": "Kiedy ostatnio moja uwaga naprawdę do ciebie dotarła w ten sposób?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_sex_002_fu_2",
+          "text": "Czy możesz mi pomóc zauważać, kiedy mi to wychodzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_appreciation_002",
+      "text": "Jaka piosenka zawsze kojarzy ci się z nami?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_appreciation_002_fu_1",
+          "text": "Jakie wspomnienie albo uczucie przywołuje jako pierwsze?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_appreciation_002_fu_2",
+          "text": "Co ta piosenka — jak ci się wydaje — oddaje w naszym związku?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_appreciation_003",
+      "text": "Jaką najpiękniejszą niespodziankę dostałeś kiedyś od kogoś bliskiego?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_appreciation_003_fu_1",
+          "text": "Co sprawiło, że ta niespodzianka była dla ciebie tak wyjątkowa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_appreciation_003_fu_2",
+          "text": "Co pokazała ci o tym, jak dobrze ta osoba cię zna?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_010",
+      "text": "Jak wyobrażasz sobie idealny leniwy dzień na wspólnych wakacjach?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_010_fu_1",
+          "text": "Co mogę zrobić, żeby takie dni były dla ciebie jak najbardziej wartościowe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_010_fu_2",
+          "text": "Czy mamy dość takich dni? Czy powinniśmy ich mieć więcej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_appreciation_004",
+      "text": "Co małego robię, co zawsze sprawia, że się uśmiechasz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_appreciation_004_fu_1",
+          "text": "Dlaczego myślisz, że ta drobnostka tyle dla ciebie znaczy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_appreciation_004_fu_2",
+          "text": "Co czujesz w tamtej chwili?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_011",
+      "text": "Wyobraź sobie, że jutro możemy pojechać gdziekolwiek na świecie. Jakie miejsce wybierasz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_011_fu_1",
+          "text": "Dlaczego właśnie tam i właśnie ze mną?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_011_fu_2",
+          "text": "Co chcesz razem poczuć w tym miejscu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_growth_001",
+      "text": "Jakie hobby albo umiejętność zawsze chcesz, żebyśmy razem wypróbowali?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_growth_001_fu_1",
+          "text": "Jak wyobrażasz sobie, że to nas do siebie zbliża?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_growth_001_fu_2",
+          "text": "Dlaczego uważasz, że robienie tego razem jest ważniejsze niż robienie tego w pojedynkę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_past_001",
+      "text": "Co było naszą najlepszą spontaniczną przygodą — taką, której w ogóle nie planowaliśmy?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_past_001_fu_1",
+          "text": "Co sprawiło, że ta spontaniczność tak dobrze nam wtedy wyszła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_past_001_fu_2",
+          "text": "Czy chcesz, żebyśmy częściej robili miejsce na takie chwile?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_dailyLife_012",
+      "text": "Jaki film lub serial kojarzy ci się z naszym związkiem?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_dailyLife_012_fu_1",
+          "text": "Co w nim najbardziej przypomina ci nas?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_dailyLife_012_fu_2",
+          "text": "Co to mówi o tym, jak postrzegasz nasz związek?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_communication_005",
+      "text": "Jaki jest twój język miłości, gdy jesteś pod presją, a jaki gdy dobrze się czujesz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_communication_005_fu_1",
+          "text": "Jak to wygląda w praktyce, gdy jesteś pod presją, a jak gdy dobrze ci idzie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_communication_005_fu_2",
+          "text": "Czego najbardziej potrzebujesz ode mnie w każdym z tych stanów?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_values_001",
+      "text": "Jaką tradycję chcesz, żebyśmy razem zaczęli?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_values_001_fu_1",
+          "text": "Jak myślisz, co ta tradycja zbuduje między nami z czasem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_values_001_fu_2",
+          "text": "Czy jest coś w twoim życiu, co sprawia, że takie rytuały są dla ciebie ważne?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_emotions_001",
+      "text": "Co potrafi natychmiast poprawić ci nastrój?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_emotions_001_fu_1",
+          "text": "Czy już to o tobie wiem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_emotions_001_fu_2",
+          "text": "A co jest odwrotnością — ta mała rzecz, która potrafi zepsuć dobry nastrój?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_conflict_001",
+      "text": "O czym najbardziej absurdalnego kiedykolwiek naprawdę się pokłóciliśmy?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_conflict_001_fu_1",
+          "text": "Co sprawiło, że w tamtej chwili wydawało się to takie ważne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_conflict_001_fu_2",
+          "text": "Czy teraz możesz się z tego śmiać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_appreciation_001",
+      "text": "Jaki komplement najbardziej cię zaskoczył?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_appreciation_001_fu_1",
+          "text": "Dlaczego myślisz, że akurat ten tak cię zaskoczył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_appreciation_001_fu_2",
+          "text": "Co poczułeś wtedy o sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_dailyLife_001",
+      "text": "Kiedy ostatnio zdarzyło ci się tak całkowicie zatracić w jakimś doświadczeniu?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_dailyLife_001_fu_1",
+          "text": "Co w tamtej chwili tak bardzo cię wciągnęło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_dailyLife_001_fu_2",
+          "text": "Jak często pozwalasz sobie na takie całkowite pochłonięcie czymś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_dailyLife_002",
+      "text": "Co jest najśmieszniejszą rzeczą, która nam się przydarzyła i której nigdy nie mamy dość opowiadania?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_dailyLife_002_fu_1",
+          "text": "Dlaczego myślisz, że ta historia jest dla nas tak czymś wyjątkowym?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_dailyLife_002_fu_2",
+          "text": "Co mówi o nas to, że właśnie z tego się śmiejemy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_001",
+      "text": "Czymś, co potrafi mnie trochę zamknąć, jest…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_001_fu_1",
+          "text": "Co w tym wyrywa cię z chwili?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_001_fu_2",
+          "text": "Wolisz to razem przepracować, czy po prostu chcesz, żebym to rozumiał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_002",
+      "text": "Jaki rodzaj energii albo uwagi zwykle budzi w tobie pragnienie?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_002_fu_1",
+          "text": "Kiedy po raz pierwszy to w sobie zauważyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_002_fu_2",
+          "text": "Co konkretnie w tym do ciebie trafia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_003",
+      "text": "Jednym z najbardziej zmysłowych przeżyć, jakie miałem, a które nie wiązało się z seksem, było…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_003_fu_1",
+          "text": "Co sprawiło, że ta chwila była tak naładowana?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_003_fu_2",
+          "text": "Co to mówi ci o tym, czym dla ciebie jest zmysłowość?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_004",
+      "text": "Wciąż pamiętam chwilę, w której poczułem się głęboko pożądany — było to, gdy…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_004_fu_1",
+          "text": "Co sprawiło, że w tej chwili poczułeś się tak bardzo chciany?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_004_fu_2",
+          "text": "Co się w tobie otwiera, kiedy czujesz się tak pożądany?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_005",
+      "text": "Intymne wspomnienie, które wciąż sprawia, że trochę się wzdryga, to…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_005_fu_1",
+          "text": "Co jest w tym takiego kłopotliwego — i czy już się z tego śmiejesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_005_fu_2",
+          "text": "Czy to coś zmieniło w tym, co pomaga ci czuć się swobodnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_006",
+      "text": "Jaki rodzaj intymnej chwili zostaje w ciele długo po tym, jak mija?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_006_fu_1",
+          "text": "Co sprawiło, że tak wyraziście zostało w tobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_006_fu_2",
+          "text": "Jak myślisz, co sprawiło, że to poczucie więzi było tak silne?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_007",
+      "text": "Co robisz, żeby intymność była żywa, a nie mechaniczna?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_007_fu_1",
+          "text": "Jak odkryłeś to u siebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_007_fu_2",
+          "text": "Jak to czujesz, kiedy ten wysiłek naprawdę dociera do partnera?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_008",
+      "text": "Krępującą intymną chwilą, której doświadczyłem, było…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_008_fu_1",
+          "text": "Jak sobie poradziłeś z tym w danej chwili?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_008_fu_2",
+          "text": "Czy potem poczułeś się bliżej, niezręcznie, czy trochę jednego i drugiego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_009",
+      "text": "Najbardziej pożądanym przez ciebie czuję się wtedy, gdy…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_009_fu_1",
+          "text": "Co jest w tym geście takiego, że naprawdę do ciebie trafia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_009_fu_2",
+          "text": "Czy myślisz, że wiem, jak wiele to dla ciebie znaczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_sex_010",
+      "text": "Chwilą, w której naprawdę poczułem się z tobą blisko fizycznie, było…",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_sex_010_fu_1",
+          "text": "Co sprawiło, że emocje i fizyczność były tak spójne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_sex_010_fu_2",
+          "text": "Jak myślisz, co pomaga budować między nami taki rodzaj więzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_deepDive_intimacy_001",
+      "text": "Co sprawiło, że dotarło do ciebie — ta osoba naprawdę mnie rozumie?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_light_deepDive_intimacy_001_fu_1",
+          "text": "Co w tamtej chwili pomogło ci poczuć tę więź zrozumienia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_deepDive_intimacy_001_fu_2",
+          "text": "Jak ten moment zmienił to, jak na mnie patrzysz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_deepDive_appreciation_001",
+      "text": "Co jest w nas takiego, czego nigdy nie chcesz zmieniać?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_light_deepDive_appreciation_001_fu_1",
+          "text": "Co czujesz na samą myśl, że mogłoby się to zmieniać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_deepDive_appreciation_001_fu_2",
+          "text": "Myślisz, że oboje widzimy to tak samo?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_deepDive_growth_001",
+      "text": "Jak myślisz, jak zmieniliśmy się nawzajem na lepsze?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_light_deepDive_growth_001_fu_1",
+          "text": "Czy jest wersja ciebie sprzed naszego związku, za którą nie tęsknisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_deepDive_growth_001_fu_2",
+          "text": "Z jakiej mojej zmiany jesteś najbardziej dumny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_deepDive_past_001",
+      "text": "Który rozdział naszej historii jest dla ciebie ulubionym?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_couples_light_deepDive_past_001_fu_1",
+          "text": "Co sprawiało, że tamten rozdział był tak wyjątkowy w porównaniu z pozostałymi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_deepDive_past_001_fu_2",
+          "text": "Jaki rozdział chcesz, żeby przyszedł następny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_001",
+      "text": "Jaka myśl powraca do ciebie, kiedy w końcu zapada cisza?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_001_fu_1",
+          "text": "Co ciągnie twój umysł z powrotem w to miejsce?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_001_fu_2",
+          "text": "Co pomogłoby tej myśli trochę odpuścić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_002",
+      "text": "Co teraz najbardziej ciąży w tobie — coś, czego pewnie w pełni nie widzę?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_002_fu_1",
+          "text": "Jak długo dźwigasz to głównie w pojedynkę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_002_fu_2",
+          "text": "Co pomogłoby temu ciężarowi trochę zelżeć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_conflict_001",
+      "text": "Kiedy coś uderzyło w ciebie mocniej, niż się mogło wydawać?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_conflict_001_fu_1",
+          "text": "Co twoim zdaniem kryło się pod tą reakcją?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_conflict_001_fu_2",
+          "text": "Zdałeś sobie z tego sprawę w tamtej chwili czy dopiero później?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_sex_001",
+      "text": "Czuję się najbardziej zmysłowo, kiedy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_sex_001_fu_1",
+          "text": "Co pomaga ci wchodzić w to uczucie w sposób najbardziej naturalny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_sex_001_fu_2",
+          "text": "Co zwykle cię od niego oddala?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_sex_002",
+      "text": "Czuję się najbardziej atrakcyjnie, kiedy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_sex_002_fu_1",
+          "text": "Co jest w tej chwili takiego, że czujesz się w niej naprawdę widziany?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_sex_002_fu_2",
+          "text": "Ile z tego uczucia pochodzi od ciebie, a ile od reakcji kogoś innego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_001",
+      "text": "Co chcesz, żebym lepiej rozumiał w tobie?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_001_fu_1",
+          "text": "Co jest najtrudniejsze do wytłumaczenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_001_fu_2",
+          "text": "Jak by się zmieniło to, co czujesz, gdybym to lepiej rozumiał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_003",
+      "text": "Jaki strach mnie przed tobą ukrywasz?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_003_fu_1",
+          "text": "Co powstrzymuje cię przed mówieniem o nim na głos?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_003_fu_2",
+          "text": "Jak myślisz, jak by to było, gdybym o tym wiedział?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_intimacy_001",
+      "text": "Kiedy najbardziej czujesz ten dystans między nami?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_intimacy_001_fu_1",
+          "text": "Co się wtedy dzieje w tobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_intimacy_001_fu_2",
+          "text": "Co pomaga ci znów poczuć bliskość ze mną?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_appreciation_001",
+      "text": "Co robię, że czujesz się naprawdę dostrzeżony?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_appreciation_001_fu_1",
+          "text": "Co jest w tym geście takiego, że do ciebie dociera?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_appreciation_001_fu_2",
+          "text": "Myślisz, że wiem, ile to dla ciebie znaczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_dailyLife_001",
+      "text": "Jaka część twojego dnia jest czymś, czym chciałoby ci się dzielić ze mną częściej?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_dailyLife_001_fu_1",
+          "text": "Co by ci to dawało, gdybym był przy tobie w tej części życia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_dailyLife_001_fu_2",
+          "text": "Co sprawia, że na razie tego nie robimy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_conflict_002",
+      "text": "Który nawyk ode mnie po cichu cię frustruje?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_conflict_002_fu_1",
+          "text": "Co w tobie się wtedy uruchamia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_conflict_002_fu_2",
+          "text": "Co sprawia, że trudno ci mi o tym powiedzieć bezpośrednio?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_conflict_003",
+      "text": "Za co od jakiegoś czasu chcesz mnie przeprosić?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_conflict_003_fu_1",
+          "text": "Co powstrzymuje te przeprosiny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_conflict_003_fu_2",
+          "text": "Co twoim zdaniem mogłoby się zmienić, gdybyś powiedział to na głos?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_intimacy_002",
+      "text": "Kiedy czujesz się ze mną najbezpieczniej?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_intimacy_002_fu_1",
+          "text": "Co w tych momentach pozwala ci się otworzyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_intimacy_002_fu_2",
+          "text": "Jak to poczucie bezpieczeństwa zmienia to, jak jesteś przy mnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_004",
+      "text": "Jaki rodzaj stresu zmienia cię w sposób, którego pewnie w pełni nie widzę?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_004_fu_1",
+          "text": "Co zaczyna się w tobie przesuwać, gdy ten stres narasta?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_004_fu_2",
+          "text": "Jak chcesz, żebym to wcześniej zauważał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_appreciation_002",
+      "text": "Co podziwiasz w tym, jak cię kocham?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_appreciation_002_fu_1",
+          "text": "Kiedy zauważasz to najbardziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_appreciation_002_fu_2",
+          "text": "Czy jest coś w tym, co chcesz móc mi oddawać w ten sam sposób?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_002",
+      "text": "Jaka rozmowa między nami zostaje w tobie najdłużej?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_002_fu_1",
+          "text": "Co w niej tak długo w tobie rezonuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_002_fu_2",
+          "text": "Czy zmieniła coś w tym, jak postrzegasz nas jako parę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_003",
+      "text": "Co między nami wydaje ci się teraz trochę omijane?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_003_fu_1",
+          "text": "Co sprawia, że ten temat czujesz się tak nietykalny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_003_fu_2",
+          "text": "Co twoim zdaniem by się stało, gdybyśmy jednak tam weszli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_004",
+      "text": "Gdy robi się ciężko, czego potrzebujesz ode mnie, a co często mi umyka?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_004_fu_1",
+          "text": "Jak ta potrzeba się w tobie objawia, zanim jeszcze znajdziesz na nią słowa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_004_fu_2",
+          "text": "Co pomogłoby mi to zauważyć wcześniej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_growth_001",
+      "text": "W jaki sposób pomogłem ci się rozwinąć, o czym jeszcze nie wspomniałeś?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_growth_001_fu_1",
+          "text": "Która część ciebie się przez to zmieniła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_growth_001_fu_2",
+          "text": "Myślisz, że w ogóle zdaję sobie sprawę, że miałem taki wpływ?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_dailyLife_002",
+      "text": "Czego mi brakuje w tym, co razem robimy — czegoś, czego nie chcesz, żebyśmy po cichu stracili?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_dailyLife_002_fu_1",
+          "text": "Co nam to dawało, kiedy było między nami bardziej żywe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_dailyLife_002_fu_2",
+          "text": "Co ostatnio staje nam na drodze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_past_001",
+      "text": "Za czym z naszych początków tęsknisz?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_past_001_fu_1",
+          "text": "Co sprawiało, że tamten czas był tak inny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_past_001_fu_2",
+          "text": "Czy da się jakoś przywołać trochę tamtej energii z powrotem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_005",
+      "text": "Po czym rozpoznajesz, że stres zaczyna cię trochę utwardzać?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_005_fu_1",
+          "text": "Co utwardza się jako pierwsze — ton głosu, cierpliwość, czy coś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_005_fu_2",
+          "text": "Co pomaga ci znowu się rozluźnić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_005",
+      "text": "Jakiej granicy potrzebujesz, żebym bardziej szanował?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_005_fu_1",
+          "text": "Co się w tobie dzieje, gdy ta granica zostaje przekroczona?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_005_fu_2",
+          "text": "Jak by się czuło, gdybym konsekwentnie jej przestrzegał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_growth_002",
+      "text": "Z czego jesteś dumny, że razem przez to przeszliśmy?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_growth_002_fu_1",
+          "text": "Co to wyzwanie ujawniło o tym, kim jesteśmy razem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_growth_002_fu_2",
+          "text": "Czy zmieniło to sposób, w jaki ufasz nam jako parze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_identity_001",
+      "text": "Kiedy czujesz się najbardziej sobą, będąc ze mną?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_identity_001_fu_1",
+          "text": "Co jest w tych chwilach takiego, że pozwala ci opuścić gardę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_identity_001_fu_2",
+          "text": "Czy są chwile, kiedy czujesz się mniej sobą, będąc ze mną?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_emotions_006",
+      "text": "Jaka niepewność wciąż pojawia się w naszym związku?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_emotions_006_fu_1",
+          "text": "Kiedy zazwyczaj wychodzi na powierzchnię?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_emotions_006_fu_2",
+          "text": "Co pomogłoby ci poczuć się z tym spokojniej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_appreciation_003",
+      "text": "Co powiedziałem ostatnio, co miało dla ciebie większe znaczenie, niż pewnie zdawałem sobie sprawę?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_appreciation_003_fu_1",
+          "text": "Czego w tobie dotknęło i zostało z tobą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_appreciation_003_fu_2",
+          "text": "Chcesz, żebym częściej mówił takie rzeczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_communication_006",
+      "text": "Czego potrzebujesz ode mnie, a trudno ci o to poprosić?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_communication_006_fu_1",
+          "text": "Co sprawia, że ta prośba jest taka trudna do wypowiedzenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_communication_006_fu_2",
+          "text": "Co by dla ciebie znaczyło, gdybym wiedział, żeby to zaproponować bez pytania?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_intimacy_003",
+      "text": "Jaki mały moment między nami wciąż do ciebie wraca?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_intimacy_003_fu_1",
+          "text": "Co sprawia, że ten moment tak wiele znaczy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_intimacy_003_fu_2",
+          "text": "Kiedy do niego wracasz, czujesz spokój czy tęsknotę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_intimacy_004",
+      "text": "Co w mijaniu lat sprawiło, że masz do mnie więcej czułości?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_intimacy_004_fu_1",
+          "text": "Co myślisz, że ta czułość otworzyła w tobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_intimacy_004_fu_2",
+          "text": "Jak zmieniła sposób, w jaki mnie kochasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_values_001",
+      "text": "Co pieniądze sprawiają, że czujesz w tym związku, czego zwykle nie mówisz na głos?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_values_001_fu_1",
+          "text": "Gdzie, jak myślisz, to uczucie związane z pieniędzmi po raz pierwszy się w tobie ukształtowało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_values_001_fu_2",
+          "text": "Jak to wpływa na to, jak zachowujesz się wobec mnie, kiedy pojawia się temat pieniędzy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_values_002",
+      "text": "Którą część naszego wspólnego życia chcesz, żebyśmy bardziej zaciekle chronili?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_values_002_fu_1",
+          "text": "Co najbardziej czujesz teraz, że jest tam zagrożone?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_values_002_fu_2",
+          "text": "Czego więcej wymagałoby od nas to chronienie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_emotions_001",
+      "text": "Kiedy ostatnio coś w tobie pękło — a ja pewnie w pełni tego nie rozumiałem?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_emotions_001_fu_1",
+          "text": "Co się wtedy w tobie działo, a mogłem przegapić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_emotions_001_fu_2",
+          "text": "Czego chcesz, żebym lepiej rozumiał w tamtej chwili?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_conflict_001",
+      "text": "Co przekonywałeś siebie, że jest między nami w porządku, choć tak naprawdę nie było?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_conflict_001_fu_1",
+          "text": "Co sprawiało, że łatwiej było to bagatelizować niż wprost nazwać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_conflict_001_fu_2",
+          "text": "Co cię kosztowało to milczenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_emotions_002",
+      "text": "Kiedy ostatnio powstrzymywałeś łzy i udawałeś, że wszystko gra?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_emotions_002_fu_1",
+          "text": "Przed czym się chroniłeś, trzymając to w środku?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_emotions_002_fu_2",
+          "text": "Jak myślisz, co by się stało, gdybyś pozwolił sobie płakać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_emotions_003",
+      "text": "Co w procesie starzenia się sprawiło, że bardziej się zamknąłeś?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_emotions_003_fu_1",
+          "text": "Co próbujesz chronić, kiedy ten mur wchodzi w górę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_emotions_003_fu_2",
+          "text": "Co sprawia, że czujesz się wystarczająco bezpiecznie, żeby go przy mnie opuścić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_communication_001",
+      "text": "Jakiej rozmowy wiesz, że potrzebujesz, a wciąż ją odkładasz?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_communication_001_fu_1",
+          "text": "Czego najbardziej boisz się usłyszeć w odpowiedzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_communication_001_fu_2",
+          "text": "Co musiałoby się stać, żebyś w końcu ją przeprowadził?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_emotions_004",
+      "text": "Czy jest coś w tym, jak zmieniam się z wiekiem, co cię niepokoi?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_emotions_004_fu_1",
+          "text": "Jaką zmianę dostrzegasz najwyraźniej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_emotions_004_fu_2",
+          "text": "Co w tobie budzi widok tej zmiany?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_communication_002",
+      "text": "Czego naprawdę chcesz ode mnie, a nie możesz się zdobyć, żeby o to poprosić?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_communication_002_fu_1",
+          "text": "Co sprawia, że ta prośba jest taka trudna do wypowiedzenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_communication_002_fu_2",
+          "text": "Jak twoim zdaniem bym zareagował, gdybyś zapytał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_conflict_002",
+      "text": "Gdzie teraz między nami czujesz największe tarcie?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_conflict_002_fu_1",
+          "text": "Co twoim zdaniem kryje się pod tym tarciem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_conflict_002_fu_2",
+          "text": "Jak wyglądałoby dla ciebie prawdziwe rozwiązanie tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_communication_003",
+      "text": "Kiedy czujesz, że reaguję na stres zamiast reagować na ciebie?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_communication_003_fu_1",
+          "text": "Co się wtedy między nami dzieje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_communication_003_fu_2",
+          "text": "Co pomogłoby ci czuć się wtedy bardziej przeze mnie widzianym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_communication_004",
+      "text": "Co złagodziłeś lub pominąłeś, bo bałeś się, jak to przyjmę?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_communication_004_fu_1",
+          "text": "Co wydawało się zbyt ryzykowne, żeby powiedzieć wprost?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_communication_004_fu_2",
+          "text": "Co twoim zdaniem by się stało, gdybyś powiedział to bez żadnych filtrów?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_emotions_005",
+      "text": "Kiedy ostatnio zazdrość naprawdę cię zżerała?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_emotions_005_fu_1",
+          "text": "Jaki głębszy strach się za nią krył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_emotions_005_fu_2",
+          "text": "Jak sobie z tym poradziłeś i co o tym teraz myślisz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_appreciation_001",
+      "text": "Co najbardziej podziwiasz w tym, jak twój partner radzi sobie z trudnymi rzeczami?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_appreciation_001_fu_1",
+          "text": "Czy jest konkretny moment, który pokazał ci tę siłę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_appreciation_001_fu_2",
+          "text": "Co budzi się w tobie, kiedy widzisz, jak sobie z tym radzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_001",
+      "text": "Chciałbym, żeby ktoś lepiej przygotował mnie do seksu, mówiąc mi…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_001_fu_1",
+          "text": "Jak odkrywanie tego na własną rękę na ciebie wpłynęło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_001_fu_2",
+          "text": "Co chcesz, żeby wiedział o tym ktoś młodszy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_002",
+      "text": "W trakcie intymności tracę zainteresowanie, kiedy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_002_fu_1",
+          "text": "Co twoim zdaniem dzieje się z tobą emocjonalnie w takich chwilach?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_002_fu_2",
+          "text": "Co pomaga ci zamiast tego pozostać obecnym i w kontakcie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_003",
+      "text": "Wiadomość o seksualnym charakterze, którą czasem chcę do ciebie wysłać, ale się powstrzymuję, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_003_fu_1",
+          "text": "Co cię powstrzymuje od wysłania jej naprawdę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_003_fu_2",
+          "text": "Jakiej reakcji liczysz się w niej spotkać, kiedy to sobie wyobrażasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_004",
+      "text": "Wiadomość od ciebie, która sprawiłaby, że poczułbym się głęboko chciany, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_004_fu_1",
+          "text": "Co by z tobą zrobiło przeczytanie takiej wiadomości?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_004_fu_2",
+          "text": "Jakiej potrzeby by dotknęła?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_005",
+      "text": "W intymności — czy mam tendencję do przejmowania inicjatywy, podążania, łagodzenia, drażnienia, powstrzymywania się, czy do czegoś zupełnie innego?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_005_fu_1",
+          "text": "Czy zawsze tak było, czy rozwinęło się to z czasem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_005_fu_2",
+          "text": "Co ta skłonność ci daje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_006",
+      "text": "Kiedy pragnę intymności, co zwykle dzieje się we mnie, zanim zrobię pierwszy krok?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_006_fu_1",
+          "text": "Co sprawia, że inicjowanie jest dla ciebie łatwe albo trudne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_006_fu_2",
+          "text": "Jakiej reakcji potrzebujesz, żeby bezpiecznie zrobić ten krok?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_007",
+      "text": "Co nauczyło cię pragnąć tego, czego pragniesz seksualnie — i co nauczyło cię się powstrzymywać?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_007_fu_1",
+          "text": "Które z tych lekcji wciąż wydają ci się prawdziwe, a które już nie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_007_fu_2",
+          "text": "Czego musiałeś się oduczyć, żeby być bardziej sobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_008",
+      "text": "Jedna seksualna prawda, o której chciałbym, żebyśmy rozmawiali bardziej otwarcie, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_008_fu_1",
+          "text": "Co sprawia, że ten temat trudno poruszyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_008_fu_2",
+          "text": "Co by nam dało, gdybyśmy mogli to razem przepracować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_sex_009",
+      "text": "Czymś, co chciałbym, żebyśmy razem odkryli — co jest ekscytujące, ale trochę trudne do nazwania — jest…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_sex_009_fu_1",
+          "text": "Co cię przyciąga do tego pomysłu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_sex_009_fu_2",
+          "text": "Czego potrzebujesz ode mnie, żeby czuć się bezpiecznie, próbując tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_emotions_001",
+      "text": "Czego twoje serce potrzebuje teraz ode mnie usłyszeć?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_emotions_001_fu_1",
+          "text": "Jak długo potrzebujesz to usłyszeć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_emotions_001_fu_2",
+          "text": "Co by się w tobie zmieniło, gdybym to powiedział?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_intimacy_001",
+      "text": "Co najbardziej zmieniło to, jak ufasz miłości?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_intimacy_001_fu_1",
+          "text": "Jakie były twoje przekonania o miłości przed tą zmianą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_intimacy_001_fu_2",
+          "text": "Jak ta zmiana wciąż przejawia się w tym, jak mnie teraz kochasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_emotions_002",
+      "text": "Co w naszej wspólnej przyszłości jednocześnie cię ekscytuje i przeraża?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_emotions_002_fu_1",
+          "text": "Które uczucie teraz silniejsze — ekscytacja czy strach?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_emotions_002_fu_2",
+          "text": "Co pomogłoby ekscytacji wygrać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_001",
+      "text": "Jak zaangażowanie zmieniło dla ciebie znaczenie intymności?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_001_fu_1",
+          "text": "Gdzie twoim zdaniem ukształtowało się w tobie to rozumienie zaangażowania i intymności?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_001_fu_2",
+          "text": "Jak to wpływa na to, czego teraz potrzebujesz ode mnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_002",
+      "text": "W trakcie intymności wszystko inne odpada, kiedy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_002_fu_1",
+          "text": "Co twoim zdaniem tworzy taki poziom obecności?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_002_fu_2",
+          "text": "Co pomaga ci do tego stanu docierać łatwiej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_003",
+      "text": "Pytanie lub wątpliwość na temat seksu, o którym wciąż myślę, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_003_fu_1",
+          "text": "Co sprawia, że to pytanie trudno rozstrzygnąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_003_fu_2",
+          "text": "Co pomogłoby ci poczuć się bezpieczniej, żeby o tym rozmawiać albo to odkrywać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_emotions_003",
+      "text": "Jaki strach związany ze starzeniem się łatwiej nosić w głowie niż powiedzieć na głos?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_emotions_003_fu_1",
+          "text": "Co sprawia, że łatwiej go trzymać w milczeniu niż się ze mną nim podzielić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_emotions_003_fu_2",
+          "text": "Co pomogłoby go razem bezpieczniej nazwać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_growth_001",
+      "text": "Jak czas nas wzmocnił, a jak uczynił nas bardziej kruchymi?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_growth_001_fu_1",
+          "text": "Gdzie teraz najwyraźniej czujesz naszą siłę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_growth_001_fu_2",
+          "text": "Gdzie najostrzej czujesz naszą kruchość?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_004",
+      "text": "Moje życie seksualne zmieniło się znacząco po…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_004_fu_1",
+          "text": "Co się w tobie zmieniło przez to doświadczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_004_fu_2",
+          "text": "Jak zmieniło to, czego szukasz w intymności?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_005",
+      "text": "Wczesne doświadczenie, które ukształtowało mój sposób myślenia o seksie, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_005_fu_1",
+          "text": "Jak to doświadczenie zabarwiło twoje podejście do intymności teraz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_005_fu_2",
+          "text": "Czy jakaś jego część wciąż jest z tobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_values_001",
+      "text": "Jak myślisz, czego będziemy od siebie potrzebować coraz bardziej, kiedy będziemy się starzeć?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_values_001_fu_1",
+          "text": "Jaka troska będzie dla ciebie, jak myślisz, najważniejsza?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_values_001_fu_2",
+          "text": "W czym masz nadzieję, że będziemy coraz lepiej sobie nawzajem dawać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_past_001",
+      "text": "Kiedy najbardziej czujesz, że nasz wspólny czas nie jest nieograniczony?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_past_001_fu_1",
+          "text": "Co ta świadomość sprawia, że chcesz chronić albo zmienić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_past_001_fu_2",
+          "text": "Jak to wpływa na to, jak mnie kochasz w tamtej chwili?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_006",
+      "text": "Seks jest dla mnie najbardziej znaczący, kiedy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_006_fu_1",
+          "text": "Co sprawia, że coś jest znaczące, a nie tylko fizyczne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_006_fu_2",
+          "text": "Co pomaga ci tworzyć to głębsze znaczenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_007",
+      "text": "Przekaz na temat seksu, który dostawałem w dzieciństwie, brzmiał…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_007_fu_1",
+          "text": "Jak ten przekaz w tobie przetrwał albo jak go przepisałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_007_fu_2",
+          "text": "Jaki przekaz chcesz przekazać zamiast tamtego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_008",
+      "text": "Najbezpieczniej czuję się w intymności wtedy, gdy…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_008_fu_1",
+          "text": "Jak to poczucie bezpieczeństwa odbierasz w ciele?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_008_fu_2",
+          "text": "Co zwykle pomaga utrzymać to poczucie bezpieczeństwa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_sex_009",
+      "text": "To, co pomaga mi naprawdę się rozluźnić i być z tobą obecny, to…",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_sex_009_fu_1",
+          "text": "Co zwykle staje na drodze do tej obecności?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_sex_009_fu_2",
+          "text": "Jak mogę ci to ułatwić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_001",
+      "text": "Jaką część siebie ukrywasz przed najbliższymi?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_001_fu_1",
+          "text": "Czego się boisz, że by się stało, gdyby to zobaczyli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_001_fu_2",
+          "text": "Jak ukrywanie tego wpływa na to, jak jesteś obecny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_001",
+      "text": "Co w nas dwojgu nigdy do końca nie dało ci spokoju?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_001_fu_1",
+          "text": "Czy to wciąż cię niepokoi, czy jakoś pogodziłeś się z tym, że nie masz odpowiedzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_001_fu_2",
+          "text": "Co twoim zdaniem by się zmieniło, gdyby to nabrało więcej sensu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_002",
+      "text": "Na ile twoim zdaniem naprawdę jesteśmy ze sobą szczerzy?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_002_fu_1",
+          "text": "Gdzie twoim zdaniem są te luki?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_002_fu_2",
+          "text": "Jak wyglądałaby pełna szczerość między nami?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_sex_001",
+      "text": "Czuję się najbardziej zmysłowo, kiedy…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_sex_001_fu_1",
+          "text": "Co pomaga ci wchodzić w to uczucie w sposób najbardziej naturalny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_sex_001_fu_2",
+          "text": "Co zwykle cię od niego oddala?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_sex_002",
+      "text": "Czuję się najbardziej atrakcyjnie, kiedy…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_sex_002_fu_1",
+          "text": "Co jest w tej chwili takiego, że czujesz się w niej naprawdę widziany?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_sex_002_fu_2",
+          "text": "Ile z tego uczucia pochodzi od ciebie, a ile od reakcji kogoś innego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_intimacy_001",
+      "text": "Jaka myśl o nas nigdy nie padła głośno?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_001_fu_1",
+          "text": "Co powstrzymywało cię przed powiedzeniem tego do tej pory?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_001_fu_2",
+          "text": "Jak myślisz, co to by we mnie wywołało?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_003",
+      "text": "Czego potrzebujesz w tym związku, a czego nie dostajesz?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_003_fu_1",
+          "text": "Jak długo nosisz w sobie tę niezaspokojoną potrzebę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_003_fu_2",
+          "text": "Jak wyglądałoby twoje życie, gdyby ta potrzeba była w pełni zaspokojona?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_001",
+      "text": "Kiedy czułeś się przeze mnie najbardziej niezrozumiany?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_001_fu_1",
+          "text": "Co chciałeś, żebym zobaczył, a co przeoczyłem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_001_fu_2",
+          "text": "Czy ta chwila zmieniła coś między nami?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_growth_001",
+      "text": "Co we mnie musiałeś nauczyć się akceptować?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_001_fu_1",
+          "text": "Czy ta akceptacja przychodziła stopniowo, czy coś ją przełamało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_001_fu_2",
+          "text": "Co było w tym najtrudniejsze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_identity_001",
+      "text": "Jaka wersja ciebie istnieje tylko dla mnie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_identity_001_fu_1",
+          "text": "Co jest w nas takiego, że ta wersja czuje się bezpiecznie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_identity_001_fu_2",
+          "text": "Lubisz tę wersję siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_appreciation_001",
+      "text": "Czy czujesz się przeze mnie doceniany w sposób, który dla ciebie naprawdę ma znaczenie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_appreciation_001_fu_1",
+          "text": "Gdzie to czujesz wyraźnie, a gdzie wciąż jest tego za mało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_appreciation_001_fu_2",
+          "text": "Jakie docenienie najbardziej do ciebie trafia: słowa, pomoc, uwaga, czy coś innego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_002",
+      "text": "Co najbardziej przeraża cię w naszej wspólnej przyszłości?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_002_fu_1",
+          "text": "Czy ten strach ma korzenie w nas, czy w czymś starszym?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_002_fu_2",
+          "text": "Co pomogłoby ten strach uciszyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_002",
+      "text": "Jaki schemat w naszym związku twoim zdaniem powinniśmy przełamać?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_002_fu_1",
+          "text": "Od czego ten schemat zazwyczaj się zaczyna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_002_fu_2",
+          "text": "Co twoim zdaniem byłoby potrzebne, żebyśmy naprawdę to zmienili?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_004",
+      "text": "W czym chcesz być ze mną bardziej szczery?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_004_fu_1",
+          "text": "Co czujesz, że jest zagrożone, jeśli to powiesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_004_fu_2",
+          "text": "Jakiej reakcji potrzebujesz, żeby szczerość stała się bezpieczna?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_003",
+      "text": "Co robię, że uruchamia w tobie coś głębszego?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_003_fu_1",
+          "text": "Czego tak naprawdę to dotyka?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_003_fu_2",
+          "text": "Myślisz, że mam pojęcie, że to tak na ciebie działa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_005",
+      "text": "Kiedy ostatnio zwątpiłeś, czy jesteśmy na tej samej stronie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_005_fu_1",
+          "text": "Co sprawiło, że nabrałeś wątpliwości?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_005_fu_2",
+          "text": "Powiedziałeś coś, czy zachowałeś to dla siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_growth_002",
+      "text": "Czego w miłości nikt cię nie ostrzegł?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_002_fu_1",
+          "text": "Jak to odkrycie cię zmieniło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_002_fu_2",
+          "text": "Co powiedzieć komuś, kto zaraz się o tym przekona?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_003",
+      "text": "Jaką urazę nosisz w sobie, a której nie wyraziłeś na głos?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_003_fu_1",
+          "text": "Co robi z tobą trzymanie tego w sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_003_fu_2",
+          "text": "Czego potrzebujesz, żeby czuć się bezpiecznie, mogąc to wypuścić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_intimacy_002",
+      "text": "Który moment z nami kojarzy ci się z największą wrażliwością?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_002_fu_1",
+          "text": "Co w tamtej chwili zburzyło twój mur?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_002_fu_2",
+          "text": "Czy ta wrażliwość nas zbliżyła, czy zostawiła poczucie odsłonięcia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_growth_003",
+      "text": "Jak myślisz, jaka jest nasza największa ślepa plamka jako pary?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_003_fu_1",
+          "text": "Co najtrudniej nam zobaczyć wyraźnie od środka?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_growth_003_fu_2",
+          "text": "Co mogłoby się zmienić, gdybyśmy widzieli to bardziej szczerze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_004",
+      "text": "Jaka prawda o tobie przeraża cię tym, że mogłaby zmienić to, jak na ciebie patrzę?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_004_fu_1",
+          "text": "Jak w najgorszym scenariuszu wyobrażasz sobie moją reakcję?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_004_fu_2",
+          "text": "Co by to znaczyło, gdybym usłyszał to i nic by się nie zmieniło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_values_001",
+      "text": "Czy kiedykolwiek czujesz, że poświęciłeś dla tego związku zbyt wiele z siebie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_values_001_fu_1",
+          "text": "Zdawałeś sobie z tego sprawę na bieżąco, czy dopiero później?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_values_001_fu_2",
+          "text": "Co ze swojej perspektywy chcesz, żeby potoczyło się inaczej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_004",
+      "text": "Jaka kłótnia między nami naprawdę zmieniła coś na lepsze?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_004_fu_1",
+          "text": "Co przebijało się przez tę kłótnię, a co inaczej mogłoby nigdy nie wyjść na jaw?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_004_fu_2",
+          "text": "Czy zmieniła coś w tym, jak postrzegasz konflikty między nami?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_past_001",
+      "text": "Co z mojej przeszłości nadal w tobie siedzi?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_past_001_fu_1",
+          "text": "Co sprawia, że to wciąż do ciebie wraca?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_past_001_fu_2",
+          "text": "Pogodziłeś się z tym, czy to nadal jest nierozwiązane?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_communication_006",
+      "text": "Co chcesz zmienić w tym, jak rozmawiamy, gdy jest ciężko?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_006_fu_1",
+          "text": "Jak wygląda nasz najgorszy schemat komunikacji?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_communication_006_fu_2",
+          "text": "Jak czułoby się to, gdybyśmy robili to lepiej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_005",
+      "text": "Jakie oczekiwanie wobec mnie masz, które może nie jest fair?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_005_fu_1",
+          "text": "Skąd twoim zdaniem pochodzi to oczekiwanie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_005_fu_2",
+          "text": "Co by dla ciebie znaczyło, gdybyś z niego zrezygnował?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_005",
+      "text": "Kiedy ostatnio czułeś się zupełnie samotnie, choć byliśmy razem?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_005_fu_1",
+          "text": "Co się wtedy między nami działo?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_005_fu_2",
+          "text": "Co pomogłoby ci czuć się mniej samotnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_conflict_006",
+      "text": "Za co mi wybaczyłeś, o czym nie wiem?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_006_fu_1",
+          "text": "Ile cię to wybaczenie kosztowało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_conflict_006_fu_2",
+          "text": "Czy jest jakaś część tego, która wciąż nie jest do końca zamknięta?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_emotions_006",
+      "text": "Czego — twoim zdaniem — każde z nas unika czuć najbardziej?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_006_fu_1",
+          "text": "Jak to unikanie przejawia się w tym, jak się nawzajem traktujemy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_emotions_006_fu_2",
+          "text": "Co by się stało, gdybyśmy przestali tego unikać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_identity_002",
+      "text": "Czy jest coś, jak się zmieniłeś odkąd jesteśmy razem, co cię niepokoi?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_identity_002_fu_1",
+          "text": "Czy to zmiana, którą wybrałeś, czy coś, co po prostu się stało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_identity_002_fu_2",
+          "text": "Co by pomyślała o tym dawna wersja ciebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_intimacy_003",
+      "text": "Czy jest coś między nami, czego wstyd ci byłoby ujawnić innym?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_003_fu_1",
+          "text": "Co myślisz, że ten wstyd chroni?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_intimacy_003_fu_2",
+          "text": "Co wydaje ci się w tym najbardziej odsłonięte?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_dailyLife_001",
+      "text": "Jaki mój nawyk w domu po cichu cię irytuje?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_dailyLife_001_fu_1",
+          "text": "Czy zdarzyło ci się kiedyś o tym powiedzieć, czy po prostu to w sobie chowasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_dailyLife_001_fu_2",
+          "text": "Co by dla ciebie znaczyło, gdybym naprawdę to zmienił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_appreciation_002",
+      "text": "Czy wystarczająco doceniam to, co po cichu dźwigasz w domu?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_appreciation_002_fu_1",
+          "text": "Co czujesz się teraz najbardziej niewidoczne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_appreciation_002_fu_2",
+          "text": "Jakiego uznania tak naprawdę potrzebujesz, żeby do ciebie dotarło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_emotions_001",
+      "text": "Co udajesz, że jest w porządku, choć naprawdę tak nie jest?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_emotions_001_fu_1",
+          "text": "Jak długo utrzymujesz ten pozór?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_emotions_001_fu_2",
+          "text": "Co myślisz, że by się stało, gdybyś przestał udawać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_conflict_001",
+      "text": "Kiedy zraniłeś kogoś mimowolnie i co się potem stało?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_001_fu_1",
+          "text": "Zorientowałeś się od razu czy dopiero po jakimś czasie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_001_fu_2",
+          "text": "Czego nauczyło cię to o różnicy między intencją a skutkiem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_conflict_002",
+      "text": "Co w tobie bywa trudne do zniesienia — jeśli masz być szczery?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_002_fu_1",
+          "text": "Jak twoim zdaniem ta część ciebie wpływa na najbliższych?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_002_fu_2",
+          "text": "Czy to coś, co próbujesz zmieniać, czy coś, z czym wciąż się poznajesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_emotions_002",
+      "text": "Kiedy ostatnio czułeś się naprawdę zagubiony i co się wtedy działo?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_emotions_002_fu_1",
+          "text": "Po co sięgnąłeś, żeby znaleźć grunt pod nogami?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_emotions_002_fu_2",
+          "text": "Czy ktokolwiek wiedział, jak bardzo się zgubiłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_growth_001",
+      "text": "W jakich sytuacjach jesteś swoim najgorszym wrogiem?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_growth_001_fu_1",
+          "text": "Jak zwykle wygląda twoje sabotowanie siebie w takich chwilach?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_growth_001_fu_2",
+          "text": "Jak myślisz, czego tak naprawdę próbujesz wtedy chronić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_conflict_003",
+      "text": "Jak wycofujesz miłość lub uwagę, gdy jesteś zdenerwowany?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_003_fu_1",
+          "text": "Czy zawsze to zauważasz, kiedy to robisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_003_fu_2",
+          "text": "Co pomogłoby ci zostać obecnym zamiast się wycofywać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_appreciation_001",
+      "text": "Czy wystarczająco ci dziękuję za to, co robisz, żeby nasze życie się toczyło?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_appreciation_001_fu_1",
+          "text": "Co robisz, co czujesz się najbardziej traktowane jako oczywistość?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_appreciation_001_fu_2",
+          "text": "Kiedy najbardziej masz wrażenie, że twój wysiłek znika w tle?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_conflict_004",
+      "text": "Kiedy przyznałeś się, że się mylisz — i jak się z tym czułeś?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_004_fu_1",
+          "text": "Co sprawiało, że to przyznanie było takie trudne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_conflict_004_fu_2",
+          "text": "Czy zmieniło to coś w związku?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_sex_001",
+      "text": "Czymś, co zawsze chciałem zbadać seksualnie, jest…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_sex_001_fu_1",
+          "text": "Co cię do tego przyciąga i co cię powstrzymuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_sex_001_fu_2",
+          "text": "Czego potrzebujesz, żeby poczuć się wystarczająco bezpiecznie i to poruszyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_sex_002",
+      "text": "Która część pragnienia jest dla ciebie najtrudniejsza do przyznania na głos — nawet przed sobą?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_sex_002_fu_1",
+          "text": "Co jest w tej granicy takiego, że cię przyciąga albo każe się wahać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_sex_002_fu_2",
+          "text": "Jakie uczucie towarzyszy tej myśli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_dailyLife_001",
+      "text": "Jakie niewidoczne oczekiwanie dźwigasz w domu, którego nigdy nie dostrzegałem?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_dailyLife_001_fu_1",
+          "text": "Jak długo nosisz to w sobie, nic nie mówiąc?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_dailyLife_001_fu_2",
+          "text": "Jak by to wyglądało, gdybym naprawdę to zobaczył?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_appreciation_002",
+      "text": "Czy mówię ci, że cię kocham wystarczająco często, żeby wciąż brzmiało prawdziwie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_appreciation_002_fu_1",
+          "text": "Kiedy słyszenie tego trafia do ciebie najgłębiej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_appreciation_002_fu_2",
+          "text": "Co sprawia, że brzmi to prawdziwie, a nie jak nawyk?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_emotions_001",
+      "text": "O czym kiedyś marzyłeś, a z czego po cichu zrezygnowałeś?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_001_fu_1",
+          "text": "Kiedy przestałeś wierzyć, że to możliwe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_001_fu_2",
+          "text": "Czy jest w tobie część, która wciąż tego pragnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_values_001",
+      "text": "Gdyby trzeba było wybierać, dla czego wszystko poświęcasz?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_values_001_fu_1",
+          "text": "Co ten wybór mówi o tym, co cenisz najbardziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_values_001_fu_2",
+          "text": "Czy ta odpowiedź zmieniła się z czasem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_intimacy_001",
+      "text": "Czy myślisz o kimś jako o tej jednej osobie, która odeszła?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_intimacy_001_fu_1",
+          "text": "Co tak naprawdę za tym tęsknisz — tę osobę czy możliwość, którą ze sobą niosła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_intimacy_001_fu_2",
+          "text": "Jak to wspomnienie wpływa na to, jak teraz kochasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_intimacy_002",
+      "text": "Jakiej najtrudniejszej lekcji nauczyła cię miłość?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_intimacy_002_fu_1",
+          "text": "Jak ta lekcja zmieniła to, czego potrzebujesz od partnera?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_intimacy_002_fu_2",
+          "text": "Wciąż się jej uczysz, czy jest już z nią pokój?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_appreciation_001",
+      "text": "Czy okazuję ci docenienie przy innych ludziach w sposób, który naprawdę czujesz?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_appreciation_001_fu_1",
+          "text": "Kiedy czujesz się przeze mnie publicznie wyróżniony, a kiedy nie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_appreciation_001_fu_2",
+          "text": "Co sprawiłoby, że to docenienie byłoby bardziej widoczne i bardziej prawdziwe?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_emotions_002",
+      "text": "Jakie złamanie serca uderzyło cię najmocniej?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_002_fu_1",
+          "text": "Jaką część ciebie otworzyło i rozbiło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_002_fu_2",
+          "text": "Jak zmieniło sposób, w jaki chronisz swoje serce?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_emotions_003",
+      "text": "Kiedy ostatnio czułeś się naprawdę samotnie, nawet jeśli nie byłeś sam?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_003_fu_1",
+          "text": "Czego brakowało w tamtej chwili?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_emotions_003_fu_2",
+          "text": "Co myślisz, że pomogłoby ci czuć się mniej samotnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_conflict_001",
+      "text": "Czego twoim zdaniem nie byłbyś w stanie wybaczyć w związku?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_conflict_001_fu_1",
+          "text": "Co ta granica w tobie chroni?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_conflict_001_fu_2",
+          "text": "Czy coś kiedykolwiek zbliżyło się do jej przekroczenia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_sex_001",
+      "text": "Jaką prawdę o sobie seksualnie najtrudniej byłoby ci powiedzieć partnerowi, który cię kocha?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_001_fu_1",
+          "text": "Co sprawia, że ta prawda tak bardzo wystawia cię na widok?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_001_fu_2",
+          "text": "Co wyobrażasz sobie, że by się zmieniło, gdyby ta prawda była w pełni znana?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_sex_002",
+      "text": "Co poczułeś po intymności, co trudniej było przyznać niż samo pragnienie?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_002_fu_1",
+          "text": "Co sprawiło, że to uczucie było trudne do nazwania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_002_fu_2",
+          "text": "Czy to coś zmieniło w tym, jak podchodziłeś potem do bliskości?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_sex_003",
+      "text": "Fantazja, do której mam mieszane uczucia, to…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_003_fu_1",
+          "text": "Na czym polega napięcie między częścią, która tego pragnie, a tą, która się opiera?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_003_fu_2",
+          "text": "Jak myślisz, za czym tak naprawdę sięga ta fantazja?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_sex_004",
+      "text": "Czymś, co do tej pory nie było do końca szczere w moim seksualnym życiorysie, jest…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_004_fu_1",
+          "text": "Co przez cały ten czas powstrzymywało cię od podzielenia się tym?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_004_fu_2",
+          "text": "Jak wyobrażasz sobie, że to by zmieniło, gdyby ktoś to wiedział?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_sex_005",
+      "text": "Fantazja, która wciąż do mnie wraca, to…",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "sex",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_005_fu_1",
+          "text": "Jak myślisz, za czym tak naprawdę sięga ta fantazja?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_sex_005_fu_2",
+          "text": "Jak się czujesz z tym, że wciąż wraca?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_dailyLife_001",
+      "text": "Która część naszego codziennego życia razem powoli cię wyczerpuje?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_dailyLife_001_fu_1",
+          "text": "Od kiedy ten ciężar jest z tobą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_dailyLife_001_fu_2",
+          "text": "Co musiałoby się zmienić, żeby znowu dało się to udźwignąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_appreciation_002",
+      "text": "Co mogę robić regularniej, żebyś czuł się głęboko doceniany — nie tylko kochany?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_appreciation_002_fu_1",
+          "text": "Za jakim docenieniem tęsknisz, a którego wciąż mi może brakować?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_appreciation_002_fu_2",
+          "text": "Co by się w tobie zmieniło, gdybyś częściej to ode mnie czuł?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_parenting_001",
+      "text": "Kiedy jako rodzice czujesz, że najbardziej tworzymy razem drużynę?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_parenting_001_fu_1",
+          "text": "Co jest w tych chwilach takiego, że czujemy się zgrani?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_parenting_001_fu_2",
+          "text": "Co chcesz, żebyśmy częściej chronili przed codziennym chaosem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_parenting_002",
+      "text": "Co w sposobie, w jaki wychowujesz dzieci, sprawia, że łatwo cię kochać?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_parenting_002_fu_1",
+          "text": "Co ta cecha daje, jak myślisz, naszej rodzinie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_parenting_002_fu_2",
+          "text": "Czy czujesz, że naprawdę widzę tę część ciebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_warmUp_parenting_003",
+      "text": "Jaka mała rodzicielska chwila między nami nadal sprawia, że się uśmiechasz?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_warmUp_parenting_003_fu_1",
+          "text": "Dlaczego, jak myślisz, tamta chwila tak przy tobie pozostała?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_warmUp_parenting_003_fu_2",
+          "text": "Co to mówi o nas, kiedy jesteśmy najlepsi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_parenting_001",
+      "text": "Która część rodzicielstwa wydobyła ze mnie stronę, której się nie spodziewałeś?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_parenting_001_fu_1",
+          "text": "Czy to zaskoczenie zbliżyło cię do mnie, czy raczej wywołało niepewność?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_parenting_001_fu_2",
+          "text": "Czego dzięki tej stronie dowiedziałeś się o mnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_realTalk_parenting_002",
+      "text": "W czym, jak myślisz, dobrze funkcjonujemy razem jako rodzice, nie doceniając tego wystarczająco?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_realTalk_parenting_002_fu_1",
+          "text": "Z czym radzimy sobie lepiej, niż zazwyczaj zauważamy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_realTalk_parenting_002_fu_2",
+          "text": "Dlaczego trudno nam to dostrzec, kiedy jesteśmy w środku tego wszystkiego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_light_deepDive_parenting_001",
+      "text": "Co rodzicielstwo sprawiło, że bardziej niż wcześniej doceniasz mnie?",
+      "mode": "couples",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_light_deepDive_parenting_001_fu_1",
+          "text": "Kiedy zacząłeś po raz pierwszy zauważać tę cechę głębiej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_light_deepDive_parenting_001_fu_2",
+          "text": "Co to docenienie w tobie teraz budzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_parenting_001",
+      "text": "Która część rodzicielstwa sprawia, że czujesz się przeze mnie najbardziej niedostrzeżony?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_parenting_001_fu_1",
+          "text": "Co chcesz, żebym rozumiał w tym ciężarze?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_parenting_001_fu_2",
+          "text": "Jakie uznanie naprawdę by do ciebie dotarło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_parenting_002",
+      "text": "Kiedy życie robi się ciężkie — czego potrzebujesz ode mnie jako rodzica i partnera, a czego mi często brakuje?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_parenting_002_fu_1",
+          "text": "Co sprawia, że tę potrzebę łatwo mi przeoczyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_parenting_002_fu_2",
+          "text": "Jak chcesz, żebym zachowywał się inaczej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_warmUp_parenting_003",
+      "text": "Co rodzicielstwo zmieniło w tym, czego ode mnie potrzebujesz?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_warmUp_parenting_003_fu_1",
+          "text": "Którą zmianę najtrudniej wyrazić na głos?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_warmUp_parenting_003_fu_2",
+          "text": "Na co liczyłeś, że sam to zauważę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_parenting_001",
+      "text": "Gdzie rodzicielstwo jest teraz między nami najbardziej nierówne?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_parenting_001_fu_1",
+          "text": "Czy ta nierównowaga dotyczy głównie czasu, obciążenia emocjonalnego, czy czegoś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_parenting_001_fu_2",
+          "text": "Jak wyglądałaby dla ciebie większa równowaga w prawdziwym życiu — nie tylko w teorii?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_parenting_002",
+      "text": "O którą część siebie najtrudniej ci było walczyć od kiedy jesteś rodzicem?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_parenting_002_fu_1",
+          "text": "Kiedy czujesz, że ta część ciebie odpływa najdalej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_parenting_002_fu_2",
+          "text": "Czego ode mnie potrzebujesz, żeby jej strzec?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_parenting_003",
+      "text": "Kiedy czujesz, że reaguję jak współrodzic, a nie jak twój partner?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_parenting_003_fu_1",
+          "text": "Co ginie między nami w takich chwilach?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_parenting_003_fu_2",
+          "text": "Co sprawia, że znów czujesz się moim partnerem, a nie tylko moim wspólnikiem w zadaniach?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_realTalk_parenting_004",
+      "text": "Gdzie nasze różnice w podejściu do dyscypliny tworzą między nami największe napięcie?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_realTalk_parenting_004_fu_1",
+          "text": "Co, jak myślisz, każde z nas próbuje chronić w swoim sposobie reagowania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_realTalk_parenting_004_fu_2",
+          "text": "Co pomogłoby nam się nie zgadzać, nie stając przy tym przeciwko sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_parenting_001",
+      "text": "Przez którą część rodzicielstwa opłakujesz coś, czym byliśmy razem kiedyś?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_parenting_001_fu_1",
+          "text": "Za czym tęsknisz najbardziej, choć wciąż trudno ci się do tego przyznać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_parenting_001_fu_2",
+          "text": "Co by to znaczyło — uznać ten żal, nie odwracając się od życia, które mamy teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_honest_deepDive_parenting_002",
+      "text": "Jaki lęk nosisz w sobie o to, jakimi rodzicami możemy się stać pod zbyt dużą presją?",
+      "mode": "couples",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_honest_deepDive_parenting_002_fu_1",
+          "text": "Przed czym, jak myślisz, ten lęk próbuje cię ochronić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_honest_deepDive_parenting_002_fu_2",
+          "text": "Co pomogłoby ci bardziej nam ufać pod presją?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_warmUp_parenting_001",
+      "text": "Jakiej urazy związanej z rodzicielstwem próbujesz nie przyznawać przed sobą?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_warmUp_parenting_001_fu_1",
+          "text": "Co robi z tobą trzymanie tej urazy w sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_warmUp_parenting_001_fu_2",
+          "text": "Co pomogłoby jej wyjść bez zamieniania się w kłótnię?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_parenting_001",
+      "text": "Gdzie, jak myślisz, opieram się na tobie w sposób, który nie jest już uczciwy?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_parenting_001_fu_1",
+          "text": "Jak długo to dźwigasz, nie nazywając tego wprost?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_parenting_001_fu_2",
+          "text": "Co musiałoby się zmienić, żebyś przestał czuć tę presję?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_realTalk_parenting_002",
+      "text": "Która część rodzicielstwa zabrała ci coś, z czym jeszcze się nie pogodziłeś?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_realTalk_parenting_002_fu_1",
+          "text": "Przyznanie się do czego jest najtrudniejsze?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_realTalk_parenting_002_fu_2",
+          "text": "Czy rozumiem, jak wiele ta strata dla ciebie kosztuje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_parenting_001",
+      "text": "Czego najbardziej się boisz, że po cichu przekazujemy dalej, choć wcale tego nie chcemy?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_parenting_001_fu_1",
+          "text": "Gdzie, jak myślisz, ten wzorzec pierwszy raz zapuścił korzenie — w tobie albo we mnie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_parenting_001_fu_2",
+          "text": "Co by trzeba, żebyśmy go przerwali zamiast powtarzać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_couples_unfiltered_deepDive_parenting_002",
+      "text": "Jaka prawda o naszym rodzicielstwie wydaje ci się zbyt ryzykowna, żeby powiedzieć ją mimochodem?",
+      "mode": "couples",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "parenting",
+      "followUps": [
+        {
+          "id": "p_couples_unfiltered_deepDive_parenting_002_fu_1",
+          "text": "Co, jak czujesz, jest najbardziej zagrożone, jeśli powiesz to wprost?",
+          "style": "origin"
+        },
+        {
+          "id": "p_couples_unfiltered_deepDive_parenting_002_fu_2",
+          "text": "Co pomogłoby ci uwierzyć, że możemy to przeżyć — całą prawdę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_001",
+      "text": "Jak chcesz, żeby ludzie cię przedstawiali innym?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_001_fu_1",
+          "text": "Co mówi ten opis o tym, co jest dla ciebie najważniejsze?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_001_fu_2",
+          "text": "Jak bardzo różni się to od tego, jak myślisz, że inni cię faktycznie widzą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_001",
+      "text": "Jaką książkę polecasz każdemu bez wyjątku?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_001_fu_1",
+          "text": "Co w niej tak mocno na ciebie zadziałało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_001_fu_2",
+          "text": "Jakiemu typowi osoby zwykle ją polecasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_conflict_001",
+      "text": "Czy masz w telefonie kontakt, który pewnie dawno należało usunąć?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_conflict_001_fu_1",
+          "text": "Co cię przed tym powstrzymuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_conflict_001_fu_2",
+          "text": "Co tak naprawdę oznaczałoby jego usunięcie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_002",
+      "text": "Gdyby twoje życie było filmem, kogo obsadzasz w roli siebie?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_002_fu_1",
+          "text": "Co w tej osobie oddaje twoją energię?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_002_fu_2",
+          "text": "Co twoim zdaniem byłoby dla niej najtrudniejsze do zagrania?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_003",
+      "text": "Kiedy ostatni raz nakryto cię na czymś, czego nie powinieneś robić?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_003_fu_1",
+          "text": "Jak zareagowałeś, kiedy cię przyłapano?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_003_fu_2",
+          "text": "Chcesz to zrobić znowu, wiedząc, że uchodzi ci to na sucho?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_004",
+      "text": "Jaki jest najbardziej żenujący moment, z którego potrafisz się teraz śmiać?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_004_fu_1",
+          "text": "Ile czasu minęło, zanim zacząłeś się z tego śmiać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_004_fu_2",
+          "text": "Co sprawiło, że przestało być żenujące, a zaczęło być śmieszne?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_appreciation_001",
+      "text": "Co naprawdę hojnego zrobiłeś ostatnio dla kogoś bez żadnej prośby?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_appreciation_001_fu_1",
+          "text": "Co cię do tego skłoniło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_appreciation_001_fu_2",
+          "text": "Czy ta osoba się dowiedziała, że to ty?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_002",
+      "text": "Jaką zasadę łamiesz z cichą przyjemnością?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_002_fu_1",
+          "text": "Co ci daje jej łamanie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_002_fu_2",
+          "text": "Czy ktoś to zauważył?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_005",
+      "text": "Za co pewnie dostałbyś jutro zwolnienie z pracy?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_005_fu_1",
+          "text": "Jesteś z tego dumny, czy próbujesz to w sobie zmienić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_005_fu_2",
+          "text": "Co to mówi o tym, jak działasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_values_001",
+      "text": "Gdyby dało się być zapamiętanym z jednej rzeczy, co by to było?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_values_001_fu_1",
+          "text": "Dlaczego akurat to, a nie coś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_values_001_fu_2",
+          "text": "Aktywnie do tego dążysz, czy to raczej życzenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_003",
+      "text": "Co zawsze zastanawiało cię — czy wszyscy robią to po cichu tak samo?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_003_fu_1",
+          "text": "Co by to dla ciebie znaczyło, gdyby robili?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_003_fu_2",
+          "text": "Jak byś się czuł, gdybyś okazał się jedyną taką osobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_values_002",
+      "text": "O czym możesz gadać godzinami, a większość ludzi by się nie spodziewała?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_values_002_fu_1",
+          "text": "Jak rozwinęło się to zainteresowanie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_values_002_fu_2",
+          "text": "Kto w twoim otoczeniu wie o tej twojej stronie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_006",
+      "text": "Czym chętnie zajmowałbyś się zawodowo, gdyby pieniądze nie miały żadnego znaczenia?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_006_fu_1",
+          "text": "Co przyciąga cię do tego bardziej niż do wszystkiego innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_006_fu_2",
+          "text": "Co powstrzymuje cię od robienia kroków w tym kierunku już teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_007",
+      "text": "Gdyby dało się jutro zacząć zupełnie inną karierę, co byś wybrał?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_007_fu_1",
+          "text": "Jaką potrzebę ta kariera zaspokajałaby, której obecna nie spełnia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_007_fu_2",
+          "text": "Co najbardziej powstrzymuje cię od tego skoku?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_values_003",
+      "text": "Gdybyś pisał książkę o swoim życiu, jak by się nazywała?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_values_003_fu_1",
+          "text": "W którym rozdziale jesteś teraz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_values_003_fu_2",
+          "text": "Jaki byłby klimat tej książki — śmieszny, ciężki, pełen nadziei?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_004",
+      "text": "Co najbardziej wyciąga z ciebie ducha rywalizacji?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_004_fu_1",
+          "text": "Skąd twoim zdaniem bierze się ta ambicja?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_004_fu_2",
+          "text": "Lubisz tę swoją konkurencyjność?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_008",
+      "text": "Gdzie na imprezie można cię najczęściej znaleźć?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_008_fu_1",
+          "text": "Co ten kąt mówi o twojej energii towarzyskiej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_008_fu_2",
+          "text": "Jesteś tam z wyboru, czy z przyzwyczajenia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_communication_001",
+      "text": "Co ludzie konsekwentnie mylnie o tobie sądzą?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_communication_001_fu_1",
+          "text": "Co twoim zdaniem wywołuje to błędne przekonanie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_communication_001_fu_2",
+          "text": "Irytuje cię to, czy przestałeś to prostować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_005",
+      "text": "W czym udajesz, że wiesz znacznie więcej, niż wiesz naprawdę?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_005_fu_1",
+          "text": "Skąd się wzięło to udawanie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_005_fu_2",
+          "text": "Czy ktoś kiedyś cię na tym przyłapał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_009",
+      "text": "Jaki jest najdziwniejszy sen, jaki ci się kiedykolwiek przyśnił?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_009_fu_1",
+          "text": "Zostało ci to po przebudzeniu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_009_fu_2",
+          "text": "Myślisz, że coś znaczył, czy to był tylko chaos?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_appreciation_002",
+      "text": "Jaką cechę swojego najbliższego przyjaciela naprawdę podziwiasz?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_appreciation_002_fu_1",
+          "text": "Czy widzisz tę cechę też w sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_appreciation_002_fu_2",
+          "text": "Czy kiedykolwiek powiedziałeś mu, że to podziwiasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_appreciation_003",
+      "text": "Kiedy ostatni raz ktoś rozkleił cię bez żadnego wysiłku z jego strony?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_appreciation_003_fu_1",
+          "text": "Co zrobił i czemu trafiło to w punkt?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_appreciation_003_fu_2",
+          "text": "Czy wiedział, jaki efekt wywołał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_010",
+      "text": "Jaka jest najbardziej absurdalna rzecz na twojej liście marzeń?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_010_fu_1",
+          "text": "Skąd wziął się ten pomysł?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_010_fu_2",
+          "text": "Co dotąd cię od tego powstrzymuje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_values_004",
+      "text": "O co gotów jesteś się kłócić do upadłego, mimo że nikomu innemu na tym nie zależy?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_values_004_fu_1",
+          "text": "Dlaczego akurat to jest dla ciebie tak ważne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_values_004_fu_2",
+          "text": "Czy bronienie tego stanowiska wciągnęło cię kiedyś w kłopoty?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_011",
+      "text": "Jaki był najlepszy posiłek w twoim życiu i gdzie go jadłeś?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_011_fu_1",
+          "text": "Co sprawiło, że ten posiłek jest niezapomniany?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_011_fu_2",
+          "text": "Chodziło o jedzenie, czy o chwilę wokół niego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_006",
+      "text": "W czym jesteś dziwnie dobry, a to nie ma żadnego praktycznego zastosowania?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_006_fu_1",
+          "text": "Jak odkryłeś ten talent?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_006_fu_2",
+          "text": "Czy kiedyś przydał się w nieoczekiwany sposób?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_dailyLife_012",
+      "text": "Co robiłeś ostatnio do późnej nocy, chociaż powinieneś iść spać?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_dailyLife_012_fu_1",
+          "text": "Było warto poświęcić sen?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_dailyLife_012_fu_2",
+          "text": "Co sprawiło, że tak trudno było przestać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_values_005",
+      "text": "Jakiego trendu absolutnie nie chcesz przyjmować?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_values_005_fu_1",
+          "text": "Co konkretnie w tym trendzie cię denerwuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_values_005_fu_2",
+          "text": "Czy ludzie dają ci za to w kość?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_appreciation_004",
+      "text": "Jaką najbardziej przemyślaną rzecz zrobił dla ciebie przyjaciel?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_appreciation_004_fu_1",
+          "text": "Co sprawiło, że to tak wiele znaczyło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_appreciation_004_fu_2",
+          "text": "Jak to zmieniło twoje spojrzenie na tę przyjaźń?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_identity_007",
+      "text": "Co robisz tylko wtedy, gdy nikt nie patrzy?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_identity_007_fu_1",
+          "text": "Dlaczego zostawiasz to dla siebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_identity_007_fu_2",
+          "text": "Co twoim zdaniem ktoś mógłby źle zrozumieć w tej sprawie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_warmUp_emotions_001",
+      "text": "Jakie uczucie zaskoczyło cię ostatnio znienacka?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_light_warmUp_emotions_001_fu_1",
+          "text": "Co twoim zdaniem je wywołało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_warmUp_emotions_001_fu_2",
+          "text": "Powiedziałeś komuś o tym, czy zostało tylko z tobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_realTalk_appreciation_001",
+      "text": "Kto miał ogromny wpływ na twoje życie, nie zdając sobie z tego sprawy?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_realTalk_appreciation_001_fu_1",
+          "text": "Co ta osoba zrobiła, co zmieniło twoje życie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_realTalk_appreciation_001_fu_2",
+          "text": "Czy kiedykolwiek brałeś pod uwagę, żeby jej o tym powiedzieć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_realTalk_growth_001",
+      "text": "Kiedy całkowicie zmieniłeś zdanie na temat czegoś, w co wcześniej wierzyłeś?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_light_realTalk_growth_001_fu_1",
+          "text": "Co w końcu sprawiło, że coś zaskoczyło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_realTalk_growth_001_fu_2",
+          "text": "Jak ta zmiana wpłynęła na to, jak poruszasz się po świecie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_realTalk_appreciation_002",
+      "text": "Komu zalegasz z dawno należnym podziękowanием?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_realTalk_appreciation_002_fu_1",
+          "text": "Co cię powstrzymuje od jego powiedzenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_realTalk_appreciation_002_fu_2",
+          "text": "Co chcesz, żeby ta osoba wiedziała?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_realTalk_growth_002",
+      "text": "Czego przyjaźń nauczyła cię o tym, co znaczy być wybranym — czego nic innego nie mogłoby ci dać?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_light_realTalk_growth_002_fu_1",
+          "text": "Kto lub co nauczyło cię tej lekcji?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_realTalk_growth_002_fu_2",
+          "text": "Jak ta lekcja kształtuje to, jak teraz pokazujesz się ludziom?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_deepDive_growth_001",
+      "text": "Jak myślisz, w jaki sposób wzajemnie na siebie wpłynęliśmy przez ten czas?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_light_deepDive_growth_001_fu_1",
+          "text": "Czy jest coś, co podchwyciłeś ode mnie, a co cię zaskoczyło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_deepDive_growth_001_fu_2",
+          "text": "Za którą część tego wpływu jesteś najbardziej wdzięczny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_deepDive_appreciation_001",
+      "text": "Co twoim zdaniem sprawia, że nasza przyjaźń trwa przez wszystko?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_light_deepDive_appreciation_001_fu_1",
+          "text": "Czy był moment, w którym ta więź była wystawiona na próbę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_deepDive_appreciation_001_fu_2",
+          "text": "Czego nigdy nie chcesz stracić z tego, co mamy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_deepDive_values_001",
+      "text": "Jaką wartość, twoim zdaniem wspólną dla nas, naprawdę cenisz?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_light_deepDive_values_001_fu_1",
+          "text": "Kiedy po raz pierwszy to zauważyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_deepDive_values_001_fu_2",
+          "text": "Jak ta wspólna wartość przejawia się w tym, jak się ze sobą traktujemy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_light_deepDive_intimacy_001",
+      "text": "Jaki to był moment, kiedy poczułeś, że naprawdę cię rozumiem?",
+      "mode": "friends",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_light_deepDive_intimacy_001_fu_1",
+          "text": "Czego wtedy potrzebowałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_light_deepDive_intimacy_001_fu_2",
+          "text": "Jak to zmieniło twoje postrzeganie naszej przyjaźni?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_001",
+      "text": "Jaka historia opowiadana o tobie przez innych nie jest do końca prawdziwa — ale nigdy się nie trudzisz, żeby ją sprostować?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_001_fu_1",
+          "text": "Dlaczego pozwalasz, żeby tak pozostało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_001_fu_2",
+          "text": "Jak brzmiałaby prawdziwa wersja?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_conflict_001",
+      "text": "Co robi bliski przyjaciel, co po cichu wyprowadza cię z równowagi — i co nigdy nie padło na głos?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_conflict_001_fu_1",
+          "text": "Co cię powstrzymuje od powiedzenia tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_conflict_001_fu_2",
+          "text": "Myślisz, że przyjaciel byłby zaskoczony, gdyby to usłyszał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_002",
+      "text": "Jaką prawdę łatwiej jest twoim znajomym trzymać, niż powinna być?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_002_fu_1",
+          "text": "Co łagodzisz lub cenzurujesz dla ich dobra?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_002_fu_2",
+          "text": "Co jest ryzykowne w tym, żeby przyjaciel dostał pełniejszą wersję?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_past_001",
+      "text": "Jaka przyjaźń stopniowo wyblakła, a ty czasem tego żałujesz?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_past_001_fu_1",
+          "text": "Co stanęło na przeszkodzie, żeby ją utrzymać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_past_001_fu_2",
+          "text": "Co byś powiedział tej osobie, gdybyście się odnaleźli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_003",
+      "text": "Czego chcesz, żeby twoi przyjaciele rozumieli o twoim życiu właśnie teraz?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_003_fu_1",
+          "text": "Jaka jest największa przepaść między tym, jak to wygląda, a jak to czujesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_003_fu_2",
+          "text": "Dlaczego trudno to wytłumaczyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_emotions_001",
+      "text": "Kiedy ostatni raz poczułeś, że jesteś pomijany przez ludzi, na których ci zależy?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_emotions_001_fu_1",
+          "text": "Co sprawiło, że tak zaboleło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_emotions_001_fu_2",
+          "text": "Czy powiedziałeś cokolwiek o tym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_appreciation_001",
+      "text": "Co przyjaciel w tobie widzi, w co ty sam wciąż trudno ci uwierzyć?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_appreciation_001_fu_1",
+          "text": "Dlaczego łatwiej im to dostrzec, niż tobie zaufać tej cesze w sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_appreciation_001_fu_2",
+          "text": "Co by się zmieniło, gdybyś trochę bardziej wpuścił ich spojrzenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_004",
+      "text": "Co jest najtrudniejsze w tym, żeby być wciąż ważną częścią życia przyjaciół, gdy się starzejemy?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_004_fu_1",
+          "text": "Co twoim zdaniem zmieniło się najbardziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_004_fu_2",
+          "text": "Jak wyglądałaby twoja idealna przyjaźń na tym etapie życia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_emotions_002",
+      "text": "Kiedy ostatni raz naprawdę zazdrościłeś przyjacielowi?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_emotions_002_fu_1",
+          "text": "Co konkretnie w jego sytuacji tak na ciebie zadziałało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_emotions_002_fu_2",
+          "text": "Co ta zazdrość mówi ci o tym, czego chcesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_005",
+      "text": "Jakiego tematu unikasz z konkretnymi przyjaciółmi i dlaczego?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_005_fu_1",
+          "text": "Czego się obawiasz, że stałoby się, gdybyś to poruszył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_005_fu_2",
+          "text": "Czy unikanie tego tworzy między wami dystans?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_006",
+      "text": "Co jest najtrudniejsze w byciu szczerym wobec osób, które są ci najbliższe?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_006_fu_1",
+          "text": "Co zazwyczaj próbujesz chronić — ich czy siebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_006_fu_2",
+          "text": "Kiedy szczerość faktycznie zbliżyła cię do kogoś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_emotions_003",
+      "text": "O co chcesz, żeby przyjaciele cię pytali zamiast zakładać, że już wiedzą?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_emotions_003_fu_1",
+          "text": "Co kryje się za tym, o co chcesz, żeby pytali?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_emotions_003_fu_2",
+          "text": "Co by to dla ciebie znaczyło, gdyby ktoś naprawdę zapytał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_values_001",
+      "text": "Jaką opinię masz, o której wiesz, że twoi przyjaciele będą się z nią spierać?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_values_001_fu_1",
+          "text": "Co sprawia, że mimo wszystko jej się trzymasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_values_001_fu_2",
+          "text": "Czy kiedykolwiek ją testowałeś na głos?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_conflict_002",
+      "text": "Kiedy przyjaciel cię zawiódł w sposób, o którym pewnie nie wie?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_conflict_002_fu_1",
+          "text": "Dlaczego nic nie powiedziałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_conflict_002_fu_2",
+          "text": "Czy to zmieniło twoje spojrzenie na niego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_identity_001",
+      "text": "Jaka część twojej osobowości wychodzi tylko przy pewnych ludziach?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_identity_001_fu_1",
+          "text": "Co w tych osobach sprawia, że to wychodzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_identity_001_fu_2",
+          "text": "Lubisz tę wersję siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_emotions_004",
+      "text": "Co ostatnio jest dla ciebie trudniejsze, niż dajesz przyjaciołom do zrozumienia?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_emotions_004_fu_1",
+          "text": "Przed czym ich chronisz — czy może przed czym chronisz siebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_emotions_004_fu_2",
+          "text": "Jak by to było przestać nosić to w pojedynkę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_growth_001",
+      "text": "W czym jako przyjaciel nie spełniasz własnych standardów — nie w teorii, ale wobec konkretnej osoby?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_growth_001_fu_1",
+          "text": "Co stoi na przeszkodzie, żeby być lepszym w tym miejscu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_growth_001_fu_2",
+          "text": "Myślisz, że to zauważa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_communication_007",
+      "text": "Jaka rozmowa, którą niedawno przeprowadziłeś, towarzyszyła ci przez kilka dni?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_communication_007_fu_1",
+          "text": "Co w tej rozmowie tak w tobie zostało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_communication_007_fu_2",
+          "text": "Czy zmieniła twoje zdanie na jakiś temat?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_appreciation_002",
+      "text": "Kiedy ostatni raz naprawdę się pojawiłeś dla kogoś w znaczący sposób?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_appreciation_002_fu_1",
+          "text": "Co sprawiło, że stanąłeś na wysokości zadania w tamtej chwili?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_appreciation_002_fu_2",
+          "text": "Jak to było być tą osobą dla kogoś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_warmUp_dailyLife_001",
+      "text": "Ile wysiłku tak naprawdę kosztuje cię teraz utrzymanie przyjaźni?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_honest_warmUp_dailyLife_001_fu_1",
+          "text": "Które są łatwe, a które czujesz jak pracę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_warmUp_dailyLife_001_fu_2",
+          "text": "Co ten wysiłek mówi o tym, gdzie jesteś w życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_conflict_001",
+      "text": "Kiedy byłeś dla przyjaciela surowszy, niż sytuacja tego wymagała?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_conflict_001_fu_1",
+          "text": "Co tak naprawdę za tym stało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_conflict_001_fu_2",
+          "text": "Czy kiedykolwiek to naprawiłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_identity_001",
+      "text": "Czego nie mówisz przy znajomych, bo obawiasz się, że zmienią swoje zdanie o tobie?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_identity_001_fu_1",
+          "text": "Co chronisz, milcząc?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_identity_001_fu_2",
+          "text": "Czy to milczenie zmieniło to, jak sam siebie postrzegasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_conflict_002",
+      "text": "Która z twoich przyjaźni wymaga od ciebie teraz najwięcej?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_conflict_002_fu_1",
+          "text": "Co sprawia, że jest tak wymagająca?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_conflict_002_fu_2",
+          "text": "Czy ten wysiłek wzmacnia przyjaźń, czy ją wyczerpuje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_identity_002",
+      "text": "Czy jest przyjaciel, którego tak bardzo podziwiasz, że trudno ci czuć się przy nim równorzędnym?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_identity_002_fu_1",
+          "text": "Co konkretnie w tej osobie tak na ciebie działa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_identity_002_fu_2",
+          "text": "Myślisz, że byłby zaskoczony, gdyby to usłyszał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_intimacy_001",
+      "text": "Co widzą w tobie tylko ci, którzy znają cię od dawna?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_intimacy_001_fu_1",
+          "text": "Dlaczego twoim zdaniem ta część wychodzi tylko przy takiej historii?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_intimacy_001_fu_2",
+          "text": "Co zmienia to, że naprawdę zna cię tylko kilka osób?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_past_001",
+      "text": "Co z twojej przeszłości masz nadzieję, że przyjaciele, którzy o tym wiedzą, już zapomnieli?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_past_001_fu_1",
+          "text": "Co z tego wciąż w tobie siedzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_past_001_fu_2",
+          "text": "Czy coś by się zmieniło, gdyby to teraz poruszyli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_appreciation_001",
+      "text": "Jaka najmilejsza rzecz, którą przyjaciel dla ciebie zrobił, nigdy nie doczekała się odpowiedniego podziękowania?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_appreciation_001_fu_1",
+          "text": "Co powstrzymało cię od powiedzenia czegoś wtedy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_appreciation_001_fu_2",
+          "text": "Czy myślisz, że wie, co to dla ciebie znaczyło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_dailyLife_001",
+      "text": "Pomyśl o niedawnym momencie, kiedy przyjaciel nie był przy tobie, gdy to miało znaczenie — co się stało?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_dailyLife_001_fu_1",
+          "text": "Powiedziałeś coś, czy po prostu to puściłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_dailyLife_001_fu_2",
+          "text": "Jak to zmieniło twoje oczekiwania wobec tej przyjaźni?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_intimacy_002",
+      "text": "Co zrozumiałeś o przyjacielu, co sprawiło, że bliskość stała się trudniejsza?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_intimacy_002_fu_1",
+          "text": "Co się w tobie zmieniło, kiedy wyraźniej to zobaczyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_intimacy_002_fu_2",
+          "text": "Czy udało ci się być wobec siebie szczerym w tej kwestii?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_values_001",
+      "text": "Czy zdarzyło ci się trwać w przyjaźni głównie z lojalności, a nie z prawdziwej bliskości?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_values_001_fu_1",
+          "text": "Co sprawia, że się pojawiasz, nawet gdy uczucia nie są już takie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_values_001_fu_2",
+          "text": "Czego potrzeba, żeby naprawdę to odpuścić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_conflict_003",
+      "text": "Kiedy szczerość przyjaciela naprawdę zabolała, choć pewnie miał rację?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_conflict_003_fu_1",
+          "text": "Co sprawiło, że tak mocno to trafiło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_conflict_003_fu_2",
+          "text": "Czy to cokolwiek zmieniło w postrzeganiu samego siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_realTalk_identity_003",
+      "text": "Co myślisz, że straciłbyś, gdyby przyjaciele widzieli cię w pełni, bez zasłon?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_honest_realTalk_identity_003_fu_1",
+          "text": "Która część wydaje ci się najbardziej ryzykowna do pokazania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_realTalk_identity_003_fu_2",
+          "text": "Czy to naprawdę chodzi o nich, czy o to, jak sam siebie widzisz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_intimacy_001",
+      "text": "Czego nigdy nie powiedziałeś bliskiemu przyjacielowi, bo obawiasz się, jak by cię potem widział?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_intimacy_001_fu_1",
+          "text": "Co twoim zdaniem by to kosztowało, gdybyś powiedział?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_intimacy_001_fu_2",
+          "text": "Czy jest ktoś, komu ufasz na tyle, żeby spróbować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_conflict_001",
+      "text": "Czy jest przyjaciel, któremu jesteś coś winien — przeprosiny, podziękowanie, wyjaśnienie — a wciąż to odkładasz?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_conflict_001_fu_1",
+          "text": "Co cię powstrzymuje od dania tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_conflict_001_fu_2",
+          "text": "Jak myślisz, co by to między wami zmieniło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_conflict_002",
+      "text": "Dla kogo z przyjaciół nie byłeś obecny tak, jak byś chciał?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_conflict_002_fu_1",
+          "text": "Co stanęło na przeszkodzie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_conflict_002_fu_2",
+          "text": "Gdyby dało się cofnąć do tamtej chwili, co chcesz zrobić inaczej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_dailyLife_001",
+      "text": "Jak decydujesz, które przyjaźnie warte są wysiłku, gdy życie przytłacza?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_dailyLife_001_fu_1",
+          "text": "Czy zdarzyło ci się, że przyjaźń wyblakła i teraz tego żałujesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_dailyLife_001_fu_2",
+          "text": "Co pomaga ci rozpoznać, które przyjaźnie chcesz dalej pielęgnować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_conflict_003",
+      "text": "Co wybaczyłeś przyjacielowi, nie czując się nigdy w pełni naprawionym?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_conflict_003_fu_1",
+          "text": "Co w tobie wciąż wydaje się niedokończone?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_conflict_003_fu_2",
+          "text": "Czego potrzebowałoby naprawienie, co się nigdy nie wydarzyło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_intimacy_002",
+      "text": "Jaki rodzaj samotności może istnieć wewnątrz długiej przyjaźni?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_intimacy_002_fu_1",
+          "text": "Kiedy czujesz to najwyraźniej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_intimacy_002_fu_2",
+          "text": "Co twoim zdaniem sprawia, że taka samotność jest trudna do przyznania?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_conflict_004",
+      "text": "W jakiej przyjaźni zaakceptowałeś mniej troski, niż na nią zasługujesz?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_conflict_004_fu_1",
+          "text": "Co sprawiło, że zadowoliłeś się taką wersją tej przyjaźni?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_conflict_004_fu_2",
+          "text": "Czego potrzeba, żeby chcieć więcej, nie czując się przy tym nieracjonalnym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_honest_deepDive_growth_001",
+      "text": "Która przyjaźń najbardziej zmieniła to, kim jesteś, i czego od ciebie wymagała?",
+      "mode": "friends",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_honest_deepDive_growth_001_fu_1",
+          "text": "Co ta przyjaźń wyciągnęła z ciebie, co mogłoby pozostać ukryte?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_honest_deepDive_growth_001_fu_2",
+          "text": "Lubisz to, kim ci pomogła zostać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_001",
+      "text": "Co udajesz, że cię nie rusza, a rusza cię bardzo?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_001_fu_1",
+          "text": "Co sprawia, że dalej udajesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_001_fu_2",
+          "text": "Co mogłoby się zmienić, gdybyś to przyznał na głos?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_communication_001",
+      "text": "Co ludzie najczęściej rozumieją o tobie źle?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_communication_001_fu_1",
+          "text": "Co twoim zdaniem wytwarza takie wrażenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_communication_001_fu_2",
+          "text": "Czy kiedykolwiek próbowałeś to prostować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_001",
+      "text": "Jaką opinię masz, z którą większość twoich znajomych by się nie zgodziła?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_001_fu_1",
+          "text": "Co daje ci taką pewność w tej kwestii?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_001_fu_2",
+          "text": "Czy kiedykolwiek testowałeś ją w rozmowie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_growth_001",
+      "text": "Jaka to była najgorsza rada, którą kiedykolwiek posłuchałeś?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_growth_001_fu_1",
+          "text": "Co sprawiło, że jej wtedy zaufałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_growth_001_fu_2",
+          "text": "Czego nauczyły cię skutki?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_identity_001",
+      "text": "Z jaką częścią siebie musiałeś się naprawdę siłować, żeby ją zaakceptować?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_001_fu_1",
+          "text": "Co sprawiło, że ta akceptacja była taka trudna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_001_fu_2",
+          "text": "Jesteś już w tym miejscu, czy wciąż nad tym pracujesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_past_001",
+      "text": "Co zrobiłeś w życiu, czego nikomu nigdy do końca nie wyjaśnisz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_past_001_fu_1",
+          "text": "Czego ktoś musiałby się dowiedzieć, żeby to zrozumieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_past_001_fu_2",
+          "text": "Czy trzymanie tego dla siebie to ochrona, czy ciężar?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_001",
+      "text": "Kiedy byłeś czarnym charakterem w czyjejś historii?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_001_fu_1",
+          "text": "Zgadzasz się z ich wersją?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_001_fu_2",
+          "text": "Jak brzmiałaby twoja strona tej historii?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_002",
+      "text": "Jakie mocne przekonanie zupełnie się posypało?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_002_fu_1",
+          "text": "Co doprowadziło do jego upadku?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_002_fu_2",
+          "text": "W co teraz wierzysz zamiast tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_growth_002",
+      "text": "Czego z wychowania musisz się oduczyć?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_growth_002_fu_1",
+          "text": "Kiedy po raz pierwszy zdałeś sobie sprawę, że to ci nie służy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_growth_002_fu_2",
+          "text": "Czym to zastąpiłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_002",
+      "text": "Kiedy poczułeś się najbardziej w pojedynkę w tłumie ludzi?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_002_fu_1",
+          "text": "Co się wokół ciebie działo, że było jeszcze gorzej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_002_fu_2",
+          "text": "Co sprawiłoby, że byłoby ci mniej w pojedynkę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_identity_002",
+      "text": "Jaka strona ciebie wychodzi tylko wtedy, gdy się złościsz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_002_fu_1",
+          "text": "Boisz się tej strony, czy jej ufasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_002_fu_2",
+          "text": "Jak to zazwyczaj wygląda, gdy się pojawia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_002",
+      "text": "Co powiedziałeś komuś, czego nie możesz cofnąć?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_002_fu_1",
+          "text": "Chcesz móc to cofnąć, czy przy tym stoisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_002_fu_2",
+          "text": "Jak to zmieniło relację z tą osobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_identity_003",
+      "text": "Jaka prawda o tobie jest czymś, z czym większość ludzi by sobie nie poradziła?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_003_fu_1",
+          "text": "Dlaczego uważasz, że by sobie nie poradziła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_identity_003_fu_2",
+          "text": "Kto w twoim życiu mógłby to udźwignąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_003",
+      "text": "Kiedy ostatni raz poważnie rozważałeś, żeby całkowicie kogoś uciąć?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_003_fu_1",
+          "text": "Co doprowadziło cię do tej granicy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_003_fu_2",
+          "text": "Czy do tego doszło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_003",
+      "text": "Za co oceniasz innych, a sam też to robisz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_003_fu_1",
+          "text": "Dlaczego łatwiej dostrzec tę wadę u innych niż u siebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_003_fu_2",
+          "text": "Co by się zmieniło, gdybyś zastosował ten sam standard do siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_004",
+      "text": "Jaka jest najbardziej egoistyczna rzecz, którą zrobiłeś i której nie żałujesz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_004_fu_1",
+          "text": "Co dało ci postawienie siebie na pierwszym miejscu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_004_fu_2",
+          "text": "Chcesz to zrobić jeszcze raz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_003",
+      "text": "Jakie uczucie tłumisz w sobie od zbyt długiego czasu?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_003_fu_1",
+          "text": "Czego się obawiasz, że stałoby się, gdybyś je wypuścił?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_003_fu_2",
+          "text": "Ile kosztuje cię utrzymywanie go w środku?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_004",
+      "text": "Czego nigdy nie byłeś w stanie sobie wybaczyć?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_004_fu_1",
+          "text": "Czego wymagałoby przebaczenie sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_004_fu_2",
+          "text": "Co sprawia, że to przebaczenie jest tak trudne do dania sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_005",
+      "text": "Czego chcesz, żeby ludzie przestali udawać, że ich to obchodzi?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_005_fu_1",
+          "text": "Co konkretnie drażni cię w tym spektaklu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_005_fu_2",
+          "text": "Jak wyglądałoby prawdziwe zaangażowanie w zamian?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_004",
+      "text": "Kiedy zorientowałeś się, że jakaś przyjaźń jest jednostronna?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_004_fu_1",
+          "text": "Co sprawiło, że nagle stało się to jasne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_004_fu_2",
+          "text": "Co zrobiłeś z tym odkryciem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_005",
+      "text": "Jaka mroczna myśl przychodzi ci do głowy, której nigdy nie mówisz na głos?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_005_fu_1",
+          "text": "Na co twoim zdaniem naprawdę wskazuje ta myśl?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_005_fu_2",
+          "text": "Czy to, że ją masz, przeraża cię, czy wydaje się bardziej ludzkie, niż się spodziewałeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_communication_002",
+      "text": "Co najbardziej szczerego powiedziałeś komuś prosto w twarz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_communication_002_fu_1",
+          "text": "Jak to przyjął?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_communication_002_fu_2",
+          "text": "Chcesz to powiedzieć jeszcze raz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_past_002",
+      "text": "Jakie doświadczenie zahartowało cię w sposób, którego inni nie widzą?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_past_002_fu_1",
+          "text": "Jaką część ciebie zamknęło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_past_002_fu_2",
+          "text": "To zahartowanie czujesz bardziej jak ochronę, stratę, czy jedno i drugie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_006",
+      "text": "Kiedy ostatni raz naprawdę poczułeś wstyd?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_006_fu_1",
+          "text": "Co wywołało ten wstyd?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_006_fu_2",
+          "text": "Co pomogło ci przez to przejść, jeśli w ogóle cokolwiek?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_intimacy_001",
+      "text": "Jaki sekret trzymasz z dala od swoich najbliższych przyjaciół?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_intimacy_001_fu_1",
+          "text": "Co zmieniłoby się w tych przyjaźniach, gdyby wiedzieli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_intimacy_001_fu_2",
+          "text": "Co powstrzymuje cię od podzielenia się tym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_005",
+      "text": "W jaki sposób manipulowałeś kiedyś sytuacją, z czego nie jesteś dumny?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_005_fu_1",
+          "text": "Co próbowałeś przez to osiągnąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_005_fu_2",
+          "text": "Zachowałbyś się dziś inaczej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_values_006",
+      "text": "Jaki podwójny standard stosujesz, wiedząc, że to niesprawiedliwe?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_values_006_fu_1",
+          "text": "Co sprawia, że trudno ci się go pozbyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_values_006_fu_2",
+          "text": "Czy ktoś kiedyś zwrócił ci na to uwagę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_conflict_006",
+      "text": "Przez co straciłeś szacunek do kogoś?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_006_fu_1",
+          "text": "Był to jeden moment, czy narastało to stopniowo?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_conflict_006_fu_2",
+          "text": "Czy kiedykolwiek mu o tym powiedziałeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_007",
+      "text": "Kiedy ostatni raz płakałeś i co to wyzwoliło?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_007_fu_1",
+          "text": "Dałeś się temu w pełni ponieść, czy próbowałeś się trzymać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_007_fu_2",
+          "text": "Co ten płacz w tobie uwolnił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_emotions_008",
+      "text": "Jakiego pytania się obawiasz, że ktoś może ci zadać?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_008_fu_1",
+          "text": "Jaka byłaby szczera odpowiedź, którą musiałbyś dać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_emotions_008_fu_2",
+          "text": "Co sprawia, że ta prawda jest tak niebezpieczna?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_warmUp_dailyLife_001",
+      "text": "Co robisz w codziennej rutynie, wiedząc dobrze, że to unikanie?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_warmUp_dailyLife_001_fu_1",
+          "text": "Czego tak naprawdę unikasz, gdy to robisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_warmUp_dailyLife_001_fu_2",
+          "text": "Jak wyglądałby twój dzień, gdybyś przestał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_conflict_001",
+      "text": "Kiedy wiedziałeś, że się mylisz, ale nie byłeś w stanie tego przyznać?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_001_fu_1",
+          "text": "Co było stawką, że przyznanie się wydawało się niemożliwe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_001_fu_2",
+          "text": "Czy ta druga osoba wiedziała, że się mylisz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_emotions_001",
+      "text": "O czym nikomu tak naprawdę nigdy nie powiedziałeś, co naprawdę czujesz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_emotions_001_fu_1",
+          "text": "Co trzymanie tego w środku zrobiło z tobą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_emotions_001_fu_2",
+          "text": "Co by zmieniło powiedzenie tego w końcu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_intimacy_001",
+      "text": "Czego naprawdę masz nadzieję, że pewne osoby nigdy się nie dowiedzą?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_intimacy_001_fu_1",
+          "text": "Czego najbardziej się obawiasz, że by pomyślały?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_intimacy_001_fu_2",
+          "text": "Co wyobrażasz sobie, że zmieniłoby się, gdyby wiedzieli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_conflict_002",
+      "text": "Kto ostatnio doprowadził cię do punktu wytrzymałości?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_002_fu_1",
+          "text": "Jak wyglądało twoje osiągnięcie tego punktu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_002_fu_2",
+          "text": "Co pomogło ci dojść do siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_conflict_003",
+      "text": "Jaką urazę nosisz w sobie dłużej, niż byś chciał?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_003_fu_1",
+          "text": "Co musiałoby się stać, żeby w końcu ją odłożyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_003_fu_2",
+          "text": "Co daje ci trzymanie jej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_conflict_004",
+      "text": "Jaką przyjaźń nadszarpnąłeś, o której czasem jeszcze myślisz?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_004_fu_1",
+          "text": "Co twoim zdaniem chcesz zrobić inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_conflict_004_fu_2",
+          "text": "Czy naprawienie tego jest jeszcze możliwe?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_values_001",
+      "text": "Co lojalność naprawdę znaczy dla ciebie, gdy jest wystawiona na próbę?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_values_001_fu_1",
+          "text": "Kiedy twoja lojalność była wystawiana na najtrudniejszą próbę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_values_001_fu_2",
+          "text": "Gdzie wyznaczasz granicę między lojalnością a szacunkiem do siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_realTalk_dailyLife_001",
+      "text": "Na ile jesteś szczery wobec siebie co do emocjonalnego wysiłku, jaki kosztują cię przyjaźnie?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_realTalk_dailyLife_001_fu_1",
+          "text": "Kto zazwyczaj dostaje od ciebie najwięcej i czy ta osoba o tym wie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_realTalk_dailyLife_001_fu_2",
+          "text": "Co wyobrażasz sobie, że stałoby się, gdybyś przestał dźwigać tyle na raz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_deepDive_conflict_001",
+      "text": "Czy jest przyjaźń, z której wyrosłeś, ale jeszcze z niej nie wyszedłeś?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_deepDive_conflict_001_fu_1",
+          "text": "Co cię w niej trzyma?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_deepDive_conflict_001_fu_2",
+          "text": "Co naprawdę kosztowałoby cię odejście?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_deepDive_intimacy_001",
+      "text": "Jaką historię opowiadałeś już wiele razy, ale nigdy w pełni szczerze?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_deepDive_intimacy_001_fu_1",
+          "text": "Co zawsze pomijasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_deepDive_intimacy_001_fu_2",
+          "text": "Co twoim zdaniem ujawniłaby pełna wersja?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_deepDive_conflict_002",
+      "text": "Kiedy ktoś złamał twoje zaufanie w sposób, który zmienił twoje zachowanie?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_deepDive_conflict_002_fu_1",
+          "text": "Jaką ochronę zbudowałeś przez to doświadczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_deepDive_conflict_002_fu_2",
+          "text": "Czy od tamtej pory ktoś zasłużył na taki poziom zaufania, jaki wtedy straciłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_friends_unfiltered_deepDive_dailyLife_001",
+      "text": "W jaki sposób po cichu przestałeś się starać w jakiejś przyjaźni, nie mówiąc nigdy dlaczego?",
+      "mode": "friends",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_friends_unfiltered_deepDive_dailyLife_001_fu_1",
+          "text": "Czy to była świadoma decyzja, czy tak po prostu wyszło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_friends_unfiltered_deepDive_dailyLife_001_fu_2",
+          "text": "Czy myślisz, że ta osoba to zauważyła i czy to dla ciebie ważne?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_values_001",
+      "text": "Jaką wartość ze swojej kultury lub tradycji naprawdę nosisz w sobie?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_values_001_fu_1",
+          "text": "Jak starasz się żyć tą wartością na co dzień?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_values_001_fu_2",
+          "text": "Czy to coś, co chcesz przekazać dalej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_001",
+      "text": "Jaki moment z młodości nie możesz uwierzyć, że wyszedł ci na sucho?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_001_fu_1",
+          "text": "Co myślisz, że cię wtedy uchroniło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_001_fu_2",
+          "text": "Jak to zmieniło podejście do ryzyka, które podejmujesz teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_001",
+      "text": "Jaką historię na pewno opowiadasz o wiele za często?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_001_fu_1",
+          "text": "Co w tej historii sprawia, że ciągle do niej wracasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_001_fu_2",
+          "text": "Czy ktoś z bliskich już kończy ją za ciebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_002",
+      "text": "Jaki zapach natychmiast przenosi cię do konkretnego momentu?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_002_fu_1",
+          "text": "Jakie wspomnienie jest z nim związane?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_002_fu_2",
+          "text": "Co czujesz, gdy ten zapach trafia do ciebie niespodziewanie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_003",
+      "text": "Co naprawdę nie możesz uwierzyć, że ujdzie ci płazem za dziecięcych lat?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_003_fu_1",
+          "text": "Co czujesz do tamtej wersji siebie dziś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_003_fu_2",
+          "text": "Kto jeszcze zna tę historię, poza tobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_002",
+      "text": "Co za każdym razem kompletnie rozkłada twoją silną wolę?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_002_fu_1",
+          "text": "Co w tym sprawia, że zawsze ulegasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_002_fu_2",
+          "text": "Czy kiedyś udało ci się oprzeć — i jak to osiągnąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_004",
+      "text": "Za czym tęsknisz — za czymś, co kiedyś było oczywiste i czego już nie ma w twoim życiu?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_004_fu_1",
+          "text": "Kiedy przestało to być możliwe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_004_fu_2",
+          "text": "Co by to dla ciebie znaczyło, gdyby dało się to odzyskać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_005",
+      "text": "Z czym chcesz wciąż móc uchodzić na sucho?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_005_fu_1",
+          "text": "Co wtedy na to pozwalało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_005_fu_2",
+          "text": "Co się zmieniło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_emotions_001",
+      "text": "Jaki masz najbardziej irracjonalny strach — taki, który kompletnie nie ma sensu?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_emotions_001_fu_1",
+          "text": "Jak sobie z nim radzisz, gdy się pojawia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_emotions_001_fu_2",
+          "text": "Masz jakiś pomysł, skąd się wziął?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_003",
+      "text": "Jaki kawał ci się najlepiej udało kiedyś wykręcić?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_003_fu_1",
+          "text": "Jak zareagowała ta osoba?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_003_fu_2",
+          "text": "Czy ta historia stała się legendą rodzinną?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_004",
+      "text": "Co jest zupełnie normalną rzeczą, a jednak robi ci dziwną tremę?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_004_fu_1",
+          "text": "Kiedy po raz pierwszy to do ciebie dotarło, że cię to krępuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_004_fu_2",
+          "text": "Czy inni to wyczuwają?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_005",
+      "text": "Jakie spotkanie było dla ciebie najbardziej nieznośne i trzeba było je jakoś wytrzymać?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_005_fu_1",
+          "text": "Co sprawiło, że było tak ciężkie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_005_fu_2",
+          "text": "Jak udało ci się przez to przebrnąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_006",
+      "text": "O czym można było marzyć godzinami w twoim dzieciństwie?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_006_fu_1",
+          "text": "Czy jakaś część tego marzenia nadal w tobie żyje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_006_fu_2",
+          "text": "Co to mówi o tym, czego wtedy najbardziej ci było potrzeba?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_006",
+      "text": "Co ostatnio trafiło ci w ręce lub przed oczy — coś, czego raczej nie miałeś widzieć?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_006_fu_1",
+          "text": "Jak to na ciebie wpłynęło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_006_fu_2",
+          "text": "Czy komuś o tym opowiedziałeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_appreciation_001",
+      "text": "Jaki prezent jest dla ciebie najbardziej znaczący spośród wszystkich, jakie trafiły w twoje ręce?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_appreciation_001_fu_1",
+          "text": "Co sprawiło, że był tak wyjątkowy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_appreciation_001_fu_2",
+          "text": "Co ten prezent dla ciebie znaczy do dziś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_appreciation_002",
+      "text": "Co w twojej rodzinie napełnia cię największą dumą?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_appreciation_002_fu_1",
+          "text": "Czy rodzina wie, że tak to odczuwasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_appreciation_002_fu_2",
+          "text": "Jak myślisz, co zbudowało tę cechę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_007",
+      "text": "Z jakiej przyjemności, na którą inni kręcą nosem, i tak nigdy nie zrezygnujesz?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_007_fu_1",
+          "text": "Dlaczego sprawia ci tyle radości?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_007_fu_2",
+          "text": "Kto najbardziej daje ci za to w kość?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_values_002",
+      "text": "Jaki rodzinny przepis lub tradycja nie może zaginąć?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_values_002_fu_1",
+          "text": "Jakie wspomnienie się z nim wiąże?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_values_002_fu_2",
+          "text": "To ty trzymasz tę tradycję przy życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_008",
+      "text": "Co najśmieszniejszego wydarzyło się kiedyś na rodzinnym spotkaniu?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_008_fu_1",
+          "text": "Kto był w centrum tej historii?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_008_fu_2",
+          "text": "Czy ta historia wraca na każdym spotkaniu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_appreciation_003",
+      "text": "Co nadal robisz tak, jak nauczył cię kiedyś ktoś z rodziny?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_appreciation_003_fu_1",
+          "text": "Czy uczyło cię świadomie, czy po prostu własnym przykładem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_appreciation_003_fu_2",
+          "text": "Czy ta osoba wie, jak wiele jej zawdzięczasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_007",
+      "text": "Jakie przezwisko miałeś w dzieciństwie i skąd się wzięło?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_007_fu_1",
+          "text": "Kochasz je, czy wolisz, żeby przepadło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_007_fu_2",
+          "text": "Ktoś jeszcze cię tak nazywa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_008",
+      "text": "Jakie rodzinne wyjazdy nigdy ci z pamięci nie wypadną?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_008_fu_1",
+          "text": "Co sprawiło, że tak zapadły ci w pamięć — coś, co wyszło świetnie, czy coś komicznie nie tak?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_008_fu_2",
+          "text": "Z kim najbardziej kojarzysz ten wyjazd?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_past_009",
+      "text": "Za co najczęściej lądowałeś w kłopotach jako dziecko?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_past_009_fu_1",
+          "text": "Czy przez większość czasu to była twoja wina?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_past_009_fu_2",
+          "text": "Widzisz coś z tamtego zachowania w sobie teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_appreciation_004",
+      "text": "Jaka piosenka lub film zawsze przywołuje ci rodzinę?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_appreciation_004_fu_1",
+          "text": "Jakie uczucie to budzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_appreciation_004_fu_2",
+          "text": "To miłe skojarzenie, czy raczej złożone?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_009",
+      "text": "O co w twojej rodzinie robi się zaskakująco duże zamieszanie, jeśli chodzi o rywalizację?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_009_fu_1",
+          "text": "Kto w rodzinie najgorzej znosi przegraną?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_009_fu_2",
+          "text": "Czy kiedyś wymknęło się to spod kontroli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_dailyLife_010",
+      "text": "Jaki macie rodzinny żart, którego żaden obcy nie zrozumie?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_dailyLife_010_fu_1",
+          "text": "Jaka historia za nim stoi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_dailyLife_010_fu_2",
+          "text": "Kto go wymyślił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_growth_001",
+      "text": "Jaką umiejętność udało ci się podpatrzyć u kogoś z rodziny?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_growth_001_fu_1",
+          "text": "Czy ta osoba wiedziała, że się od niej uczysz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_growth_001_fu_2",
+          "text": "Jak ta umiejętność ukształtowała twoje życie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_values_003",
+      "text": "Jaka rada od kogoś z rodziny wciąż z tobą zostaje?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_values_003_fu_1",
+          "text": "Kiedy do ciebie dotarło po raz pierwszy, że mieli rację?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_values_003_fu_2",
+          "text": "Czy ta rada zdała egzamin przez lata?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_values_004",
+      "text": "Która świąteczna tradycja znaczy dla ciebie najwięcej i dlaczego?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_values_004_fu_1",
+          "text": "Co by to znaczyło, gdyby ta tradycja miała zniknąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_values_004_fu_2",
+          "text": "Co ona dla ciebie symbolizuje poza samym rytuałem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_appreciation_005",
+      "text": "Kto w twojej rodzinie zawsze umie sprawić, że czujesz się choć trochę lepiej?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_appreciation_005_fu_1",
+          "text": "Co ta osoba robi, że tak dobrze to działa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_appreciation_005_fu_2",
+          "text": "Czy wie, że ma tę moc?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_communication_001",
+      "text": "O czym wasza rodzina mówi na każdym spotkaniu bez wyjątku?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_communication_001_fu_1",
+          "text": "Czy wszyscy to lubią, czy to po prostu nawyk?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_communication_001_fu_2",
+          "text": "O czym zamiast tego wolisz rozmawiać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_warmUp_conflict_001",
+      "text": "O co wasza rodzina kłóci się dla zabawy za każdym razem, gdy się spotkacie?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_light_warmUp_conflict_001_fu_1",
+          "text": "Czy ktoś się naprawdę unosi, czy to wszystko na wesoło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_warmUp_conflict_001_fu_2",
+          "text": "Po której stronie zawsze stajesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_values_001",
+      "text": "Jaką historię o sobie chcesz, żeby kiedyś żyła w twojej rodzinie?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_values_001_fu_1",
+          "text": "Co ta historia mówi o tym, kim jesteś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_values_001_fu_2",
+          "text": "Kto miałby ją opowiadać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_past_001",
+      "text": "Jaki jest jeden dzień w twoim życiu, o którym wiesz, że go nie zapomnisz?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_past_001_fu_1",
+          "text": "Co sprawiło, że ten dzień tak mocno utkwił ci w pamięci?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_past_001_fu_2",
+          "text": "Jak cię zmienił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_past_002",
+      "text": "Jak postrzegałeś świat w młodości i kiedy to się zmieniło?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_past_002_fu_1",
+          "text": "Jakie doświadczenie było punktem zwrotnym?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_past_002_fu_2",
+          "text": "Czy tęsknisz za tamtym spojrzeniem na świat?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_appreciation_001",
+      "text": "Co jest najżyczliwszą rzeczą, jaką ktokolwiek dla ciebie zrobił?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_appreciation_001_fu_1",
+          "text": "Dlaczego poczułeś w tym tak głęboką życzliwość?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_appreciation_001_fu_2",
+          "text": "Czy to zmieniło twoje przekonanie o tym, do czego ludzie są zdolni?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_appreciation_002",
+      "text": "Co twoja rodzina robi takiego, czego nie doceniałeś, dopóki nie dorosłeś?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_appreciation_002_fu_1",
+          "text": "Co sprawiło, że w końcu zacząłeś to widzieć inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_appreciation_002_fu_2",
+          "text": "Czy dałeś im kiedyś znać, że tak to teraz postrzegasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_realTalk_appreciation_003",
+      "text": "Co w twojej rodzinie wydawało się zwykłe, gdy dorastałeś, a teraz jest dla ciebie czymś wyjątkowym?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_realTalk_appreciation_003_fu_1",
+          "text": "Kiedy zacząłeś to widzieć inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_realTalk_appreciation_003_fu_2",
+          "text": "Co to dla ciebie teraz znaczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_deepDive_values_001",
+      "text": "Jak twoje rozumienie słowa \"rodzina\" zmieniało się przez lata?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_deepDive_values_001_fu_1",
+          "text": "Jakie doświadczenie najbardziej to zmieniło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_deepDive_values_001_fu_2",
+          "text": "Co rodzina znaczy dla ciebie teraz, czego wcześniej nie znaczyła?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_deepDive_values_002",
+      "text": "Co masz nadzieję, że następne pokolenie przejmie od nas?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_light_deepDive_values_002_fu_1",
+          "text": "Jaką jedną rzecz chcesz, żeby zabrali ze sobą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_deepDive_values_002_fu_2",
+          "text": "Co masz nadzieję, że zostawią za sobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_deepDive_intimacy_001",
+      "text": "Jaki moment zbliżył nas do siebie bardziej niż cokolwiek innego?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_family_light_deepDive_intimacy_001_fu_1",
+          "text": "Co w tym momencie sprawiło, że coś się przełamało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_deepDive_intimacy_001_fu_2",
+          "text": "Jak zmieniło się między nami to, co czuliśmy potem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_light_deepDive_appreciation_001",
+      "text": "Co najbardziej lubisz w tym, że jesteś częścią tej rodziny?",
+      "mode": "family",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_light_deepDive_appreciation_001_fu_1",
+          "text": "Kiedy czujesz to najmocniej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_light_deepDive_appreciation_001_fu_2",
+          "text": "Czy jest coś, co chcesz dodać, żeby było jeszcze lepiej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_emotions_001",
+      "text": "Jakie uczucia pojawiają się w tobie przy rodzinnych spotkaniach?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_emotions_001_fu_1",
+          "text": "To bardziej oczekiwanie, obawa, czy coś pomiędzy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_emotions_001_fu_2",
+          "text": "Jak zazwyczaj radzisz sobie z tym, co w tobie wtedy powstaje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_communication_001",
+      "text": "O czym ta rodzina, jak myślisz, stara się nie rozmawiać?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_communication_001_fu_1",
+          "text": "Jak myślisz, co by się stało, gdyby ktoś w końcu to poruszył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_communication_001_fu_2",
+          "text": "Jak to milczenie wpływa na wszystkich?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_emotions_002",
+      "text": "Co zmieniło się w tej rodzinie, do czego wciąż się adaptujesz?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_emotions_002_fu_1",
+          "text": "Co w tej zmianie było najtrudniejsze?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_emotions_002_fu_2",
+          "text": "Co by ci pomogło się z tym oswoić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_values_001",
+      "text": "Jakie rodzinne oczekiwanie sprawiło ci trudność w spełnieniu?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_values_001_fu_1",
+          "text": "Zależy ci na spełnieniu tego oczekiwania, czy wolisz je puścić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_values_001_fu_2",
+          "text": "Jaką presję to na ciebie wywiera?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_communication_002",
+      "text": "Co chcesz powiedzieć komuś z rodziny, choć żałujesz, że nie powiedziałeś wcześniej?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_communication_002_fu_1",
+          "text": "Co powstrzymywało cię od powiedzenia tego, gdy miało to znaczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_communication_002_fu_2",
+          "text": "Czy jest jeszcze czas?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_past_001",
+      "text": "Kiedy po raz pierwszy zdałeś sobie sprawę, że twoja rodzina nie jest taka jak inne?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_past_001_fu_1",
+          "text": "Jak na ciebie uderzyło to odkrycie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_past_001_fu_2",
+          "text": "Czy zmieniło to twój stosunek do rodziny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_001",
+      "text": "W jaki sposób twoja rodzina okazuje miłość, który dopiero z czasem nauczyłeś się rozpoznawać?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_001_fu_1",
+          "text": "Za co to uważałeś, zanim zrozumiałeś, że to miłość?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_001_fu_2",
+          "text": "Jak teraz na to patrzysz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_identity_001",
+      "text": "Jaką rolę odgrywasz w rodzinie i jak się z tym czujesz?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_identity_001_fu_1",
+          "text": "Wybrałeś tę rolę, czy to ona wybrała ciebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_identity_001_fu_2",
+          "text": "Co by się stało, gdybyś przestał ją pełnić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_identity_002",
+      "text": "Co odziedziczyłeś po rodzicach — nawyk albo cechę — które cię zaskakuje?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_identity_002_fu_1",
+          "text": "Kiedy po raz pierwszy to w sobie zauważyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_identity_002_fu_2",
+          "text": "Chcesz to zatrzymać, czy z tego zrezygnować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_past_002",
+      "text": "Co wciąż lubisz wspominać ze swojego dzieciństwa?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_past_002_fu_1",
+          "text": "Czego z tamtego czasu brakuje ci najbardziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_past_002_fu_2",
+          "text": "Czy znalazłeś coś w dorosłym życiu, co daje ci podobne uczucie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_past_003",
+      "text": "Co rodzice wciąż źle rozumieli w tym, czego potrzebowałeś?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_past_003_fu_1",
+          "text": "Jak radziłeś sobie z tym, że tego od nich nie dostawałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_past_003_fu_2",
+          "text": "Czy myślisz, że teraz rozumieją to lepiej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_002",
+      "text": "Jaka ofiara kogoś z rodziny często do ciebie wraca?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_002_fu_1",
+          "text": "Czy ta osoba wie, ile to dla ciebie znaczyło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_002_fu_2",
+          "text": "Jak to ukształtowało to, jak jesteś dla innych?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_growth_001",
+      "text": "Co z twojego wychowania nie budziło w tobie wątpliwości, dopóki nie dorosłeś?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_growth_001_fu_1",
+          "text": "Co sprawiło, że zacząłeś to kwestionować?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_growth_001_fu_2",
+          "text": "Jak nowa perspektywa cię zmieniła?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_growth_002",
+      "text": "Kogo z rodziny rozumiesz teraz inaczej, gdy jesteś starszy?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_growth_002_fu_1",
+          "text": "Co zmieniło twoje rozumienie tej osoby?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_growth_002_fu_2",
+          "text": "Czy przez to bliskość stała się łatwiejsza, czy bardziej skomplikowana?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_values_002",
+      "text": "Czego rodzina nauczyła cię robić, gdy zaufanie zostaje nadszarpnięte?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_values_002_fu_1",
+          "text": "Czy tę lekcję ktoś wypowiedział wprost, czy uczyłeś się jej przez obserwację?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_values_002_fu_2",
+          "text": "Czy tak wciąż radzisz sobie z bólem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_conflict_001",
+      "text": "Jakie nieporozumienie w twojej rodzinie nigdy nie zostało porządnie wyjaśnione?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_conflict_001_fu_1",
+          "text": "Czy wciąż wpływa to na wasze relacje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_conflict_001_fu_2",
+          "text": "Co byłoby potrzebne, żeby w końcu wyczyścić powietrze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_emotions_003",
+      "text": "O co twoja rodzina martwi się najbardziej, gdy chodzi o ciebie?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_emotions_003_fu_1",
+          "text": "Czy jakaś część tej troski wydaje ci się słuszna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_emotions_003_fu_2",
+          "text": "Jak się czujesz, wiedząc, że noszą w sobie tę obawę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_003",
+      "text": "Kiedy twoja rodzina była w najlepszej formie i co to umożliwiło?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_003_fu_1",
+          "text": "Co było wtedy inne w każdym z was?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_003_fu_2",
+          "text": "Czy myślisz, że ta wersja waszej rodziny jest wciąż osiągalna?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_communication_003",
+      "text": "Co w rolach, jakie wszyscy odgrywają w waszej rodzinie, osoba z zewnątrz by nie zrozumiała?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_communication_003_fu_1",
+          "text": "Czy to ci odpowiada, czy wolisz, żeby było inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_communication_003_fu_2",
+          "text": "Co chcesz, żeby ktoś z zewnątrz o tym wiedział?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_004",
+      "text": "Kiedy twoja rodzina stanęła przy tobie w sposób, który sprawił, że poczułeś się mniej w pojedynkę?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_004_fu_1",
+          "text": "Co konkretnie w tym, jak się pojawili, do ciebie dotarło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_004_fu_2",
+          "text": "Czy zmieniło to twoje przekonanie o tym, co potrafią ci dać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_conflict_002",
+      "text": "Jaka rozmowa z rodziną wciąż kręci się w kółko i nigdzie nie prowadzi?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_conflict_002_fu_1",
+          "text": "Jak myślisz, dlaczego wciąż utyka?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_conflict_002_fu_2",
+          "text": "Jak wyglądałby prawdziwy przełom?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_005",
+      "text": "Co doceniasz w swojej rodzinie, o czym rzadko mówisz?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_005_fu_1",
+          "text": "Co sprawia, że trudno ci to powiedzieć głośno?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_005_fu_2",
+          "text": "Co, twoim zdaniem, znaczyłoby dla nich to usłyszeć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_growth_003",
+      "text": "Jakiej lekcji nauczyła cię rodzina poprzez swoje błędy?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_growth_003_fu_1",
+          "text": "Jak obserwowanie tego błędu wpłynęło na ciebie w dzieciństwie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_growth_003_fu_2",
+          "text": "Czy zmieniło to twój sposób radzenia sobie w podobnych sytuacjach?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_growth_004",
+      "text": "W jaki sposób próbowałeś przerwać jakiś rodzinny schemat?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_growth_004_fu_1",
+          "text": "Jak ci z tym idzie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_growth_004_fu_2",
+          "text": "Co sprawia, że tak trudno ten schemat złamać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_emotions_004",
+      "text": "Z jaką emocją kojarzysz ci się dom rodzinny?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_emotions_004_fu_1",
+          "text": "Czy ta emocja jest w tobie do dziś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_emotions_004_fu_2",
+          "text": "Jak zabarwia twoje myślenie o domu teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_conflict_003",
+      "text": "Co wybaczyłeś komuś z rodziny, co wiele cię kosztowało?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_conflict_003_fu_1",
+          "text": "Czego wymagało od ciebie to przebaczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_conflict_003_fu_2",
+          "text": "Czy przebaczenie zmieniło tę relację?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_appreciation_006",
+      "text": "Co twoja rodzina robi dobrze i co nadal warto chronić?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_appreciation_006_fu_1",
+          "text": "Kiedy ta mocna strona waszej rodziny widać najwyraźniej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_appreciation_006_fu_2",
+          "text": "Czego najbardziej nie chcesz, żeby wasza rodzina straciła?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_past_004",
+      "text": "Jaka historia z wczesnego życia twoich rodziców zmieniła twój obraz nich?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_past_004_fu_1",
+          "text": "Co pomogło ci zrozumieć, kim są?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_past_004_fu_2",
+          "text": "Poczułeś się wtedy bliżej nich, czy relacja stała się bardziej skomplikowana?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_communication_004",
+      "text": "Co twoja rodzina wie, ale zachowuje się, jakby nie wiedziała?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_communication_004_fu_1",
+          "text": "W jaki sposób wszyscy pomagają podtrzymywać to milczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_communication_004_fu_2",
+          "text": "Co twoim zdaniem zmieniłoby się, gdyby ktoś to wprost nazwał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_emotions_005",
+      "text": "Kiedy czułeś się rozdarty między miłością do rodziny a potrzebą dystansu od niej?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_emotions_005_fu_1",
+          "text": "Co się wtedy działo, że obydwa uczucia były jednocześnie prawdziwe?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_emotions_005_fu_2",
+          "text": "Jak zazwyczaj radzisz sobie z tym napięciem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_warmUp_dailyLife_001",
+      "text": "Jaki obowiązek rodzinny wypełniasz, choć cię wyczerpuje?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_honest_warmUp_dailyLife_001_fu_1",
+          "text": "Co sprawia, że dalej przez to przechodzisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_warmUp_dailyLife_001_fu_2",
+          "text": "Co by się stało, gdybyś powiedział wprost, jak się z tym czujesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_communication_001",
+      "text": "Jaka rozmowa z twoimi rodzicami czeka na swój moment?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_communication_001_fu_1",
+          "text": "Co ją powstrzymuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_communication_001_fu_2",
+          "text": "Jak sobie wyobrażasz, jak mogłaby przebiec?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_past_001",
+      "text": "Jaka decyzja kogoś z twojej rodziny wciąż kształtuje twoje życie?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_past_001_fu_1",
+          "text": "Ile miałeś wtedy do powiedzenia w tej sprawie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_past_001_fu_2",
+          "text": "Czy wciąż czujesz, że to ich decyzja, czy stała się już też twoja?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_communication_002",
+      "text": "Kto ma największą władzę w twojej rodzinie i jak to wpływa na wszystkich innych?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_communication_002_fu_1",
+          "text": "Czy ta dynamika władzy jest otwarcie uznawana, czy raczej przemilczana?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_communication_002_fu_2",
+          "text": "Jak ukształtowała twój własny stosunek do autorytetu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_emotions_001",
+      "text": "Którego elementu wychowania boisz się najbardziej powtórzyć?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_emotions_001_fu_1",
+          "text": "Kiedy ten schemat czujesz najbliżej powierzchni?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_emotions_001_fu_2",
+          "text": "Co byłoby potrzebne, żeby go przerwać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_past_002",
+      "text": "Co twoja rodzina sprawiła, że wydawało się normalne, a zakwestionowanie zajęło ci lata?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_past_002_fu_1",
+          "text": "Co pomogło ci w końcu spojrzeć na to inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_past_002_fu_2",
+          "text": "Jak to odkrycie zmieniło sposób, w jaki patrzysz na swoje dzieciństwo?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_values_001",
+      "text": "Co w twojej rodzinie łatwo źle odczytać, jeśli nie mieszkało się z wami wystarczająco blisko?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_values_001_fu_1",
+          "text": "Co z zewnątrz zazwyczaj jest rozumiane opacznie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_values_001_fu_2",
+          "text": "Co umyka temu niezrozumieniu z tego, jak to naprawdę wyglądało?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_conflict_001",
+      "text": "Jak w twojej rodzinie radzono sobie z konfliktami między rodzeństwem i czy nadal reagujesz na konflikty w podobny sposób?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_conflict_001_fu_1",
+          "text": "Jak ten sposób radzenia sobie z konfliktem sprawdza się teraz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_conflict_001_fu_2",
+          "text": "Czego żałujesz, że nie nauczyłeś się zamiast tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_values_002",
+      "text": "Co twoja rodzina wciąż ci wypomina, choć nie uważasz już, żeby to cię określało?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_values_002_fu_1",
+          "text": "Co zdają się widzieć, kiedy patrzą na tę część twojej przeszłości?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_values_002_fu_2",
+          "text": "Co by dla ciebie znaczyło, gdyby pozwolili ci być kimś więcej niż tamtą historią?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_realTalk_dailyLife_001",
+      "text": "Kto w twojej rodzinie wykonuje dużo niewidocznej pracy i czy ktoś to dostrzega?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_honest_realTalk_dailyLife_001_fu_1",
+          "text": "Jak ta rola na niego przypadła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_realTalk_dailyLife_001_fu_2",
+          "text": "Co by się zmieniło, gdyby przestał to robić przez tydzień?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_past_001",
+      "text": "Czego brakowało ci wtedy, żeby ktoś ci to powiedział, kiedy dorastałeś?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_past_001_fu_1",
+          "text": "Jak usłyszenie tego zmieniłoby bieg twojego życia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_past_001_fu_2",
+          "text": "Kto powinien był to powiedzieć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_past_002",
+      "text": "Co się wydarzyło w twojej rodzinie, co ukształtowało cię bardziej, niż większość ludzi zdaje sobie sprawę?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_past_002_fu_1",
+          "text": "Dlaczego myślisz, że rzadko o tym mówisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_past_002_fu_2",
+          "text": "Co ludzie zrozumieliby inaczej w tobie, gdyby o tym wiedzieli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_intimacy_001",
+      "text": "Czego nauczyli cię rodzice o miłości — niezależnie od tego, czy chcieli cię tego nauczyć?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_intimacy_001_fu_1",
+          "text": "To była lekcja, którą trzeba było odpuścić, czy taka, za którą jesteś wdzięczny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_intimacy_001_fu_2",
+          "text": "Jak przejawia się w twoich relacjach teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_intimacy_002",
+      "text": "Kto z twojej rodziny najbardziej nauczył cię, jak miłość wygląda w prawdziwym życiu?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_intimacy_002_fu_1",
+          "text": "Co robił, że ta lekcja tak głęboko do ciebie trafiła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_intimacy_002_fu_2",
+          "text": "Czy to była lekcja, którą chciałeś zatrzymać, czy taka, którą musiałeś na własny użytek przerobić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_past_003",
+      "text": "Gdyby dało się zmienić jedną rzecz w sposobie, w jaki cię wychowano — co by to było?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_past_003_fu_1",
+          "text": "Jak myślisz, jak ta jedna zmiana mogłaby się odbić echem w twoim życiu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_past_003_fu_2",
+          "text": "Czy udało ci się z rodzicami o tym porozmawiać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_past_004",
+      "text": "Co chcesz powiedzieć sobie — temu, który próbował przetrwać w swojej rodzinie jako dziecko?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_past_004_fu_1",
+          "text": "Czego potrzebowało tamto młodsze ja, a czego nie dostawało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_past_004_fu_2",
+          "text": "Co nadal nosisz w sobie z tamtego sposobu radzenia sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_honest_deepDive_dailyLife_001",
+      "text": "Jaka rutyna w twojej rodzinie ukształtowała cię bardziej, niż ktokolwiek zdaje sobie sprawę?",
+      "mode": "family",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_honest_deepDive_dailyLife_001_fu_1",
+          "text": "Czy to był świadomy wybór, czy po prostu tak było?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_honest_deepDive_dailyLife_001_fu_2",
+          "text": "Jak to wciąż pojawia się w twoim życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_identity_001",
+      "text": "Jaką rolę odgrywasz w swojej rodzinie i jak do niej doszedłeś?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_identity_001_fu_1",
+          "text": "Czy to rola, której chcesz, czy taka, która ci przypadła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_identity_001_fu_2",
+          "text": "Kim możesz być, kiedy nie trzeba już jej dźwigać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_conflict_001",
+      "text": "Której rozmowy się obawiasz, a wiesz, że musi się odbyć?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_001_fu_1",
+          "text": "Jaki najgorszy scenariusz sobie wyobrażasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_001_fu_2",
+          "text": "Ile cię kosztuje każde kolejne odkładanie tego na później?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_001",
+      "text": "Co by się zmieniło, gdyby wszyscy w tej rodzinie mówili to, co naprawdę mają na myśli?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_001_fu_1",
+          "text": "Czy to by was zbliżyło, czy wszystko by rozsadziło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_001_fu_2",
+          "text": "Kto ma w sobie najwięcej do powiedzenia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_past_001",
+      "text": "Jaka rodzinna tajemnica ukształtowała cię bardziej, niż ktokolwiek zdaje sobie sprawę?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_past_001_fu_1",
+          "text": "Jak się o niej dowiedziałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_past_001_fu_2",
+          "text": "Co zrobiło z tobą noszenie tej wiedzy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_002",
+      "text": "Jakie jest największe kłamstwo, które twoja rodzina opowiada sobie o sobie?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_002_fu_1",
+          "text": "Kto korzysta na podtrzymywaniu tego kłamstwa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_002_fu_2",
+          "text": "Co twoim zdaniem prawda zażądałaby od każdego z was?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_001",
+      "text": "Co z twojego dzieciństwa w tej rodzinie wciąż cię dopada?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_001_fu_1",
+          "text": "Kiedy zazwyczaj to wraca na powierzchnię?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_001_fu_2",
+          "text": "Czego twoim zdaniem to od ciebie wciąż chce?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_002",
+      "text": "Jaka rana z twojej rodziny wciąż się nie zagoiła?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_002_fu_1",
+          "text": "Co stoi na przeszkodzie temu, żeby się zagoiła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_002_fu_2",
+          "text": "Jak wyglądałoby dla ciebie prawdziwe uzdrowienie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_growth_001",
+      "text": "Kiedy przestałeś starać się zdobyć aprobatę kogoś z rodziny?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_growth_001_fu_1",
+          "text": "Co było tą ostatnią kroplą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_growth_001_fu_2",
+          "text": "Jak odpuszczenie tego cię zmieniło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_conflict_002",
+      "text": "Co cię gryzie w tym, jak obowiązki są podzielone w twojej rodzinie?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_002_fu_1",
+          "text": "Czy kiedykolwiek to poruszyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_002_fu_2",
+          "text": "Jak wyglądałoby sprawiedliwe rozwiązanie według ciebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_past_002",
+      "text": "Jaka część historii twojej rodziny jest ciężka do niesienia?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_past_002_fu_1",
+          "text": "Czy czujesz, że jesteś za ten ciężar odpowiedzialny?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_past_002_fu_2",
+          "text": "Kto jeszcze z rodziny niesie go razem z tobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_conflict_003",
+      "text": "Co zrobiła ci bliska osoba w rodzinie, czego do dziś naprawdę nie możesz wybaczyć?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_003_fu_1",
+          "text": "Czego wymagałoby od ciebie przebaczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_003_fu_2",
+          "text": "Co sprawia, że ta rana nadal nie goi się?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_003",
+      "text": "Czego pragniesz, żeby twoi rodzice naprawdę wiedzieli o twoim życiu teraz?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_003_fu_1",
+          "text": "Co powstrzymuje cię od powiedzenia im tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_003_fu_2",
+          "text": "Jak myślisz, jak by zareagowali?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_003",
+      "text": "W jaki sposób rodzina sprawiała, że czułeś się mały, nie zdając sobie z tego sprawy?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_003_fu_1",
+          "text": "Czy to nadal się zdarza?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_003_fu_2",
+          "text": "Jak to uczucie ukształtowało sposób, w jaki siebie postrzegasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_growth_002",
+      "text": "Jaki szkodliwy schemat z twojej rodziny starasz się nie powtarzać?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_growth_002_fu_1",
+          "text": "Kiedy łapiesz się na tym, że w niego wpadasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_growth_002_fu_2",
+          "text": "Co starasz się zamiast tego ćwiczyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_004",
+      "text": "Co jest najtrudniejsze w kochaniu kogoś z twojej rodziny?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_004_fu_1",
+          "text": "Co sprawia, że ta miłość jest skomplikowana?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_004_fu_2",
+          "text": "Jak teraz rozumiesz tę trudność?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_identity_002",
+      "text": "Jaka część twojej tożsamości wciąż nie jest w pełni akceptowana przez rodzinę?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_identity_002_fu_1",
+          "text": "Jak brak ich akceptacji wpływa na ciebie na co dzień?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_identity_002_fu_2",
+          "text": "Czy przestałeś już próbować sprawić, żeby to zobaczyli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_past_003",
+      "text": "Co twoje młodsze ja pomyślałoby o twoim dzisiejszym stosunku do rodziny?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_past_003_fu_1",
+          "text": "Czy poczułoby ulgę, zagubienie, czy ból?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_past_003_fu_2",
+          "text": "Co chcesz mu wytłumaczyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_conflict_004",
+      "text": "Jaką granicę w relacji z rodziną musiałeś wywalczyć, żeby ją postawić?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_004_fu_1",
+          "text": "Co cię kosztowało utrzymanie tej granicy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_004_fu_2",
+          "text": "Czy od tamtej pory jest ona respektowana?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_004",
+      "text": "Jest coś, z czym nigdy nie skonfrontowałeś się z kimś z rodziny, a może powinieneś?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_004_fu_1",
+          "text": "Co cię powstrzymywało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_004_fu_2",
+          "text": "Co chcesz powiedzieć, gdy w końcu to zrobisz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_conflict_005",
+      "text": "W jaki sposób twoja rodzina radziła sobie z konfliktem — i czego musiałeś się odzwyczaić?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_005_fu_1",
+          "text": "Czym to zastąpiłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_conflict_005_fu_2",
+          "text": "Czy to odzwyczajenie przyszło stopniowo, czy wymusił je jakiś konkretny moment?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_005",
+      "text": "Co najboleśniejszego powiedział ci kiedyś ktoś z rodziny?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_005_fu_1",
+          "text": "Czy myślisz, że wiedział, jak bardzo to zabolało?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_005_fu_2",
+          "text": "Jak to zmieniło wasz stosunek do siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_identity_003",
+      "text": "Kiedy czułeś się czarną owcą w swojej rodzinie?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_identity_003_fu_1",
+          "text": "To było coś, co zrobiłeś, czy po prostu to, kim jesteś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_identity_003_fu_2",
+          "text": "Czy pogodziłeś się z tym poczuciem bycia z zewnątrz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_intimacy_001",
+      "text": "Co w związku twoich rodziców wpłynęło na to, jak patrzysz na miłość?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_intimacy_001_fu_1",
+          "text": "Chciałeś to powtórzyć, czy za wszelką cenę uniknąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_intimacy_001_fu_2",
+          "text": "Jak to się przejawia w twoich własnych relacjach?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_values_001",
+      "text": "Jakie niesprawiedliwe oczekiwanie ciążyło na tobie w dzieciństwie?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_values_001_fu_1",
+          "text": "Kto je na ciebie nałożył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_values_001_fu_2",
+          "text": "Udało ci się je zostawić za sobą, czy wciąż tobą kieruje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_005",
+      "text": "Jaka prawda o twojej rodzinie jest taka, że nikt z zewnątrz by nie uwierzył?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_005_fu_1",
+          "text": "Co ktoś musiałby zobaczyć, żeby to zrozumieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_005_fu_2",
+          "text": "Jak jednocześnie nosisz w sobie tę prawdę i jej publiczny obraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_emotions_006",
+      "text": "Co dźwigasz po swojej rodzinie, a tak bardzo chcesz w końcu odłożyć?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_006_fu_1",
+          "text": "Co sprawia, że wciąż to trzymasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_emotions_006_fu_2",
+          "text": "Jak wyglądałoby twoje życie bez tego ciężaru?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_appreciation_001",
+      "text": "Jaką ofiarę złożyłeś dla rodziny, która przeszła bez echa?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_appreciation_001_fu_1",
+          "text": "Jak się czułeś, dając tyle bez żadnego uznania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_appreciation_001_fu_2",
+          "text": "Da się to zrobić jeszcze raz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_growth_003",
+      "text": "Co obiecałeś sobie, że nigdy nie zrobisz jako rodzic — i łapiesz się na tym, że jednak to robisz?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_growth_003_fu_1",
+          "text": "Co czujesz, gdy to zauważasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_growth_003_fu_2",
+          "text": "Co starasz się robić inaczej mimo wszystko?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_growth_004",
+      "text": "Kiedy po raz pierwszy zorientowałeś się, że powtarzasz rodzinny schemat?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_growth_004_fu_1",
+          "text": "Co cię naprowdziło na ten trop?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_growth_004_fu_2",
+          "text": "Udało ci się go przerwać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_communication_006",
+      "text": "Na co twoja rodzina jest najbardziej w zaprzeczeniu?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_communication_006_fu_1",
+          "text": "Co przyznanie tego przed sobą wymagałoby od każdego z was?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_communication_006_fu_2",
+          "text": "Myślisz, że ktoś inny w rodzinie też to widzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_warmUp_dailyLife_001",
+      "text": "Jaki rodzinny rytuał spotkań przypomina bardziej spektakl niż prawdziwe bycie razem?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_warmUp_dailyLife_001_fu_1",
+          "text": "Dla kogo tak naprawdę jest ten spektakl?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_warmUp_dailyLife_001_fu_2",
+          "text": "Jak by to wyglądało, gdyby wszyscy po prostu przestali udawać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_realTalk_communication_001",
+      "text": "Jaki temat mógłby rozerwać twoją rodzinę na strzępy, gdyby ktoś w końcu nazwał go wprost?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_realTalk_communication_001_fu_1",
+          "text": "Kto ma najwięcej do stracenia, jeśli to zostanie powiedziane na głos?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_realTalk_communication_001_fu_2",
+          "text": "Myślisz, że konsekwencje byłyby chwilowe, czy zmieniłyby rodzinę na zawsze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_realTalk_communication_002",
+      "text": "Kto w twojej rodzinie jest najbardziej chroniony przed prawdą?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_realTalk_communication_002_fu_1",
+          "text": "Jak wszyscy pomagają utrzymać tę ochronę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_realTalk_communication_002_fu_2",
+          "text": "Co kosztuje resztę rodziny ciągłe podtrzymywanie tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_realTalk_past_001",
+      "text": "Czego boisz się, że twoje dzieci — lub przyszłe dzieci — mogą odziedziczyć po tobie z twojej rodziny?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_realTalk_past_001_fu_1",
+          "text": "Kiedy najsilniej czujesz to dziedzictwo w sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_realTalk_past_001_fu_2",
+          "text": "Co robisz, jeśli cokolwiek, żeby nie przeszło przez ciebie w niezmienionej formie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_realTalk_communication_003",
+      "text": "Jakie pytanie zawsze chciałeś zadać rodzicom, a nigdy tego nie zrobiłeś?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_realTalk_communication_003_fu_1",
+          "text": "Czego boisz się, że odpowiedź mogłaby brzmieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_realTalk_communication_003_fu_2",
+          "text": "Co by się zmieniło, gdyby to pytanie w końcu padło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_realTalk_dailyLife_001",
+      "text": "Jaką rolę w domu przypisano ci w dzieciństwie — a na którą nigdy nie wyraziłeś zgody?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_realTalk_dailyLife_001_fu_1",
+          "text": "Jak to ukształtowało sposób, w jaki funkcjonujesz w rodzinie teraz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_realTalk_dailyLife_001_fu_2",
+          "text": "Czy próbowałeś kiedyś tę rolę odłożyć albo zwrócić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_past_001",
+      "text": "Co rodzina ci zabrała, a co wciąż kształtuje sposób, w jaki żyjesz?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_past_001_fu_1",
+          "text": "Jak strata tego zmieniła to, kim stałeś się w tej rodzinie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_past_001_fu_2",
+          "text": "Czy myślisz, że da się teraz odzyskać choć część tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_emotions_001",
+      "text": "Jak strata kogoś z rodziny dotknęła cię wtedy — i jak dotyka teraz?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_emotions_001_fu_1",
+          "text": "Jaka część tej straty wciąż jest w tobie żywa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_emotions_001_fu_2",
+          "text": "Czy to, jak w tobie mieszka, zmieniło się z czasem, czy po prostu ucichło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_past_002",
+      "text": "Jakiej cechy rodziców najbardziej boisz się zobaczyć w sobie?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_past_002_fu_1",
+          "text": "Kiedy dostrzegasz jej przebłyski?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_past_002_fu_2",
+          "text": "Co robisz, gdy widzisz, że zaczyna wychodzić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_past_003",
+      "text": "Jak śmierć była wyjaśniana w twojej rodzinie, kiedy dorastałeś — i czy to wyjaśnienie wciąż cię pociesza?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_past_003_fu_1",
+          "text": "Czy to wyjaśnienie naprawdę cię wtedy pocieszało, czy po prostu nauczyłeś się w nim żyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_past_003_fu_2",
+          "text": "Co teraz myślisz o śmierci, a co różni się od tego, czego cię uczono?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_communication_001",
+      "text": "Jest coś, czego nigdy nie powiedziałeś rodzicom?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_communication_001_fu_1",
+          "text": "Co by to dla nich znaczyło, gdyby w końcu to wiedzieli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_communication_001_fu_2",
+          "text": "Co przez cały ten czas powstrzymywało cię od powiedzenia tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_communication_002",
+      "text": "Jakiej rozmowy z kimś z rodziny wciąż ci brakuje tak bardzo, że wiele dałoby się za nią oddać?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_communication_002_fu_1",
+          "text": "Co chcesz powiedzieć, gdyby dało się dostać tę szansę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_communication_002_fu_2",
+          "text": "Czego wciąż pragniesz, żeby tamta osoba ci odpowiedziała?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_family_unfiltered_deepDive_dailyLife_001",
+      "text": "Jakie praktyczne napięcie w twojej rodzinie wszyscy omijają, zamiast naprawdę się nim zająć?",
+      "mode": "family",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_family_unfiltered_deepDive_dailyLife_001_fu_1",
+          "text": "Co byłoby potrzebne, żeby naprawdę się z tym zmierzyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_family_unfiltered_deepDive_dailyLife_001_fu_2",
+          "text": "Komu najbardziej opłaca się zostawiać to nierozwiązane?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_001",
+      "text": "Na co poświęcasz za dużo czasu, choć pewnie nie powinieneś?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_001_fu_1",
+          "text": "Co ci to daje, że wciąż do tego wracasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_001_fu_2",
+          "text": "Co chcesz robić z tym czasem, kiedy go odzyskasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_001",
+      "text": "Z czego jesteś teraz naprawdę dumny?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_001_fu_1",
+          "text": "Co było potrzebne, żeby to osiągnąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_001_fu_2",
+          "text": "Czy pozwoliłeś sobie w pełni to poczuć i ucieszyć się z tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_emotions_001",
+      "text": "Co ostatnio pojawia się w twoich snach?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_001_fu_1",
+          "text": "Czy uważasz, że sny próbują ci coś powiedzieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_001_fu_2",
+          "text": "Jak się czujesz, kiedy się budzisz po takim śnie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_002",
+      "text": "W czym po cichu coraz lepiej ci idzie, choć nikt tego nie zauważa?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_002_fu_1",
+          "text": "Co napędza ten cichy postęp?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_002_fu_2",
+          "text": "Czy zależy ci na tym, żeby ktoś to zauważył?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_002",
+      "text": "Co robisz, gdy jesteś zupełnie w pojedynkę i nikt nie patrzy?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_002_fu_1",
+          "text": "Co to zachowanie mówi o tym, kim naprawdę jesteś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_002_fu_2",
+          "text": "Czy to coś, co lubisz robić, czy tylko nawyk?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_003",
+      "text": "Na co najczęściej się narzekasz?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_003_fu_1",
+          "text": "Co kryje się pod tymi narzekaniami?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_003_fu_2",
+          "text": "Czy to coś, co możesz zmienić, czy po prostu potrzebujesz to z siebie wyrzucić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_past_001",
+      "text": "Jaką umiejętność kiedyś miałeś, a teraz brakuje ci jej bardziej, niż się spodziewałeś?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_past_001_fu_1",
+          "text": "Co ta umiejętność dawała ci poczuć lub wyrazić, kiedy była jeszcze częścią twojego życia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_past_001_fu_2",
+          "text": "Chcesz ją odzyskać, czy miała swój czas i idziesz już dalej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_003",
+      "text": "Jakie małe zwycięstwo odniosłeś ostatnio, którego za bardzo nie uczciłeś?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_003_fu_1",
+          "text": "Dlaczego pozwoliłeś temu przejść niezauważonemu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_003_fu_2",
+          "text": "Jak wyglądałoby świętowanie tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_identity_001",
+      "text": "Kiedy ostatnio coś naprawdę cię zaskoczyło w sobie samym?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_identity_001_fu_1",
+          "text": "Czy to było przyjemne zaskoczenie, czy raczej niepokojące?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_identity_001_fu_2",
+          "text": "Co to twoim zdaniem mówi o tym, dokąd zmierzasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_004",
+      "text": "Jaki comfort food zawsze sprawia, że wszystko staje się odrobinę lepsze?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_004_fu_1",
+          "text": "Jakie wspomnienie lub uczucie się z nim wiąże?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_004_fu_2",
+          "text": "Co cię bardziej uspokaja — smak czy sam rytuał jedzenia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_emotions_002",
+      "text": "Jakie miejsce zawsze daje ci spokój?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_002_fu_1",
+          "text": "Co jest w tym miejscu, co cię wycisza?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_002_fu_2",
+          "text": "Kiedy ostatnio tam byłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_005",
+      "text": "Na co teraz czekasz z niecierpliwością?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_005_fu_1",
+          "text": "Co cię w tym najbardziej ekscytuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_005_fu_2",
+          "text": "Jak posiadanie czegoś, na co czekasz, wpływa na twój nastrój?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_006",
+      "text": "Co chcesz robić przez cały dzień bez żadnych zobowiązań?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_006_fu_1",
+          "text": "Czy planujesz taki dzień z góry, czy wolisz pozwolić mu się potoczyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_006_fu_2",
+          "text": "Co idealna wersja takiego dnia mówi o tym, czego potrzebujesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_growth_001",
+      "text": "Do czego od jakiegoś czasu chcesz wrócić?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_growth_001_fu_1",
+          "text": "Co w pierwszej kolejności odciągnęło cię od tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_growth_001_fu_2",
+          "text": "Co daje ci powrót do tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_004",
+      "text": "Jaki komplement dostałeś, który zapamiętałeś najbardziej?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_004_fu_1",
+          "text": "Dlaczego właśnie ten trafił tak głęboko?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_004_fu_2",
+          "text": "Czy naprawdę w to wierzysz o sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_007",
+      "text": "Jaka prosta przyjemność nigdy ci się nie nudzi?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_007_fu_1",
+          "text": "Co sprawia, że za każdym razem jest jak nowa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_007_fu_2",
+          "text": "Kiedy odkryłeś, jak wiele dla ciebie znaczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_005",
+      "text": "Za co jesteś wdzięczny, choć rzadko o tym myślisz?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_005_fu_1",
+          "text": "Jak wyglądałoby twoje życie bez tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_005_fu_2",
+          "text": "Dlaczego tak łatwo to pomijasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_growth_002",
+      "text": "Jakiej umiejętności nauczyłeś się i jak zmieniła twoje codzienne życie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_growth_002_fu_1",
+          "text": "Jak ją zdobyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_growth_002_fu_2",
+          "text": "Jaką różnicę robi w zwykły dzień?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_008",
+      "text": "Jak zwykle się regenerujesz, kiedy działasz na oparach?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_008_fu_1",
+          "text": "Czy to naprawdę cię odnawia, czy tylko odwraca uwagę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_008_fu_2",
+          "text": "Po czym poznajesz, że dotarłeś do kresu sił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_growth_003",
+      "text": "Czego ostatnio się nauczyłeś i co naprawdę cię ekscytuje?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_growth_003_fu_1",
+          "text": "Co w tym wywołało taki entuzjazm?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_growth_003_fu_2",
+          "text": "Czy zrobiłeś z tym coś od tamtej pory?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_past_002",
+      "text": "Jakie wspomnienie z dzieciństwa zawsze sprawia, że się uśmiechasz?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_past_002_fu_1",
+          "text": "Co w tym jest tak ciepłego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_past_002_fu_2",
+          "text": "Kto jest w tym wspomnieniu razem z tobą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_009",
+      "text": "Co w twoim porannym rytuale nadaje ton całemu dniu?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_009_fu_1",
+          "text": "Co się dzieje z twoim dniem, kiedy to pomijasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_009_fu_2",
+          "text": "Jak to stało się twoim rytuałem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_values_001",
+      "text": "Jaką osobistą zasadę stosujesz w życiu, o której mało kto wie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_values_001_fu_1",
+          "text": "Skąd pochodzi ta zasada?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_values_001_fu_2",
+          "text": "Czy była kiedyś wystawiona na próbę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_growth_004",
+      "text": "W czym stałeś się bardziej cierpliwy z wiekiem?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_growth_004_fu_1",
+          "text": "Co nauczyło cię tej cierpliwości?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_growth_004_fu_2",
+          "text": "Czy jest coś, w czym wciąż nie masz cierpliwości?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_emotions_003",
+      "text": "Jaka piosenka zawsze poprawia ci humor?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_003_fu_1",
+          "text": "Jakie wspomnienie lub uczucie ona przywołuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_emotions_003_fu_2",
+          "text": "Kiedy po nią sięgasz najczęściej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_010",
+      "text": "Kiedy ostatnio zrobiłeś coś, co czuło się naprawdę spontanicznie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_010_fu_1",
+          "text": "Co pchnęło cię do działania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_010_fu_2",
+          "text": "Jak to wyglądało w porównaniu z twoim zwykłym, zaplanowanym podejściem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_appreciation_006",
+      "text": "Jaką cechę w sobie zacząłeś doceniać?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_006_fu_1",
+          "text": "Czy od zawsze widziałeś w niej siłę, czy to wymagało czasu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_appreciation_006_fu_2",
+          "text": "Jak ta cecha przejawia się w twoim codziennym życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_identity_002",
+      "text": "Co kolekcjonujesz — dosłownie lub w głowie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_identity_002_fu_1",
+          "text": "Co cię do tego przyciąga?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_identity_002_fu_2",
+          "text": "Co ta kolekcja dla ciebie znaczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_past_003",
+      "text": "Jakie miejsce, które odwiedziłeś, zostawiło w tobie trwały ślad?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_past_003_fu_1",
+          "text": "Co tak bardzo na ciebie wpłynęło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_past_003_fu_2",
+          "text": "Chcesz tam wrócić, czy samo wspomnienie wystarczy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_dailyLife_011",
+      "text": "Co robisz wyłącznie dla radości, bez żadnego celu?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_011_fu_1",
+          "text": "Jak na to trafiłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_dailyLife_011_fu_2",
+          "text": "Co ci to daje, czego nie dają rzeczy zorientowane na cel?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_communication_001",
+      "text": "Do kogo ostatnio nosisz w sobie niezamieszane słowa?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_communication_001_fu_1",
+          "text": "Co sprawia, że trudno je wypowiedzieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_communication_001_fu_2",
+          "text": "Jak myślisz, jak byś się poczuł, kiedy w końcu to powiesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_warmUp_conflict_001",
+      "text": "Jakie małe nieporozumienie z ostatnich dni zostało z tobą dłużej, niż powinno?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "warmUp",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_warmUp_conflict_001_fu_1",
+          "text": "O co chodziło tak naprawdę pod spodem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_warmUp_conflict_001_fu_2",
+          "text": "Czy to rozwiązałeś, czy po prostu dałeś temu minąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_values_001",
+      "text": "Co chcesz, żeby ludzie pamiętali o tobie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_values_001_fu_1",
+          "text": "Czy żyjesz w sposób, który do tego prowadzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_values_001_fu_2",
+          "text": "Co trzeba by zmienić, żeby być bliżej tego ideału?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_emotions_001",
+      "text": "Kiedy ostatnio czułeś się zupełnie i całkowicie wolny?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_emotions_001_fu_1",
+          "text": "Co stworzyło to uczucie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_emotions_001_fu_2",
+          "text": "Jak często dajesz sobie przyzwolenie, żeby tak się czuć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_past_001",
+      "text": "Co straciłeś, o czym wciąż myślisz?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_past_001_fu_1",
+          "text": "Czego ta strata nauczyła cię o tym, co ma znaczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_past_001_fu_2",
+          "text": "Czy znalazłeś coś, co wypełnia tę pustkę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_emotions_002",
+      "text": "Kiedy ostatnio miałeś poczucie, że wszystko idzie po twojej myśli?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_emotions_002_fu_1",
+          "text": "Co było inne w tamtym czasie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_emotions_002_fu_2",
+          "text": "Co twoim zdaniem to umożliwiło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_growth_001",
+      "text": "Na czym ci kiedyś bardzo zależało, a teraz ledwo to dostrzegasz?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_growth_001_fu_1",
+          "text": "Co spowodowało tę zmianę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_growth_001_fu_2",
+          "text": "Czy odpuszczenie tego to dla ciebie wzrost, czy raczej strata?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_realTalk_growth_002",
+      "text": "Co zacząłeś z czasem widzieć bardziej realistycznie?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_realTalk_growth_002_fu_1",
+          "text": "Co pomogło ci zacząć to widzieć inaczej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_realTalk_growth_002_fu_2",
+          "text": "Czy mając ten jaśniejszy obraz, czujesz się lepiej czy gorzej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_deepDive_values_001",
+      "text": "Jak naprawdę wygląda dla ciebie dobre życie — nie to, które ktoś ci mówił, że powinno?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_deepDive_values_001_fu_1",
+          "text": "Jak blisko jesteś tej wersji życia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_deepDive_values_001_fu_2",
+          "text": "Jaka jest największa przepaść między tym, gdzie jesteś, a gdzie chcesz być?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_deepDive_values_002",
+      "text": "Jakie przekonanie ukształtowało cię bardziej niż cokolwiek innego?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_deepDive_values_002_fu_1",
+          "text": "Gdzie to przekonanie zapuściło korzenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_deepDive_values_002_fu_2",
+          "text": "Czy było kiedyś podważone?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_deepDive_growth_001",
+      "text": "Co zbudowałeś — nawyk, relację, sposób myślenia — z czego jesteś naprawdę dumny?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_deepDive_growth_001_fu_1",
+          "text": "Co było potrzebne, żeby to zbudować?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_deepDive_growth_001_fu_2",
+          "text": "Co daje ci coś, czego wcześniej nie miałeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_light_deepDive_appreciation_001",
+      "text": "Jaka część twojego życia wydaje ci się dokładnie taka, jaka powinna być?",
+      "mode": "soloReflection",
+      "intensity": "light",
+      "depth": "deepDive",
+      "topic": "appreciation",
+      "followUps": [
+        {
+          "id": "p_soloReflection_light_deepDive_appreciation_001_fu_1",
+          "text": "Co sprawia, że tak dobrze pasuje?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_light_deepDive_appreciation_001_fu_2",
+          "text": "Jak ją doprowadziłeś do tego miejsca?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_001",
+      "text": "Co przychodzi ci do głowy, kiedy przypadkowo złapiesz swoje odbicie?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_001_fu_1",
+          "text": "Czy to myśl życzliwa, czy krytyczna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_001_fu_2",
+          "text": "Czy głos w twojej głowie zawsze tak mówił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_001",
+      "text": "Jaki zły nawyk próbowałeś porzucić, ale wciąż do niego wracasz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_001_fu_1",
+          "text": "Co ten nawyk ci daje, że jest taki trudny do porzucenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_001_fu_2",
+          "text": "Czego by od ciebie wymagało naprawdę go porzucenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_002",
+      "text": "Jaki rodzaj stresu zmienia cię w sposób, którego może do końca nie widzisz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_002_fu_1",
+          "text": "Co zaczyna się w tobie zmieniać, gdy ten stres narasta?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_002_fu_2",
+          "text": "Co zwykle pomaga ci to wcześniej zauważyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_communication_001",
+      "text": "Na co zaskakująco trudno ci powiedzieć tak?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_communication_001_fu_1",
+          "text": "Co kryje się pod tym wahaniem?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_communication_001_fu_2",
+          "text": "Co chronisz, powstrzymując się?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_identity_001",
+      "text": "Gdzie twoje życie najbardziej rozmija się z tym, gdzie myślałeś, że będziesz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_001_fu_1",
+          "text": "Czy ta różnica motywuje cię, czy raczej zniechęca?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_001_fu_2",
+          "text": "Czego by wymagało jej zmniejszenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_002",
+      "text": "Co wciąż odkładasz, choć naprawdę ci na tym zależy?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_002_fu_1",
+          "text": "Jaki jest prawdziwy powód, dla którego to odkładasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_002_fu_2",
+          "text": "Jak byś się czuł, gdybyś to w końcu zrobił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_003",
+      "text": "Jaką emocję najtrudniej ci wytrzymać?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_003_fu_1",
+          "text": "Co zwykle robisz, żeby od niej uciec?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_003_fu_2",
+          "text": "Co twoim zdaniem próbuje ci ona powiedzieć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_values_001",
+      "text": "Jakiego standardu wobec siebie trzymasz, który może być zbyt wysoki?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_values_001_fu_1",
+          "text": "Skąd ten standard pochodzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_values_001_fu_2",
+          "text": "Co w twoim życiu by zelżało, gdybyś go obniżył?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_003",
+      "text": "Co mówisz sobie od dłuższego czasu, co może nie być prawdą?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_003_fu_1",
+          "text": "Od jak dawna powtarzasz sobie tę historię?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_003_fu_2",
+          "text": "Co by się zmieniło, gdybyś ją puścił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_intimacy_001",
+      "text": "Która relacja w twoim życiu domaga się więcej uwagi?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "intimacy",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_intimacy_001_fu_1",
+          "text": "Co stoi na przeszkodzie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_intimacy_001_fu_2",
+          "text": "Jak wyglądałoby bycie nieco bardziej obecnym w tej relacji?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_004",
+      "text": "Co nosisz w sobie, czym jeszcze z nikim się nie podzieliłeś?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_004_fu_1",
+          "text": "Czego potrzebujesz, żeby to komuś powiedzieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_004_fu_2",
+          "text": "Jak niesienie tego w pojedynkę na ciebie wpływa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_identity_002",
+      "text": "Co ludzie o tobie zakładają, a co jest błędne?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_002_fu_1",
+          "text": "Co tworzy to fałszywe wrażenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_002_fu_2",
+          "text": "Czy na tyle ci to przeszkadza, żeby to prostować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_005",
+      "text": "Jakiej decyzji z ostatnich dni wciąż jesteś niepewny?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_005_fu_1",
+          "text": "Jaka jest wersja wydarzeń, w której podjąłeś właściwą decyzję?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_005_fu_2",
+          "text": "Co by rozwiało te wątpliwości?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_006",
+      "text": "Gdy życie staje się ciężkie, czego potrzebujesz, a rzadko sobie dajesz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_006_fu_1",
+          "text": "Dlaczego twoim zdaniem nie zauważasz tej potrzeby, gdy jesteś pod presją?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_006_fu_2",
+          "text": "Co by ułatwiło ci danie sobie tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_004",
+      "text": "W jakiej dziedzinie życia jedziesz na autopilocie?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_004_fu_1",
+          "text": "Jak wyglądałoby to, gdybyś znów zaczął się starać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_004_fu_2",
+          "text": "Co pozwoliło ci przejść na tryb automatyczny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_007",
+      "text": "Po czym poznajesz, że stres zaczyna cię trochę stwardzać?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_007_fu_1",
+          "text": "Co zwykle twardnieje pierwsze — twój ton, cierpliwość, czy coś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_007_fu_2",
+          "text": "Co pomaga ci znów zmięknieć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_005",
+      "text": "Co by się zmieniło w twoim życiu, gdybyś przestał próbować zadowalać wszystkich?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_005_fu_1",
+          "text": "Kogo rozczarowujesz jako pierwszego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_005_fu_2",
+          "text": "Co zyskujesz, decydując się na szczerość zamiast tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_values_002",
+      "text": "Co kiedyś było dla ciebie pewne, a teraz już nie jest?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_values_002_fu_1",
+          "text": "Co sprawiło, że ta pewność zaczęła pękać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_values_002_fu_2",
+          "text": "Czy ta niepewność jest dla ciebie ciężarem, czy wyzwoleniem?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_dailyLife_001",
+      "text": "Co twoim zdaniem jest teraz twoim największym rozpraszaczem w życiu?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_dailyLife_001_fu_1",
+          "text": "Od czego cię to odciąga?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_dailyLife_001_fu_2",
+          "text": "Z czym musiałbyś się zmierzyć bez tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_identity_003",
+      "text": "Którą część swojej osobowości ostatnio ukrywasz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_003_fu_1",
+          "text": "Co sprawiło, że zdecydowałeś ją schować?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_003_fu_2",
+          "text": "Czy tęsknisz za tą częścią siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_identity_004",
+      "text": "Jaki komplement trudno ci przyjąć na swój temat?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_004_fu_1",
+          "text": "Dlaczego tak trudno go wpuścić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_004_fu_2",
+          "text": "Co by to znaczyło, gdybyś w to uwierzył?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_008",
+      "text": "Za co potrzebujesz sobie wybaczyć?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_008_fu_1",
+          "text": "Co stało na drodze do tego przebaczenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_008_fu_2",
+          "text": "Co by ci to puszczenie umożliwiło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_006",
+      "text": "Kiedy ostatnio byłeś naprawdę szczery ze sobą w jakiejś niewygodnej sprawie?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_006_fu_1",
+          "text": "Co wtedy przyznałeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_006_fu_2",
+          "text": "Jak się poczułeś, kiedy przestałeś to w sobie chować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_communication_002",
+      "text": "Jaką granicę musisz postawić, ale jeszcze tego nie zrobiłeś?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_communication_002_fu_1",
+          "text": "Co powstrzymuje cię od jej wyznaczenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_communication_002_fu_2",
+          "text": "Co by się zmieniło, kiedy już istnieje?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_identity_005",
+      "text": "Jaka jest różnica między tym, jak się prezentujesz, a tym, jak naprawdę się czujesz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_005_fu_1",
+          "text": "Kto w twoim życiu widzi cię najbliżej prawdy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_identity_005_fu_2",
+          "text": "Co by było potrzebne, żeby tę różnicę zmniejszyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_values_003",
+      "text": "Co bardziej cię motywuje — strach przed porażką czy pragnienie czegoś lepszego?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_values_003_fu_1",
+          "text": "Jak ten motywator kształtuje sposób, w jaki podejmujesz ryzyko?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_values_003_fu_2",
+          "text": "Który chcesz, żeby bardziej tobą kierował?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_007",
+      "text": "Co w starzeniu się sprawiło, że stajesz się dla siebie bardziej łagodny?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_007_fu_1",
+          "text": "Czego ta łagodność cię uczy?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_007_fu_2",
+          "text": "Gdzie wciąż opierasz się, żeby ją sobie dać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_008",
+      "text": "W jaki sposób urosłeś w minionym roku, a jeszcze tego nie przyznałeś?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_008_fu_1",
+          "text": "Dlaczego tak trudno uznać to przed sobą?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_008_fu_2",
+          "text": "Co ten rozwój znaczy dla tego, kim się stajesz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_growth_009",
+      "text": "Czego unikasz, bo oznaczałoby to prawdziwą zmianę?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_009_fu_1",
+          "text": "Jakiej zmiany najbardziej się boisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_growth_009_fu_2",
+          "text": "Jak wyglądałoby życie po drugiej stronie tej zmiany?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_warmUp_emotions_009",
+      "text": "Co w starzeniu się sprawiło, że stałeś się bardziej zamknięty?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_009_fu_1",
+          "text": "Co chronisz, kiedy ta bariera wchodzi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_warmUp_emotions_009_fu_2",
+          "text": "Co pomaga ci czuć się wystarczająco bezpiecznie, żeby zmięknieć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_001",
+      "text": "Czego w sobie powoli nie możesz już nie widzieć?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_001_fu_1",
+          "text": "Co pomogło ci to zacząć zauważać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_001_fu_2",
+          "text": "Jak rozpoznanie tego cokolwiek zmieniło w twoim życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_002",
+      "text": "Jakiej decyzji ciągle unikasz, choć wiesz, że ma znaczenie?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_002_fu_1",
+          "text": "Co sprawia, że unikanie czuje się bezpieczniej niż podjęcie decyzji?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_002_fu_2",
+          "text": "Jaki jest koszt dalszego odkładania?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_values_001",
+      "text": "Jak się czujesz, gdy to ty masz władzę w jakiejś sytuacji?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_values_001_fu_1",
+          "text": "Czy czujesz się komfortowo z władzą, czy to cię niepokoi?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_values_001_fu_2",
+          "text": "Jak radzisz sobie z odpowiedzialnością, która idzie za tym?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_emotions_001",
+      "text": "Kiedy zauważasz, że odpowiadasz ze stresu, a nie z tego, co naprawdę czujesz?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_001_fu_1",
+          "text": "Co zwykle w tobie zanika, gdy stres przejmuje kontrolę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_001_fu_2",
+          "text": "Co by ci pomogło odpowiadać bardziej szczerze w tych chwilach?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_emotions_002",
+      "text": "Jakiego lęku związanego ze starzeniem trudniej ci doświadczać w głowie niż na głos?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_002_fu_1",
+          "text": "Co sprawia, że łatwiej go trzymać w ciszy niż go wypowiedzieć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_002_fu_2",
+          "text": "Co by się zmieniło, gdybyś pozwolił sobie go nazwać wprost?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_003",
+      "text": "Kiedy jesteś najbardziej dumny z tego, że stanąłeś w swojej obronie?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_003_fu_1",
+          "text": "Co dało ci odwagę, żeby to zrobić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_003_fu_2",
+          "text": "Jak to zmieniło to, czego wymagasz od siebie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_past_001",
+      "text": "Co nosisz w sobie dłużej, niż zasługuje na zajmowanie w tobie miejsca?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_past_001_fu_1",
+          "text": "Co by się stało, gdybyś to w końcu puścił?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_past_001_fu_2",
+          "text": "Co dawało ci trzymanie się tego?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_conflict_001",
+      "text": "Kiedy ostatnio nagiąłeś zasady w sposób, który wciąż w tobie siedzi?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_conflict_001_fu_1",
+          "text": "Czy czujesz się z tym winny, czy uważasz to za uzasadnione?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_conflict_001_fu_2",
+          "text": "Czy chcesz to zrobić znowu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_emotions_003",
+      "text": "Jacy ludzie budzą w tobie największą zazdrość i dlaczego?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_003_fu_1",
+          "text": "Co ta zazdrość ujawnia o tym, czego chcesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_003_fu_2",
+          "text": "Czy to coś, za czym możesz realnie podążać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_004",
+      "text": "Jak czas uczynił cię silniejszym, a jak bardziej kruchym?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_004_fu_1",
+          "text": "Gdzie teraz czujesz swoją siłę najwyraźniej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_004_fu_2",
+          "text": "Gdzie czujesz swoją kruchość najostrzej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_005",
+      "text": "Jaką granicę postawiłeś ostatnio, co poczułeś jako prawdziwy postęp?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_005_fu_1",
+          "text": "Co sprawiło, że w końcu ją wyznaczyłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_005_fu_2",
+          "text": "Jak od tamtej pory zmieniło się twoje życie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_growth_006",
+      "text": "Kiedy zacząłeś czuć, że doskonała sprawiedliwość może nie istnieć?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_006_fu_1",
+          "text": "Jakie doświadczenie sprawiło, że ta idea przestała być realna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_growth_006_fu_2",
+          "text": "Jak to zmieniło twój sposób patrzenia na sprawiedliwość i na ludzi?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_realTalk_emotions_004",
+      "text": "W co kiedyś wierzyłeś, że zawsze się ułoży, a teraz nie masz już takiej pewności?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_004_fu_1",
+          "text": "Co spowodowało tę zmianę przekonania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_realTalk_emotions_004_fu_2",
+          "text": "Jak czujesz się teraz, niosąc tę niepewność?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_deepDive_values_001",
+      "text": "Czego twoim zdaniem będziesz potrzebował coraz więcej z wiekiem?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_deepDive_values_001_fu_1",
+          "text": "Jaka troska lub stabilność będzie miała dla ciebie największe znaczenie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_deepDive_values_001_fu_2",
+          "text": "Która część ciebie wciąż ma trudność z przyznaniem się do tej potrzeby?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_deepDive_past_001",
+      "text": "Kiedy czujesz najsilniej, że twój czas nie jest nieograniczony?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_deepDive_past_001_fu_1",
+          "text": "Co ta świadomość sprawia, że chcesz chronić lub zmienić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_deepDive_past_001_fu_2",
+          "text": "Jak to wpływa na to, jak chcesz żyć teraz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_deepDive_growth_001",
+      "text": "Co wiesz, że musisz puścić, a nie możesz się do tego zmusić?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_deepDive_growth_001_fu_1",
+          "text": "Jak wyglądałoby twoje życie bez tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_deepDive_growth_001_fu_2",
+          "text": "Co sprawia, że twój uchwyt jest tak mocny?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_honest_deepDive_growth_002",
+      "text": "Jaka jest różnica między tym, kim jesteś, a kim chcesz być — i co żyje w tej przestrzeni?",
+      "mode": "soloReflection",
+      "intensity": "honest",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_honest_deepDive_growth_002_fu_1",
+          "text": "Co teraz wypełnia tę przestrzeń — strach, nawyk, czy coś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_honest_deepDive_growth_002_fu_2",
+          "text": "Jaki jest pierwszy krok ku zmniejszeniu tej różnicy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_001",
+      "text": "Z czym masz skomplikowaną relację, którą trudno ci wytłumaczyć?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_001_fu_1",
+          "text": "Co sprawia, że tak trudno to ująć w słowa?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_001_fu_2",
+          "text": "Czy ta komplikacja cię niepokoi, czy już ją przyjąłeś?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_values_001",
+      "text": "Kiedy jesteś najbardziej kuszony, by łamać własne zasady?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_values_001_fu_1",
+          "text": "Co zwykle kosztuje cię uleganie tej pokusie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_values_001_fu_2",
+          "text": "Czy ta pokusa dotyczy samej rzeczy, czy raczej buntu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_002",
+      "text": "Jakie uczucie połykasz, zamiast je wyrażać?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_002_fu_1",
+          "text": "Czego się boisz, że się stanie, jeśli je wypuścisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_002_fu_2",
+          "text": "Jak trzymanie tego w sobie na ciebie wpływa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_003",
+      "text": "Gdy negatywne myśli o sobie zaczynają brać górę, jak zwykle reagujesz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_003_fu_1",
+          "text": "Czy wiesz, jak się pocieszać w takich chwilach?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_003_fu_2",
+          "text": "Jaka odpowiedź z twojej strony naprawdę pomaga?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_past_001",
+      "text": "Gdyby dało się wymazać jakiś fragment twojej przeszłości, który byś wybrał?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_001_fu_1",
+          "text": "Czym różniłbyś się bez tego doświadczenia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_001_fu_2",
+          "text": "Czy jest w tym coś, co ukształtowało cię w sposób, który cenisz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_001",
+      "text": "W jaki sposób się sabotajesz, i w pełni o tym wiesz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_001_fu_1",
+          "text": "Co twoim zdaniem próbujesz w ten sposób ominąć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_001_fu_2",
+          "text": "Co by było potrzebne, żeby przerwać to koło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_001",
+      "text": "Jaką prawdę o swoim życiu upiększasz, gdy o niej mówisz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_001_fu_1",
+          "text": "Jaka jest ta wersja bez upiększeń?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_001_fu_2",
+          "text": "Dlaczego prawdziwa wersja wydaje się zbyt wrażliwa, by ją udostępniać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_002",
+      "text": "Co udajesz, że masz ogarnięte, choć naprawdę nie masz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_002_fu_1",
+          "text": "Co by to znaczyło przyznać, że wciąż jesteś tu zagubiony?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_002_fu_2",
+          "text": "Do kogo byś poszedł po pomoc, gdybyś mógł?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_002",
+      "text": "Jaki mechanizm radzenia sobie stosujesz, który tak naprawdę nie jest zdrowy?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_002_fu_1",
+          "text": "Co znieczula lub co omija?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_002_fu_2",
+          "text": "Co zdrowsza alternatywa mogłaby ci zamiast tego dać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_004",
+      "text": "Co twoje wewnętrzne życie o tobie wie, a twoje zewnętrzne życie wciąż nie chce przyznać?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_004_fu_1",
+          "text": "Co nie pozwala tej prawdzie wyjść na jaw?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_004_fu_2",
+          "text": "Jak to rozdarcie między tym, co wiesz, a tym, jak żyjesz, na ciebie wpływa?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_003",
+      "text": "Co jest najbardziej bolesnym uświadomieniem o sobie, jakie miałeś?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_003_fu_1",
+          "text": "Jak to na ciebie dotarło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_003_fu_2",
+          "text": "Co zrobiłeś z tą wiedzą?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_005",
+      "text": "Jakiego pragnienia masz, za które czujesz wstyd?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_005_fu_1",
+          "text": "Skąd pochodzi ten wstyd — z ciebie, czy z czyjejś głosu?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_005_fu_2",
+          "text": "Jak by to wyglądało, gdybyś tego pragnął bez poczucia winy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_003",
+      "text": "Jaką wersję siebie zakopałeś, która czasem jeszcze wypływa?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_003_fu_1",
+          "text": "Kiedy zwykle powraca?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_003_fu_2",
+          "text": "Czy to wersja, za którą tęsknisz, czy taka, z której chcesz wyrosnąć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_006",
+      "text": "Co jest najtrudniejsze w byciu tobą, a czego nikt naprawdę nie widzi?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_006_fu_1",
+          "text": "Co by to dla ciebie znaczyło, gdyby ktoś to w końcu zobaczył?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_006_fu_2",
+          "text": "Jak nosisz to w pojedynkę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_values_002",
+      "text": "Jaką obietnicę złożyłeś sobie już nieraz, a wciąż jej nie dotrzymałeś?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_values_002_fu_1",
+          "text": "Co za każdym razem staje na przeszkodzie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_values_002_fu_2",
+          "text": "Co by było potrzebne, żeby tym razem ją dotrzymać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_past_002",
+      "text": "W jakiej relacji zostałeś za długo i dlaczego?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_002_fu_1",
+          "text": "Co trzymało cię tam po dacie ważności?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_002_fu_2",
+          "text": "Czego nauczyło cię odejście — lub nieodejście?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_007",
+      "text": "Czego boisz się pragnąć, bo możesz tego nie dostać?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_007_fu_1",
+          "text": "Co kosztuje cię pragnąć tego w pełni?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_007_fu_2",
+          "text": "Co jest gorsze — nie dostać tego, czy nigdy nie spróbować?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_004",
+      "text": "Jak twoim zdaniem wyglądałoby twoje życie, gdybyś przestał grać dla innych?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_004_fu_1",
+          "text": "Kogo byś stracił?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_004_fu_2",
+          "text": "Kogo byś w końcu przyciągnął?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_past_003",
+      "text": "Jakie wspomnienie wciąż wywołuje w tobie wstyd, gdy wypłynie?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_003_fu_1",
+          "text": "Co dokładnie uruchamia ten wstyd?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_003_fu_2",
+          "text": "Czy byłeś w stanie o tym z kimś porozmawiać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_004",
+      "text": "Jaka jest najbardziej szczera rzecz, jaką możesz powiedzieć o tym, gdzie jesteś teraz w życiu?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_004_fu_1",
+          "text": "Jak czujesz się z tą szczerością?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_004_fu_2",
+          "text": "Co byś chciał zmienić jako pierwsze?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_008",
+      "text": "Czego potrzebujesz, a wmówiłeś sobie, że nie potrzebujesz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_008_fu_1",
+          "text": "Kiedy zacząłeś mówić sobie, że to niepotrzebne?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_008_fu_2",
+          "text": "Co by się zmieniło, gdybyś przyznał tę potrzebę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_009",
+      "text": "Co nie daje ci spać w nocy, a czego nikomu nie powiedziałeś?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_009_fu_1",
+          "text": "Co sprawia, że to czujesz się zbyt ciężkie, by się podzielić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_009_fu_2",
+          "text": "Czego byś potrzebował od drugiej osoby, żeby czuć się bezpiecznie to mówiąc?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_005",
+      "text": "Jaki wzorzec w twoich relacjach wciąż się powtarza, mimo że nie możesz go przerwać?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_005_fu_1",
+          "text": "Kiedy po raz pierwszy zauważyłeś, że się powtarza?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_005_fu_2",
+          "text": "Co twoim zdaniem próbuje rozwiązać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_005",
+      "text": "Czego w sobie boisz się najbardziej, że inni mogliby się dowiedzieć?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_005_fu_1",
+          "text": "Co czujesz się najbardziej zagrożone, gdyby inni wiedzieli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_005_fu_2",
+          "text": "Co twoim zdaniem by się naprawdę stało, gdyby to wyszło na jaw?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_010",
+      "text": "Na co się znieczuliłeś, a wiesz, że kiedyś będziesz musiał to w końcu stawić czoła?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_010_fu_1",
+          "text": "Jak to omijasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_010_fu_2",
+          "text": "Co twoim zdaniem by się stało, gdybyś to podjął?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_past_004",
+      "text": "Którą część swojej historii przepisałeś, żeby łatwiej było ją opowiadać?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_004_fu_1",
+          "text": "Co pominąłeś i dlaczego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_past_004_fu_2",
+          "text": "Co by ujawniła o tobie wersja bez edycji?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_006",
+      "text": "Co w sposobie, w jaki teraz żyjesz, wiesz, że już tak naprawdę nie działa?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_006_fu_1",
+          "text": "Dlaczego mimo to wciąż próbujesz to podtrzymać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_006_fu_2",
+          "text": "Z czym musiałbyś się zmierzyć, gdybyś to zmienił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_growth_007",
+      "text": "Co wciąż nazywasz bezinteresownością, a co może być tak naprawdę zacieraniem siebie?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_007_fu_1",
+          "text": "Czego nie musisz wprost prosić, gdy tak się zachowujesz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_growth_007_fu_2",
+          "text": "Ile kosztuje cię to ciągłe znikanie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_identity_006",
+      "text": "Czy lubisz siebie, czy lubisz siebie głównie przy określonych warunkach?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_006_fu_1",
+          "text": "Jakie to warunki?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_identity_006_fu_2",
+          "text": "Jak trwałe jest to uczucie naprawdę?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_emotions_011",
+      "text": "Czy masz w sobie ból, który nigdy do końca się nie goi?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_011_fu_1",
+          "text": "Czy to coś, o co możesz zadbać w pojedynkę, czy potrzebujesz kogoś innego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_emotions_011_fu_2",
+          "text": "Czego twoim zdaniem wymaga prawdziwe uzdrowienie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_dailyLife_001",
+      "text": "Do jakiego nawyku wracasz, wiedząc, że nie jest dla ciebie dobry?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_dailyLife_001_fu_1",
+          "text": "Co daje ci w tej chwili, czego trudno dostać gdzie indziej?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_dailyLife_001_fu_2",
+          "text": "Jak naprawdę wyglądałoby twoje życie, gdybyś w końcu przestał?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_warmUp_communication_001",
+      "text": "Co chcesz powiedzieć komuś od długiego czasu, ale prawdopodobnie nigdy tego nie zrobisz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "warmUp",
+      "topic": "communication",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_communication_001_fu_1",
+          "text": "Co by cię kosztowało powiedzenie tego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_warmUp_communication_001_fu_2",
+          "text": "A co kosztuje cię trzymanie tego w sobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_past_001",
+      "text": "Czego żałujesz, że kiedykolwiek musiałeś zobaczyć?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_past_001_fu_1",
+          "text": "Jak to zobaczenie cię zmieniło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_past_001_fu_2",
+          "text": "Czy udało ci się to przetworzyć?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_identity_001",
+      "text": "W którym obszarze swojego życia po cichu boisz się, że gdyby ktoś przyjrzał się bliżej, zobaczyłby mniej niż to, co prezentujesz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_identity_001_fu_1",
+          "text": "O co tak bardzo się starasz, żeby tego nie zobaczyli?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_identity_001_fu_2",
+          "text": "Ile z tego lęku wydaje ci się uzasadnione, a ile ma stare korzenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_identity_002",
+      "text": "Jak szczerze opisujesz swoją relację z własnym ciałem?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_identity_002_fu_1",
+          "text": "Kiedy ta relacja jest najtrudniejsza?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_identity_002_fu_2",
+          "text": "Jak wyglądałaby jej zdrowsza wersja?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_growth_001",
+      "text": "Jaką prawdę o sobie okrążasz, nie pozwalając jej w pełni wylądować?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_growth_001_fu_1",
+          "text": "Co musiałoby się zmienić, gdybyś pozwolił jej stać się w pełni realna?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_growth_001_fu_2",
+          "text": "Co sprawia, że wciąż krążysz wokół zamiast wejść w to?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_growth_002",
+      "text": "Co ostatnio udajesz, a już jesteś tym zmęczony?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_growth_002_fu_1",
+          "text": "Dla kogo grasz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_growth_002_fu_2",
+          "text": "Co by cię kosztowało zdjęcie tej maski?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_conflict_001",
+      "text": "Jakie kłamstwo kiedyś powiedziałeś, o którym wciąż myślisz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_conflict_001_fu_1",
+          "text": "Dlaczego wciąż ma nad tobą taką władzę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_conflict_001_fu_2",
+          "text": "Gdybyś chciał to naprawić teraz, jak by to mogło wyglądać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_emotions_001",
+      "text": "Kiedy po raz pierwszy naprawdę uświadomiłeś sobie, że kiedyś umrzesz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_emotions_001_fu_1",
+          "text": "Ile miałeś lat i co sprawiło, że to dotarło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_emotions_001_fu_2",
+          "text": "Czy ta świadomość zmienia to, jak myślisz teraz o swoim życiu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_realTalk_dailyLife_001",
+      "text": "Ile twojego codziennego życia jest zorganizowane wokół unikania tego, czego nie chcesz czuć?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "realTalk",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_dailyLife_001_fu_1",
+          "text": "Jakich uczuć jesteś mistrzem omijania?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_realTalk_dailyLife_001_fu_2",
+          "text": "Jak wyglądałby dzień bez tego unikania?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_identity_001",
+      "text": "Przed czym odkładasz szczerość wobec siebie?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "identity",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_identity_001_fu_1",
+          "text": "Jak brzmiałaby szczera wersja, gdybyś powiedział to na głos?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_identity_001_fu_2",
+          "text": "Co najprawdopodobniej się zmieni, kiedy to przyznasz?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_conflict_001",
+      "text": "Czy jest relacja w twoim życiu, która twoim zdaniem dobiegła już końca?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_conflict_001_fu_1",
+          "text": "Co powstrzymuje cię od odejścia?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_conflict_001_fu_2",
+          "text": "Czego byś żałował, gdybyś to puścił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_growth_001",
+      "text": "Która część ciebie wie, że potrzebujesz z niej wyrosnąć?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "growth",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_growth_001_fu_1",
+          "text": "Przed czym ta część cię chroniła?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_growth_001_fu_2",
+          "text": "Kim byś był bez niej?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_emotions_001",
+      "text": "Z czym wciąż chodzisz z poczuciem winy?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_001_fu_1",
+          "text": "Co by było potrzebne, żeby to w końcu odłożyć?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_001_fu_2",
+          "text": "Co sprawia, że tak trudno dać sobie jakiekolwiek przebaczenie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_values_001",
+      "text": "Jakie przekonanie żywisz głęboko, ale nigdy nie wypowiedziałeś na głos?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_001_fu_1",
+          "text": "Co sprawia, że czujesz, iż ryzyko podzielenia się nim jest zbyt duże?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_001_fu_2",
+          "text": "Co by to znaczyło otwarcie się do tego przyznać?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_emotions_002",
+      "text": "Co cię skrzywdziło, a co wciąż umniejszasz, opowiadając o tym?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_002_fu_1",
+          "text": "Co czujesz się bezpieczniejsze w tym, że to wydaje się mniejsze niż było?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_002_fu_2",
+          "text": "Co by ujawniła pełniejsza wersja o tym, co to z tobą naprawdę zrobiło?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_past_001",
+      "text": "Gdyby dało się całkowicie wymazać jedno wspomnienie, które byś wybrał?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_001_fu_1",
+          "text": "Jak czujesz się wyobrażając sobie życie bez niego?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_001_fu_2",
+          "text": "Czy jest coś, co to wspomnienie ci dało, co też byś stracił?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_conflict_002",
+      "text": "Co najgorszego zrobiłeś komuś, co wciąż w tobie ciąży?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "conflict",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_conflict_002_fu_1",
+          "text": "Czy próbowałeś to naprawić?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_conflict_002_fu_2",
+          "text": "Co byś teraz powiedział tej osobie?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_emotions_003",
+      "text": "Kiedy w życiu czułeś się najbardziej upokorzony?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_003_fu_1",
+          "text": "Jak to doświadczenie ukształtowało to, jak się chronisz?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_003_fu_2",
+          "text": "Czy doszedłeś do siebie po tym, czy wciąż boli?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_values_002",
+      "text": "Gdybyś mógł wybrać, jak kończy się historia twojego życia, jak by wyglądała?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_002_fu_1",
+          "text": "O czym byłby ostatni rozdział?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_002_fu_2",
+          "text": "Czy żyjesz w sposób, który zmierza ku temu zakończeniu?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_past_002",
+      "text": "Jak to, że ktoś źle cię traktował, ukształtowało sposób, w jaki siebie widzisz?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_002_fu_1",
+          "text": "Czy wciąż nosisz w sobie ich wersję ciebie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_002_fu_2",
+          "text": "Czego by wymagało zastąpienie jej swoją własną?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_past_003",
+      "text": "Co się wydarzyło, co trwale zmieniło to, kim jesteś?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "past",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_003_fu_1",
+          "text": "Czy ta zmiana to coś, co wybrałeś, czy coś, co ci się przydarzyło?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_past_003_fu_2",
+          "text": "Czy rozpoznajesz siebie po obu stronach tej granicy?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_emotions_004",
+      "text": "Kiedy doświadczyłeś odrzucenia, które naprawdę zabolało?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_004_fu_1",
+          "text": "W co to odrzucenie kazało ci uwierzyć o sobie?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_004_fu_2",
+          "text": "Czy udało ci się oddzielić to odrzucenie od swojej wartości?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_emotions_005",
+      "text": "Gdzie wciąż czekasz na rodzaj zamknięcia, które może nigdy nie nadejść?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "emotions",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_005_fu_1",
+          "text": "Co sprawia, że wciąż czekasz, zamiast to opłakać?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_emotions_005_fu_2",
+          "text": "Co by to znaczyło przestać uzależniać swój spokój od tego zakończenia?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_values_003",
+      "text": "Jakiej zasady nigdy byś nie zdradził, cokolwiek by się działo?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "values",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_003_fu_1",
+          "text": "Kiedy ta zasada była wystawiona na najtwardszą próbę?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_values_003_fu_2",
+          "text": "Co chroni w tobie tak, że nic innego nie jest w stanie tego zrobić?",
+          "style": "impact"
+        }
+      ]
+    },
+    {
+      "id": "p_soloReflection_unfiltered_deepDive_dailyLife_001",
+      "text": "Która część twojej codziennej rutyny jest tak naprawdę mechanizmem radzenia sobie, którego nigdy nie zbadałeś?",
+      "mode": "soloReflection",
+      "intensity": "unfiltered",
+      "depth": "deepDive",
+      "topic": "dailyLife",
+      "followUps": [
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_dailyLife_001_fu_1",
+          "text": "Kiedy się zaczęła i przez co wtedy przechodziłeś?",
+          "style": "origin"
+        },
+        {
+          "id": "p_soloReflection_unfiltered_deepDive_dailyLife_001_fu_2",
+          "text": "Z czym musiałbyś się zmierzyć, gdybyś ją usunął?",
+          "style": "impact"
+        }
+      ]
+    }
+  ]
+}

--- a/Connections/Data/share_experience_pl.json
+++ b/Connections/Data/share_experience_pl.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": 1,
+  "language": "pl",
+  "experiences": [
+    {
+      "id": "se1",
+      "fullText": "Opowiedz o doświadczeniu, które jest naprawdę niewiarygodne.",
+      "intensity": "light",
+      "topic": "dailyLife"
+    },
+    {
+      "id": "se2",
+      "fullText": "Podziel się czymś, co wymagało od ciebie odwagi.",
+      "intensity": "honest",
+      "topic": "growth"
+    },
+    {
+      "id": "se3",
+      "fullText": "Opowiedz o doświadczeniu pełnym ciepłej nostalgii.",
+      "intensity": "light",
+      "topic": "past"
+    },
+    {
+      "id": "se4",
+      "fullText": "Przypomnij sobie doświadczenie, które było prowokacyjne lub zmusiło cię do przemyśleń.",
+      "intensity": "unfiltered",
+      "topic": "values"
+    },
+    {
+      "id": "se5",
+      "fullText": "Opowiedz o doświadczeniu, które było smutne albo ciężkie do uniesienia.",
+      "intensity": "unfiltered",
+      "topic": "emotions"
+    },
+    {
+      "id": "se6",
+      "fullText": "Podziel się doświadczeniem, które zmieniło twoje życie.",
+      "intensity": "honest",
+      "topic": "growth"
+    },
+    {
+      "id": "se7",
+      "fullText": "Opowiedz o chwili, która była dla ciebie naprawdę radosna.",
+      "intensity": "light",
+      "topic": "appreciation"
+    },
+    {
+      "id": "se8",
+      "fullText": "Podziel się doświadczeniem, którego nie da się zapomnieć.",
+      "intensity": "honest",
+      "topic": "past"
+    },
+    {
+      "id": "se9",
+      "fullText": "Przypomnij sobie jakieś doświadczenie z czasów nastolatka.",
+      "intensity": "light",
+      "topic": "past"
+    },
+    {
+      "id": "se10",
+      "fullText": "Opowiedz o doświadczeniu, które jest ci szczególnie bliskie.",
+      "intensity": "honest",
+      "topic": "emotions"
+    },
+    {
+      "id": "se11",
+      "fullText": "Podziel się czymś, co do tej pory wyprowadza cię z równowagi.",
+      "intensity": "unfiltered",
+      "topic": "conflict"
+    },
+    {
+      "id": "se12",
+      "fullText": "Opowiedz o doświadczeniu, o którym mama nie wie.",
+      "intensity": "unfiltered",
+      "topic": "identity"
+    },
+    {
+      "id": "se13",
+      "fullText": "Podziel się czymś, o czym twoi współpracownicy nie mają pojęcia.",
+      "intensity": "honest",
+      "topic": "identity"
+    },
+    {
+      "id": "se14",
+      "fullText": "Opowiedz o doświadczeniu, o którym nikt jeszcze nie wie.",
+      "intensity": "unfiltered",
+      "topic": "identity"
+    },
+    {
+      "id": "se15",
+      "fullText": "Przypomnij sobie chwilę, kiedy dotarło do ciebie, że rodzice nie są doskonali.",
+      "intensity": "honest",
+      "topic": "growth"
+    },
+    {
+      "id": "se16",
+      "fullText": "Opowiedz o doświadczeniu, które do tej pory trzymasz w tajemnicy.",
+      "intensity": "unfiltered",
+      "topic": "identity"
+    },
+    {
+      "id": "se17",
+      "fullText": "Podziel się doświadczeniem, które napełniło cię wdzięcznością.",
+      "intensity": "light",
+      "topic": "dailyLife"
+    },
+    {
+      "id": "se18",
+      "fullText": "Opowiedz o chwili, która napełniła cię dumą z tego, kim jesteś.",
+      "intensity": "honest",
+      "topic": "identity"
+    },
+    {
+      "id": "se19",
+      "fullText": "Przypomnij sobie doświadczenie, które wydawało ci się naprawdę ryzykowne.",
+      "intensity": "unfiltered",
+      "topic": "growth"
+    },
+    {
+      "id": "se20",
+      "fullText": "Podziel się czymś, co złamało ci serce.",
+      "intensity": "unfiltered",
+      "topic": "emotions"
+    },
+    {
+      "id": "se21",
+      "fullText": "Opowiedz o doświadczeniu, które zmieniło kierunek twojego życia.",
+      "intensity": "light",
+      "topic": "dailyLife"
+    }
+  ]
+}

--- a/Connections/Localizable.xcstrings
+++ b/Connections/Localizable.xcstrings
@@ -29,6 +29,12 @@
             "state": "translated",
             "value": "Atrás"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wstecz"
+          }
         }
       }
     },
@@ -46,6 +52,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cancelar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuluj"
           }
         }
       }
@@ -65,6 +77,12 @@
             "state": "translated",
             "value": "Cerrar"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zamknij"
+          }
         }
       }
     },
@@ -82,6 +100,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Listo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gotowe"
           }
         }
       }
@@ -101,6 +125,12 @@
             "state": "translated",
             "value": "Ajustes"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustawienia"
+          }
         }
       }
     },
@@ -118,6 +148,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Esto se volvió más emotivo mientras seguiste adelante."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im dłużej trwała ta rozmowa, tym bardziej poruszała."
           }
         }
       }
@@ -137,6 +173,12 @@
             "state": "translated",
             "value": "Conectados"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Połączeni"
+          }
         }
       }
     },
@@ -154,6 +196,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Llegaron a un nivel más profundo esta noche."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dziś rozmowa sięgnęła głębszego poziomu."
           }
         }
       }
@@ -173,6 +221,12 @@
             "state": "translated",
             "value": "Profundamente Conectados"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głęboko Połączeni"
+          }
         }
       }
     },
@@ -190,6 +244,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Te fuiste abriendo más a medida que avanzabas."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Z każdą chwilą otwierało się coraz bardziej."
           }
         }
       }
@@ -209,6 +269,12 @@
             "state": "translated",
             "value": "Abriéndose"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwieranie się"
+          }
         }
       }
     },
@@ -226,6 +292,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Inmersión Profunda"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W głąb"
           }
         }
       }
@@ -245,6 +317,12 @@
             "state": "translated",
             "value": "Conversación Real"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szczera rozmowa"
+          }
         }
       }
     },
@@ -262,6 +340,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Calentamiento"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozgrzewka"
           }
         }
       }
@@ -281,6 +365,12 @@
             "state": "translated",
             "value": "No por casualidad — sino a través de la atención, la honestidad y los momentos compartidos.\n\nUna serie de preguntas cuidadosamente diseñadas puede profundizar la conexión, despertar la curiosidad y acercarlos — una conversación a la vez."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie przez przypadek — przez uwagę, szczerość i wspólne chwile.\n\nSeria starannie opracowanych pytań może pogłębić więź, rozbudzić ciekawość i zbliżyć do siebie — jedna rozmowa na raz."
+          }
         }
       }
     },
@@ -298,6 +388,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Algunas conversaciones crean claridad, confianza y conexión inesperada.\n\nEstas preguntas están diseñadas para ayudar a dos personas a ir más allá de la charla superficial y llegar a algo más honesto, abierto y real."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niektóre rozmowy budują jasność, zaufanie i niespodziewaną więź.\n\nTe pytania mają pomóc dwóm osobom wyjść poza powierzchowną rozmowę i wejść w coś bardziej szczerego, otwartego i prawdziwego."
           }
         }
       }
@@ -317,6 +413,12 @@
             "state": "translated",
             "value": "Comenzar sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij sesję"
+          }
         }
       }
     },
@@ -334,6 +436,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Por qué funciona"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego to działa"
           }
         }
       }
@@ -353,6 +461,12 @@
             "state": "translated",
             "value": "No mostrar esto de nuevo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie pokazuj ponownie"
+          }
         }
       }
     },
@@ -370,6 +484,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enamorarse de nuevo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zakochaj się na nowo"
           }
         }
       }
@@ -389,6 +509,12 @@
             "state": "translated",
             "value": "Acercarse más"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zbliżcie się"
+          }
         }
       }
     },
@@ -406,6 +532,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Entendido"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozumiem"
           }
         }
       }
@@ -425,6 +557,12 @@
             "state": "translated",
             "value": "Cuando dos personas se turnan para responder preguntas honestas, naturalmente igualan la apertura del otro"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiedy dwie osoby na zmianę odpowiadają na szczere pytania, naturalnie dopasowują poziom swojej otwartości"
+          }
         }
       }
     },
@@ -442,6 +580,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sentirse genuinamente escuchado — no solo oído — es uno de los factores más poderosos para generar cercanía"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poczucie, że ktoś naprawdę słucha — nie tylko słyszy — jest jednym z najsilniejszych czynników budujących bliskość"
           }
         }
       }
@@ -461,6 +605,12 @@
             "state": "translated",
             "value": "La vulnerabilidad no solo construye confianza. Señala que la confianza ya existe."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wrażliwość nie tylko buduje zaufanie. Sygnalizuje, że zaufanie już istnieje."
+          }
         }
       }
     },
@@ -478,6 +628,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las conversaciones que profundizan una relación rara vez son dramáticas. Son aquellas en las que alguien se siente visto."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowy, które pogłębiają związek, rzadko są dramatyczne. To te, w których ktoś poczuł się naprawdę zrozumiany."
           }
         }
       }
@@ -497,6 +653,12 @@
             "state": "translated",
             "value": "No te enamoras de golpe.\nLo construyes — un momento honesto a la vez."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie zakochujesz się raz na zawsze.\nBudujesz to — jedna szczera chwila na raz."
+          }
         }
       }
     },
@@ -514,6 +676,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cuando una persona comparte algo real, los demás tienden a igualar esa apertura — sin que se les pida"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kiedy jedna osoba dzieli się czymś prawdziwym, inne zazwyczaj dopasowują tę otwartość — bez pytania"
           }
         }
       }
@@ -533,6 +701,12 @@
             "state": "translated",
             "value": "Hacer una pregunta genuina y escuchar de verdad es una de las formas más simples de profundizar una amistad"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zadanie szczerego pytania i prawdziwe słuchanie to jeden z najprostszych sposobów na pogłębienie przyjaźni"
+          }
         }
       }
     },
@@ -550,6 +724,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La confianza crece en pequeños momentos — cuando alguien se siente escuchado, no solo hablado"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaufanie rośnie w małych chwilach — gdy ktoś czuje się wysłuchany, a nie tylko wysłuchiwany"
           }
         }
       }
@@ -569,6 +749,12 @@
             "state": "translated",
             "value": "La mayoría de las amistades se quedan en la superficie no porque no les importe, sino porque nadie da el primer paso"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Większość przyjaźni pozostaje na powierzchni nie dlatego, że ludziom nie zależy, ale dlatego, że nikt nie zaczyna pierwszy"
+          }
         }
       }
     },
@@ -586,6 +772,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las amistades más profundas no se encuentran.\nSe construyen — una conversación real a la vez."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Najgłębszych przyjaźni się nie znajduje.\nBuduje się je — jedna prawdziwa rozmowa na raz."
           }
         }
       }
@@ -605,6 +797,12 @@
             "state": "translated",
             "value": "Por qué funciona"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego to działa"
+          }
         }
       }
     },
@@ -622,6 +820,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reiniciar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
           }
         }
       }
@@ -641,6 +845,12 @@
             "state": "translated",
             "value": "Esto reiniciará tu progreso a la Pregunta 1. Es útil cuando comienzas con una nueva persona."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spowoduje to zresetowanie postępu do pytania 1. Przydatne przy rozmowie z nową osobą."
+          }
         }
       }
     },
@@ -658,6 +868,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "¿Empezar de nuevo?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zacząć od nowa?"
           }
         }
       }
@@ -677,6 +893,12 @@
             "state": "translated",
             "value": "Anterior"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poprzednie"
+          }
         }
       }
     },
@@ -694,6 +916,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Empezar de nuevo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zacznij od nowa"
           }
         }
       }
@@ -713,6 +941,12 @@
             "state": "translated",
             "value": "Toma un momento para apreciar la conexión que han construido."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Znajdź chwilę, by docenić więź, którą zbudowaliście."
+          }
         }
       }
     },
@@ -730,6 +964,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Hiciste espacio para un tipo más profundo de conversación."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zrobiło się miejsce na głębszą rozmowę."
           }
         }
       }
@@ -749,6 +989,12 @@
             "state": "translated",
             "value": "Te quedaste para las 36 preguntas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie 36 pytań — od początku do końca"
+          }
         }
       }
     },
@@ -766,6 +1012,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Algo fue construido aquí"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coś tu zostało zbudowane"
           }
         }
       }
@@ -785,6 +1037,12 @@
             "state": "translated",
             "value": "Algo cambió"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coś się zmieniło"
+          }
         }
       }
     },
@@ -802,6 +1060,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enamorarse"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fall in Love"
           }
         }
       }
@@ -821,6 +1085,12 @@
             "state": "translated",
             "value": "Acercarse"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zbliżcie się"
+          }
         }
       }
     },
@@ -838,6 +1108,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "36 Preguntas · %1$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "36 pytań · %1$@"
           }
         }
       }
@@ -857,6 +1133,12 @@
             "state": "translated",
             "value": "Compartir Experiencia · %1$@"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share Experience · %1$@"
+          }
         }
       }
     },
@@ -871,6 +1153,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · %2$@ · %3$@"
+          }
+        },
+        "pl": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ · %2$@ · %3$@"
@@ -893,6 +1181,12 @@
             "state": "translated",
             "value": "Toca el corazón en cualquier pregunta para guardarla aquí para después."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dotknij serduszka przy dowolnym pytaniu, żeby zapisać je tutaj na później."
+          }
         }
       }
     },
@@ -910,6 +1204,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Regresar al inicio"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wróć do ekranu głównego"
           }
         }
       }
@@ -929,6 +1229,12 @@
             "state": "translated",
             "value": "Aún no hay favoritos"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak ulubionych"
+          }
         }
       }
     },
@@ -946,6 +1252,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eliminar de favoritos"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń z ulubionych"
           }
         }
       }
@@ -965,6 +1277,12 @@
             "state": "translated",
             "value": "Favoritos"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ulubione"
+          }
         }
       }
     },
@@ -982,6 +1300,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Profundo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głęboko"
           }
         }
       }
@@ -1001,6 +1325,12 @@
             "state": "translated",
             "value": "Estás llegando a algo."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tu się coś otwiera."
+          }
         }
       }
     },
@@ -1018,6 +1348,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eso fue profundo."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To poszło głęboko."
           }
         }
       }
@@ -1037,6 +1373,12 @@
             "state": "translated",
             "value": "Te quedaste con ello."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To zostało z tobą."
+          }
         }
       }
     },
@@ -1054,6 +1396,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tierno"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czule"
           }
         }
       }
@@ -1073,6 +1421,12 @@
             "state": "translated",
             "value": "Eso se sintió tierno."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To było czułe."
+          }
         }
       }
     },
@@ -1090,6 +1444,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eso requirió honestidad."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To wymagało szczerości."
           }
         }
       }
@@ -1109,6 +1469,12 @@
             "state": "translated",
             "value": "Eso tocó algo."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To dotknęło czegoś."
+          }
         }
       }
     },
@@ -1126,6 +1492,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ligero"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lekko"
           }
         }
       }
@@ -1145,6 +1517,12 @@
             "state": "translated",
             "value": "Conmovido"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poruszająco"
+          }
         }
       }
     },
@@ -1162,6 +1540,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eso te conmovió."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To cię poruszyło."
           }
         }
       }
@@ -1181,6 +1565,12 @@
             "state": "translated",
             "value": "Algo aterrizó ahí."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coś tu trafiło."
+          }
         }
       }
     },
@@ -1198,6 +1588,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ese importó."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To miało znaczenie."
           }
         }
       }
@@ -1217,6 +1613,12 @@
             "state": "translated",
             "value": "¿Cómo se sintió eso?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak to odczuwasz?"
+          }
         }
       }
     },
@@ -1234,6 +1636,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Iniciar una sesión"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij sesję"
           }
         }
       }
@@ -1253,6 +1661,12 @@
             "state": "translated",
             "value": "Elige un tono. Sigue las preguntas.\nVe adónde te lleva."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz ton. Odpowiedz na pytania.\nZobacz, dokąd to prowadzi."
+          }
         }
       }
     },
@@ -1270,6 +1684,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preguntas que te acercan"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania, które zbliżają"
           }
         }
       }
@@ -1289,6 +1709,12 @@
             "state": "translated",
             "value": "Significativo y reflexivo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głęboka i refleksyjna"
+          }
         }
       }
     },
@@ -1306,6 +1732,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Honesto"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szczery"
           }
         }
       }
@@ -1325,6 +1757,12 @@
             "state": "translated",
             "value": "Fácil y sin presión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lekka i bez presji"
+          }
         }
       }
     },
@@ -1342,6 +1780,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ligero"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lekki"
           }
         }
       }
@@ -1361,6 +1805,12 @@
             "state": "translated",
             "value": "Una mezcla natural de tonos"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Naturalne połączenie tonów"
+          }
         }
       }
     },
@@ -1378,6 +1828,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mixto"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mieszany"
           }
         }
       }
@@ -1397,6 +1853,12 @@
             "state": "translated",
             "value": "Profundo y emocionalmente revelador"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głęboka i emocjonalnie odsłaniająca"
+          }
         }
       }
     },
@@ -1414,6 +1876,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sin Filtros"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bez filtrów"
           }
         }
       }
@@ -1433,6 +1901,12 @@
             "state": "translated",
             "value": "¿Qué tan profundo quieres ir?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak głęboko chcesz się zagłębić?"
+          }
         }
       }
     },
@@ -1450,6 +1924,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Establece el tono"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ustaw ton"
           }
         }
       }
@@ -1469,6 +1949,12 @@
             "state": "translated",
             "value": "Creencias y Valores"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przekonania i wartości"
+          }
         }
       }
     },
@@ -1486,6 +1972,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Infancia"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dzieciństwo"
           }
         }
       }
@@ -1505,6 +1997,12 @@
             "state": "translated",
             "value": "Dificultades y Resiliencia"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trudności i odporność"
+          }
         }
       }
     },
@@ -1522,6 +2020,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Legado"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dziedzictwo"
           }
         }
       }
@@ -1541,6 +2045,12 @@
             "state": "translated",
             "value": "Mirando Atrás"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spojrzenie wstecz"
+          }
         }
       }
     },
@@ -1558,6 +2068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Amor y Compañerismo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Miłość i partnerstwo"
           }
         }
       }
@@ -1577,6 +2093,12 @@
             "state": "translated",
             "value": "Crianza y Vida Familiar"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodzicielstwo i życie rodzinne"
+          }
         }
       }
     },
@@ -1594,6 +2116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Capítulo %1$lld de %2$lld · %3$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozdział %1$lld z %2$lld · %3$@"
           }
         }
       }
@@ -1613,6 +2141,12 @@
             "state": "translated",
             "value": "Escuela y Crecimiento"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Szkoła i dorastanie"
+          }
         }
       }
     },
@@ -1630,6 +2164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Trabajo y Primeros Años de Adultez"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Praca i wczesna dorosłość"
           }
         }
       }
@@ -1649,6 +2189,12 @@
             "state": "translated",
             "value": "Una conversación guiada para hacer a padres, abuelos o familiares mayores las preguntas que quizás desearías haber hecho antes."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowa przewodnia — pytania do rodziców, dziadków lub starszych bliskich, które możesz żałować, że nie padły wcześniej."
+          }
         }
       }
     },
@@ -1666,6 +2212,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cómo funciona"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak to działa"
           }
         }
       }
@@ -1685,6 +2237,12 @@
             "state": "translated",
             "value": "Comenzar sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij sesję"
+          }
         }
       }
     },
@@ -1702,6 +2260,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No mostrar esto de nuevo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie pokazuj ponownie"
           }
         }
       }
@@ -1721,6 +2285,12 @@
             "state": "translated",
             "value": "50 preguntas organizadas en 9 capítulos de vida — desde la infancia hasta el legado"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 pytań ułożonych w 9 rozdziałach życia — od dzieciństwa po dziedzictwo"
+          }
         }
       }
     },
@@ -1738,6 +2308,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cada pregunta incluye dos seguimientos para ayudar a que la conversación fluya más profundamente de manera natural"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Każde pytanie ma dwa pytania uzupełniające, które pomagają rozmowie pójść głębiej"
           }
         }
       }
@@ -1757,6 +2333,12 @@
             "state": "translated",
             "value": "Tu progreso se guarda, para que puedas pausar y regresar en múltiples sesiones"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postęp jest zapisywany, więc możesz zrobić przerwę i wrócić przy kolejnym spotkaniu"
+          }
         }
       }
     },
@@ -1774,6 +2356,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Diseñado para leerse en voz alta — una persona pregunta, la otra cuenta su historia"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeznaczone do czytania na głos — jedna osoba pyta, druga opowiada swoją historię"
           }
         }
       }
@@ -1793,6 +2381,12 @@
             "state": "translated",
             "value": "Entendido"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozumiem"
+          }
         }
       }
     },
@@ -1810,6 +2404,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Algunas conversaciones solo ocurren\ncuando alguien sabe preguntar."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niektóre rozmowy zdarzają się tylko wtedy,\ngdy ktoś wie, o co zapytać."
           }
         }
       }
@@ -1829,6 +2429,12 @@
             "state": "translated",
             "value": "Cómo funciona"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak to działa"
+          }
         }
       }
     },
@@ -1846,6 +2452,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Explora la infancia, el amor, el trabajo, las dificultades, la historia familiar y el legado."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odkryj dzieciństwo, miłość, pracę, trudności, historię rodziny i dziedzictwo."
           }
         }
       }
@@ -1865,6 +2477,12 @@
             "state": "translated",
             "value": "Historia de Vida"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Life Story"
+          }
         }
       }
     },
@@ -1882,6 +2500,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reiniciar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
           }
         }
       }
@@ -1901,6 +2525,12 @@
             "state": "translated",
             "value": "Esto reiniciará tu progreso a la Pregunta 1."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spowoduje to zresetowanie postępu do pytania 1."
+          }
         }
       }
     },
@@ -1918,6 +2548,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "¿Empezar de nuevo?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zacząć od nowa?"
           }
         }
       }
@@ -1937,6 +2573,12 @@
             "state": "translated",
             "value": "Empezar de nuevo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zacznij od nowa"
+          }
         }
       }
     },
@@ -1954,6 +2596,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las conversaciones que más importan son las que casi no tuvimos."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowy, które mają największe znaczenie, to te, których prawie nie było."
           }
         }
       }
@@ -1973,6 +2621,12 @@
             "state": "translated",
             "value": "Te quedaste para las 50 preguntas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie 50 pytań — od początku do końca"
+          }
         }
       }
     },
@@ -1990,6 +2644,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Una vida, escuchada"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Życie, które zostało wysłuchane"
           }
         }
       }
@@ -2009,6 +2669,12 @@
             "state": "translated",
             "value": "Historia de Vida"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Life Story"
+          }
         }
       }
     },
@@ -2026,6 +2692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Construye química, cercanía y comprensión"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buduj chemię, bliskość i wzajemne zrozumienie"
           }
         }
       }
@@ -2045,6 +2717,12 @@
             "state": "translated",
             "value": "Pareja"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Para"
+          }
         }
       }
     },
@@ -2062,6 +2740,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fortalece la conexión entre generaciones"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wzmacniaj więź między pokoleniami"
           }
         }
       }
@@ -2081,6 +2765,12 @@
             "state": "translated",
             "value": "Familia"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodzina"
+          }
         }
       }
     },
@@ -2098,6 +2788,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ve más allá de las charlas triviales"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyjdź poza small talk"
           }
         }
       }
@@ -2117,6 +2813,12 @@
             "state": "translated",
             "value": "Amigos"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Znajomi"
+          }
         }
       }
     },
@@ -2134,6 +2836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reflexiona con honestidad e intención"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reflektuj ze szczerością i intencją"
           }
         }
       }
@@ -2153,6 +2861,12 @@
             "state": "translated",
             "value": "Reflexión Personal"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refleksja solo"
+          }
         }
       }
     },
@@ -2170,6 +2884,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "¿Para quién es esta sesión?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dla kogo jest ta sesja?"
           }
         }
       }
@@ -2189,6 +2909,12 @@
             "state": "translated",
             "value": "Elige un modo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz tryb"
+          }
         }
       }
     },
@@ -2206,6 +2932,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Túrnate para compartir experiencias reales"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na zmianę dzielcie się prawdziwymi doświadczeniami"
           }
         }
       }
@@ -2225,6 +2957,12 @@
             "state": "translated",
             "value": "Compartir"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podziel się"
+          }
         }
       }
     },
@@ -2242,6 +2980,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Comenzar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaczynaj"
           }
         }
       }
@@ -2261,6 +3005,12 @@
             "state": "translated",
             "value": "Siguiente"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dalej"
+          }
         }
       }
     },
@@ -2278,6 +3028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Omitir"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomiń"
           }
         }
       }
@@ -2297,6 +3053,12 @@
             "state": "translated",
             "value": "Algunas conversaciones se quedan en la superficie.\nEsto te ayuda a llegar a algo más real."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niektóre rozmowy pozostają na powierzchni.\nTo pomaga dotrzeć do czegoś bardziej prawdziwego."
+          }
         }
       }
     },
@@ -2314,6 +3076,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Ve más allá de las charlas triviales"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wyjdź poza small talk"
           }
         }
       }
@@ -2333,6 +3101,12 @@
             "state": "translated",
             "value": "Las preguntas reflexivas ayudan a las personas a ir más despacio, abrirse y entenderse mutuamente con más honestidad."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przemyślane pytania pomagają ludziom zwolnić, otworzyć się i lepiej siebie nawzajem zrozumieć."
+          }
         }
       }
     },
@@ -2350,6 +3124,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Construido para la conexión"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stworzone dla więzi"
           }
         }
       }
@@ -2369,6 +3149,12 @@
             "state": "translated",
             "value": "Con una pareja, un amigo, tu familia, o contigo mismo.\nNo hay una forma perfecta de comenzar."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Z partnerem, przyjacielem, rodziną lub w pojedynkę.\nNie ma idealnego sposobu, żeby zacząć."
+          }
         }
       }
     },
@@ -2386,6 +3172,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Comienza donde estás"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zacznij tam, gdzie jesteś"
           }
         }
       }
@@ -2405,6 +3197,12 @@
             "state": "translated",
             "value": "Elige para quién es.\nEstablece el tono.\nEmpieza a hablar."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz, dla kogo.\nUstaw ton.\nZacznij rozmawiać."
+          }
         }
       }
     },
@@ -2422,6 +3220,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Simple por diseño"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proste z założenia"
           }
         }
       }
@@ -2441,6 +3245,12 @@
             "state": "translated",
             "value": "Entendido"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozumiem"
+          }
         }
       }
     },
@@ -2458,6 +3268,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "El acceso premium está incluido en esta versión de prueba. No se requiere compra."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dostęp premium jest w pełni zawarty w tej wersji testowej. Zakup nie jest potrzebny."
           }
         }
       }
@@ -2477,6 +3293,12 @@
             "state": "translated",
             "value": "Obtén preguntas más profundas, conversaciones más largas y experiencias guiadas diseñadas para los momentos que más importan."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Uzyskaj głębsze pytania, dłuższe rozmowy i prowadzone doświadczenia zaprojektowane na chwile, które mają największe znaczenie."
+          }
         }
       }
     },
@@ -2494,6 +3316,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "207 preguntas Sin Filtros en todos los modos"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "207 pytań Bez filtrów w każdym trybie"
           }
         }
       }
@@ -2513,6 +3341,12 @@
             "state": "translated",
             "value": "41 preguntas de intimidad exclusivas para parejas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "41 pytań intymności tylko dla par"
+          }
         }
       }
     },
@@ -2530,6 +3364,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sesiones largas de 20 preguntas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Długie sesje — 20 pytań"
           }
         }
       }
@@ -2549,6 +3389,12 @@
             "state": "translated",
             "value": "Viaje de Enamorarse de 36 preguntas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podróż Fall in Love z 36 pytaniami"
+          }
         }
       }
     },
@@ -2566,6 +3412,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Historia de Vida de 50 preguntas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Life Story z 50 pytaniami"
           }
         }
       }
@@ -2585,6 +3437,12 @@
             "state": "translated",
             "value": "Comparte tus historias en un modo de conversación diferente"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dziel się swoimi historiami w innym trybie rozmowy"
+          }
         }
       }
     },
@@ -2602,6 +3460,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un acceso para conversaciones más profundas, viajes guiados y las preguntas que la gente recuerda."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jedno odblokowanie — głębsze rozmowy, prowadzone podróże i pytania, które się pamięta."
           }
         }
       }
@@ -2621,6 +3485,12 @@
             "state": "translated",
             "value": "Desbloquea la app completa"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odblokuj pełną aplikację"
+          }
         }
       }
     },
@@ -2638,6 +3508,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Una experiencia guiada para hacer a padres, abuelos o familiares mayores preguntas significativas sobre sus historias, recuerdos y legado."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prowadzone doświadczenie — pytania do rodziców, dziadków lub starszych bliskich o ich historię, wspomnienia i dziedzictwo."
           }
         }
       }
@@ -2657,6 +3533,12 @@
             "state": "translated",
             "value": "50 preguntas en 9 capítulos de vida"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "50 pytań w 9 rozdziałach życia"
+          }
         }
       }
     },
@@ -2674,6 +3556,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "2 seguimientos para cada pregunta"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "2 pytania uzupełniające do każdego pytania"
           }
         }
       }
@@ -2693,6 +3581,12 @@
             "state": "translated",
             "value": "Progreso guardado entre sesiones"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Postęp zapisywany między sesjami"
+          }
         }
       }
     },
@@ -2710,6 +3604,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Incluido con el acceso completo a la app"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zawarte w pełnym odblokowaniu aplikacji"
           }
         }
       }
@@ -2729,6 +3629,12 @@
             "state": "translated",
             "value": "Desbloquear Historia de Vida"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odblokuj Life Story"
+          }
         }
       }
     },
@@ -2746,6 +3652,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Desbloquear Acceso Completo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odblokuj pełny dostęp"
           }
         }
       }
@@ -2765,6 +3677,12 @@
             "state": "translated",
             "value": "Ahora no"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie teraz"
+          }
         }
       }
     },
@@ -2782,6 +3700,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restaurar Compras"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przywróć zakupy"
           }
         }
       }
@@ -2801,6 +3725,12 @@
             "state": "translated",
             "value": "Paga una vez. Guárdalo para siempre."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Płacisz raz. Masz na zawsze."
+          }
         }
       }
     },
@@ -2818,6 +3748,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Te quedaste con preguntas sobre %1$@. Vale la pena explorar %2$@ a continuación."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania o %1$@ wciągnęły najbardziej. Warto zajrzeć w %2$@."
           }
         }
       }
@@ -2837,6 +3773,12 @@
             "state": "translated",
             "value": "Estuviste presente durante toda la sesión."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cała sesja miała twoją uwagę."
+          }
         }
       }
     },
@@ -2854,6 +3796,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un ritmo más ligero podría sentirse mejor la próxima vez."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następnym razem lżejsze tempo może lepiej pasować."
           }
         }
       }
@@ -2873,6 +3821,12 @@
             "state": "translated",
             "value": "%1$@ podría sentirse más natural."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ może pasować bardziej naturalnie."
+          }
         }
       }
     },
@@ -2890,6 +3844,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fuiste profundo — %1$@ tiene más que ofrecerte."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta sesja weszła głęboko — %1$@ ma jeszcze więcej do zaoferowania."
           }
         }
       }
@@ -2909,6 +3869,12 @@
             "state": "translated",
             "value": "Seguiste inclinándote — prueba %1$@."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zagłębianie przychodziło naturalnie — spróbuj %1$@."
+          }
         }
       }
     },
@@ -2926,6 +3892,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Seguiste profundizando en preguntas sobre %1$@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania o %1$@ prowadziły coraz głębiej."
           }
         }
       }
@@ -2945,6 +3917,12 @@
             "state": "translated",
             "value": "Parecías atraído por preguntas sobre %1$@."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania o %1$@ zdawały się przyciągać uwagę najbardziej."
+          }
         }
       }
     },
@@ -2962,6 +3940,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Guardaste varias preguntas sobre %1$@."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kilka pytań o %1$@ trafiło do ulubionych."
           }
         }
       }
@@ -2981,6 +3965,12 @@
             "state": "translated",
             "value": "Te detuviste en preguntas sobre %1$@."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania o %1$@ przyciągały uwagę na dłużej."
+          }
         }
       }
     },
@@ -2998,6 +3988,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Siguiente paso sólido"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mocny następny krok"
           }
         }
       }
@@ -3017,6 +4013,12 @@
             "state": "translated",
             "value": "Posible siguiente paso"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Możliwy następny krok"
+          }
         }
       }
     },
@@ -3034,6 +4036,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Todos los temas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie tematy"
           }
         }
       }
@@ -3053,6 +4061,12 @@
             "state": "translated",
             "value": "36 preguntas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "36 pytań"
+          }
         }
       }
     },
@@ -3070,6 +4084,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tu progreso se guarda entre sesiones"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twój postęp jest zapisywany między sesjami"
           }
         }
       }
@@ -3089,6 +4109,12 @@
             "state": "translated",
             "value": "diseñado para construir cercanía"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "zaprojektowane do budowania bliskości"
+          }
         }
       }
     },
@@ -3106,6 +4132,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "seguimientos incluidos"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pytania uzupełniające"
           }
         }
       }
@@ -3125,6 +4157,12 @@
             "state": "translated",
             "value": "Sesión guiada"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesja prowadzona"
+          }
         }
       }
     },
@@ -3142,6 +4180,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 pregunta guardada de sesiones anteriores"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 zapisane pytanie z poprzednich sesji"
           }
         }
       }
@@ -3161,6 +4205,12 @@
             "state": "translated",
             "value": "%1$lld preguntas guardadas de sesiones anteriores"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld zapisanych pytań z poprzednich sesji"
+          }
         }
       }
     },
@@ -3178,6 +4228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Reproducir Favoritos"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odtwarzaj ulubione"
           }
         }
       }
@@ -3197,6 +4253,12 @@
             "state": "translated",
             "value": "Agrega preguntas suaves para ayudarte a profundizar."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaje delikatne pytania, które pomagają zagłębić się głębiej."
+          }
         }
       }
     },
@@ -3214,6 +4276,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Preguntas de seguimiento"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania uzupełniające"
           }
         }
       }
@@ -3233,6 +4301,12 @@
             "state": "translated",
             "value": "Tu sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Twoja sesja"
+          }
         }
       }
     },
@@ -3250,6 +4324,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Una conversación guiada a través de toda una vida"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prowadzona rozmowa przez całe życie"
           }
         }
       }
@@ -3269,6 +4349,12 @@
             "state": "translated",
             "value": "Historia de Vida"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Life Story"
+          }
         }
       }
     },
@@ -3286,6 +4372,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "5 preguntas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 pytań"
           }
         }
       }
@@ -3305,6 +4397,12 @@
             "state": "translated",
             "value": "10 preguntas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "10 pytań"
+          }
         }
       }
     },
@@ -3322,6 +4420,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "20 preguntas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "20 pytań"
           }
         }
       }
@@ -3341,6 +4445,12 @@
             "state": "translated",
             "value": "Elegir yo mismo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybieram siebie"
+          }
         }
       }
     },
@@ -3358,6 +4468,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Profundizar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zagłęb się"
           }
         }
       }
@@ -3377,6 +4493,12 @@
             "state": "translated",
             "value": "Siguiente"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dalej"
+          }
         }
       }
     },
@@ -3394,6 +4516,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Iniciar siguiente sesión"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij następną sesję"
           }
         }
       }
@@ -3413,6 +4541,12 @@
             "state": "translated",
             "value": "Momentos que se quedaron contigo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chwile, które zostały z tobą"
+          }
         }
       }
     },
@@ -3430,6 +4564,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "%1$lld de %2$lld"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld z %2$lld"
           }
         }
       }
@@ -3449,6 +4589,12 @@
             "state": "translated",
             "value": "Basándonos en cómo se desarrolló esta sesión, creemos que una sesión %1$@ podría ser un buen siguiente paso. ¿La iniciamos?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na podstawie przebiegu tej sesji myślimy, że sesja w trybie %1$@ mogłaby być dobrym kolejnym krokiem. Mamy ją dla ciebie uruchomić?"
+          }
         }
       }
     },
@@ -3466,6 +4612,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Basándonos en cómo se desarrolló esta sesión, creemos que una sesión sobre %1$@ a nivel %2$@ podría ser un buen siguiente paso. ¿La iniciamos?"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Na podstawie przebiegu tej sesji myślimy, że sesja o %1$@ na poziomie %2$@ mogłaby być dobrym kolejnym krokiem. Mamy ją dla ciebie uruchomić?"
           }
         }
       }
@@ -3485,6 +4637,12 @@
             "state": "translated",
             "value": "Compartir esta pregunta"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Udostępnij to pytanie"
+          }
         }
       }
     },
@@ -3502,6 +4660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "1 más profundo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "1 głębiej"
           }
         }
       }
@@ -3521,6 +4685,12 @@
             "state": "translated",
             "value": "%1$lld más profundo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$lld głębiej"
+          }
         }
       }
     },
@@ -3538,6 +4708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Más profundo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Najgłębiej"
           }
         }
       }
@@ -3557,6 +4733,12 @@
             "state": "translated",
             "value": "Tiempo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czas"
+          }
         }
       }
     },
@@ -3574,6 +4756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tengo 18 años o más"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mam 18 lat lub więcej"
           }
         }
       }
@@ -3593,6 +4781,12 @@
             "state": "translated",
             "value": "Las preguntas sobre sexo contienen contenido para adultos. Confirma que tienes 18 años o más para continuar."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania o seks zawierają treści dla dorosłych. Potwierdź, że masz 18 lat lub więcej, żeby kontynuować."
+          }
         }
       }
     },
@@ -3610,6 +4804,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Confirmación de Edad"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Potwierdzenie wieku"
           }
         }
       }
@@ -3629,6 +4829,12 @@
             "state": "translated",
             "value": "Comenzar"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zaczynaj"
+          }
         }
       }
     },
@@ -3646,6 +4852,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Iniciar Sesión"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozpocznij sesję"
           }
         }
       }
@@ -3665,6 +4877,12 @@
             "state": "translated",
             "value": "Las preguntas van de casuales a profundamente personales. Tu progreso se guarda para que puedas pausar y continuar cuando quieras."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania przechodzą od swobodnych do głęboko osobistych. Twój postęp jest zapisywany, więc możesz zrobić przerwę i wrócić w dowolnym momencie."
+          }
         }
       }
     },
@@ -3682,6 +4900,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "36 preguntas diseñadas para construir cercanía"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "36 pytań zaprojektowanych do budowania bliskości"
           }
         }
       }
@@ -3701,6 +4925,12 @@
             "state": "translated",
             "value": "Agrega preguntas opcionales para profundizar durante la sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaje opcjonalne pytania, żeby pogłębić sesję"
+          }
         }
       }
     },
@@ -3719,6 +4949,12 @@
             "state": "translated",
             "value": "Preguntas de seguimiento"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania uzupełniające"
+          }
         }
       }
     },
@@ -3733,6 +4969,12 @@
           }
         },
         "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@ · %2$@"
+          }
+        },
+        "pl": {
           "stringUnit": {
             "state": "translated",
             "value": "%1$@ · %2$@"
@@ -3755,6 +4997,12 @@
             "state": "translated",
             "value": "Configura tu sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skonfiguruj sesję"
+          }
         }
       }
     },
@@ -3772,6 +5020,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Número de preguntas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liczba pytań"
           }
         }
       }
@@ -3791,6 +5045,12 @@
             "state": "translated",
             "value": "Todos los Temas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie tematy"
+          }
         }
       }
     },
@@ -3808,6 +5068,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Tema"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temat"
           }
         }
       }
@@ -3827,6 +5093,12 @@
             "state": "translated",
             "value": "Instrucciones"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instrukcje"
+          }
         }
       }
     },
@@ -3844,6 +5116,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Política de Privacidad"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Polityka prywatności"
           }
         }
       }
@@ -3863,6 +5141,12 @@
             "state": "translated",
             "value": "Propósito"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cel"
+          }
         }
       }
     },
@@ -3880,6 +5164,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Por qué importa esto"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego to ważne"
           }
         }
       }
@@ -3899,6 +5189,12 @@
             "state": "translated",
             "value": "Sobrescribir Premium"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nadpisanie premium"
+          }
         }
       }
     },
@@ -3916,6 +5212,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Estado: Gratis"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status: Bezpłatny"
           }
         }
       }
@@ -3935,6 +5237,12 @@
             "state": "translated",
             "value": "Estado: Premium"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Status: Premium"
+          }
         }
       }
     },
@@ -3952,6 +5260,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Retroalimentación por vibración en las interacciones"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wibracje przy interakcjach"
           }
         }
       }
@@ -3971,6 +5285,12 @@
             "state": "translated",
             "value": "Háptica"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Haptyka"
+          }
         }
       }
     },
@@ -3988,6 +5308,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mejor experiencia"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Najlepsze doświadczenie"
           }
         }
       }
@@ -4007,6 +5333,12 @@
             "state": "translated",
             "value": "Elige un modo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz tryb"
+          }
         }
       }
     },
@@ -4024,6 +5356,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Elige el tono que quieres para la conversación"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz ton, jaki chcesz nadać rozmowie"
           }
         }
       }
@@ -4043,6 +5381,12 @@
             "state": "translated",
             "value": "Elige una duración de sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wybierz długość sesji"
+          }
         }
       }
     },
@@ -4060,6 +5404,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Lee la pregunta en voz alta o reflexiona sobre ella en silencio"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeczytaj pytanie na głos lub zastanów się nad nim w ciszy"
           }
         }
       }
@@ -4079,6 +5429,12 @@
             "state": "translated",
             "value": "Usa Profundizar si quieres un seguimiento más específico"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Użyj opcji Zagłęb się, jeśli chcesz bardziej szczegółowego pytania uzupełniającego"
+          }
         }
       }
     },
@@ -4096,6 +5452,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Toca el corazón para guardar tus preguntas favoritas para después"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dotknij serduszka, żeby zapisać ulubione pytania na później"
           }
         }
       }
@@ -4115,6 +5477,12 @@
             "state": "translated",
             "value": "No te apresures"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie spiesz się"
+          }
         }
       }
     },
@@ -4132,6 +5500,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Responde con honestidad"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odpowiadaj szczerze"
           }
         }
       }
@@ -4151,6 +5525,12 @@
             "state": "translated",
             "value": "Revisa los favoritos cuando quieras un tipo diferente de sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wracaj do ulubionych, gdy chcesz innego rodzaju sesji"
+          }
         }
       }
     },
@@ -4168,6 +5548,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Deja que ocurra el silencio"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pozwól na ciszę"
           }
         }
       }
@@ -4187,6 +5573,12 @@
             "state": "translated",
             "value": "Omite lo que no encaje"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pomiń to, co nie pasuje"
+          }
         }
       }
     },
@@ -4204,6 +5596,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cómo usar la app"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jak korzystać z aplikacji"
           }
         }
       }
@@ -4223,6 +5621,12 @@
             "state": "translated",
             "value": "Abre la configuración de esta app en Configuración de iOS."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwiera ustawienia tej aplikacji w Ustawieniach iOS."
+          }
         }
       }
     },
@@ -4240,6 +5644,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cámbialo en Configuración de iOS. Si la opción de idioma no aparece, primero agrega otro idioma en Configuración › General › Idioma y región."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zmień to w Ustawieniach iOS. Jeśli opcja języka nie pojawi się, najpierw dodaj inny język w Ustawienia › Ogólne › Język i region."
           }
         }
       }
@@ -4259,6 +5669,12 @@
             "state": "translated",
             "value": "Idioma de la app"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Język aplikacji"
+          }
         }
       }
     },
@@ -4276,6 +5692,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Idioma"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Język"
           }
         }
       }
@@ -4295,6 +5717,12 @@
             "state": "translated",
             "value": "Esta app está diseñada para ayudar a las personas a ir más allá de las conversaciones superficiales y hacia una conexión más significativa. Ya sea que la uses con una pareja, amigo, familiar, o para la reflexión personal, las preguntas están pensadas para crear honestidad, curiosidad y presencia emocional."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ta aplikacja jest zaprojektowana, by pomagać ludziom wychodzić poza powierzchowną rozmowę i budować głębszą więź. Niezależnie od tego, czy korzystasz z niej z partnerem, przyjacielem, członkiem rodziny, czy do refleksji solo, pytania mają tworzyć szczerość, ciekawość i emocjonalną obecność."
+          }
         }
       }
     },
@@ -4312,6 +5740,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Conexión a través de la conversación guiada"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Więź przez prowadzone rozmowy"
           }
         }
       }
@@ -4331,6 +5765,12 @@
             "state": "translated",
             "value": "Reiniciar"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
+          }
         }
       }
     },
@@ -4348,6 +5788,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Esto restaurará tus preferencias a sus valores predeterminados."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przywróci to domyślne wartości preferencji."
           }
         }
       }
@@ -4367,6 +5813,12 @@
             "state": "translated",
             "value": "¿Reiniciar ajustes?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zresetować ustawienia?"
+          }
         }
       }
     },
@@ -4384,6 +5836,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restablecer Valores Predeterminados"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przywróć ustawienia domyślne"
           }
         }
       }
@@ -4403,6 +5861,12 @@
             "state": "translated",
             "value": "Acerca de"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O aplikacji"
+          }
         }
       }
     },
@@ -4420,6 +5884,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Depuración"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug"
           }
         }
       }
@@ -4439,6 +5909,12 @@
             "state": "translated",
             "value": "Experiencia"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Doświadczenie"
+          }
         }
       }
     },
@@ -4456,6 +5932,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Restablecer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resetuj"
           }
         }
       }
@@ -4475,6 +5957,12 @@
             "state": "translated",
             "value": "Sesión"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesja"
+          }
         }
       }
     },
@@ -4492,6 +5980,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Mostrar preguntas \"Profundizar\" durante las sesiones"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż pytania „Zagłęb się“ podczas sesji"
           }
         }
       }
@@ -4511,6 +6005,12 @@
             "state": "translated",
             "value": "Preguntas de seguimiento"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pytania uzupełniające"
+          }
         }
       }
     },
@@ -4528,6 +6028,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Número de preguntas predeterminado"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Domyślna liczba pytań"
           }
         }
       }
@@ -4547,6 +6053,12 @@
             "state": "translated",
             "value": "Las buenas relaciones moldean cómo nos sentimos, cómo manejamos el estrés y cuán apoyados nos sentimos en la vida diaria. Esta app está construida alrededor de la idea de que las conversaciones reflexivas pueden ayudar a las personas a conocerse mejor, responder con más honestidad y acercarse con el tiempo."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dobre relacje kształtują to, jak się czujemy, jak radzimy sobie ze stresem i jak wspierani czujemy się na co dzień. Ta aplikacja opiera się na przekonaniu, że przemyślana rozmowa może pomóc ludziom lepiej się nawzajem poznać, bardziej szczerze reagować i zbliżać się do siebie z biegiem czasu."
+          }
         }
       }
     },
@@ -4564,6 +6076,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Porque la cercanía generalmente crece a través de la atención, la honestidad y la capacidad de respuesta. Las preguntas pueden ayudar a las personas a ir más despacio, expresarse con mayor claridad y notar lo que realmente importa."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ponieważ bliskość zazwyczaj rośnie przez uwagę, szczerość i responsywność. Pytania mogą pomóc ludziom zwolnić, jaśniej powiedzieć, co mają na myśli, i zauważyć to, co ważne."
           }
         }
       }
@@ -4583,6 +6101,12 @@
             "state": "translated",
             "value": "¿Por qué la app se enfoca en la conversación significativa?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego aplikacja skupia się na znaczącej rozmowie?"
+          }
         }
       }
     },
@@ -4600,6 +6124,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "La conversación superficial tiene su lugar, pero la profundidad suele venir de quedarse un poco más con algo. Las preguntas de seguimiento pueden ayudar a las personas a ir más allá de la primera respuesta fácil y llegar a lo que es más verdadero, más específico o más importante."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowy powierzchowne mają swoje miejsce, ale głębia często pojawia się przez zatrzymanie się przy czymś nieco dłużej. Pytania uzupełniające mogą pomóc ludziom wyjść poza pierwszą łatwą odpowiedź i dotrzeć do tego, co jest bardziej prawdziwe, bardziej konkretne lub ważniejsze."
           }
         }
       }
@@ -4619,6 +6149,12 @@
             "state": "translated",
             "value": "¿Por qué importan la profundidad y el seguimiento?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego głębia i pytania uzupełniające mają znaczenie?"
+          }
         }
       }
     },
@@ -4636,6 +6172,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Frecuentemente, sí. Sentirse escuchado, comprendido y atendido puede fortalecer la confianza y la seguridad emocional. Una buena conversación no lo resuelve todo, pero puede hacer que las personas se sientan más conocidas entre sí."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Często tak. Poczucie, że ktoś słyszy, rozumie i odpowiada, może wzmocnić zaufanie i poczucie bezpieczeństwa emocjonalnego. Dobra rozmowa nie rozwiązuje wszystkiego, ale może sprawić, że ludzie poczują się lepiej nawzajem poznani."
           }
         }
       }
@@ -4655,6 +6197,12 @@
             "state": "translated",
             "value": "¿Las conversaciones realmente pueden fortalecer las relaciones?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy rozmowy mogą naprawdę wzmocnić relacje?"
+          }
         }
       }
     },
@@ -4672,6 +6220,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Las relaciones sólidas están estrechamente ligadas al bienestar. Pueden ayudar a las personas a sentirse menos solas, más apoyadas y más capaces de manejar el estrés. Con el tiempo, la conexión social también se asocia con mejor salud y mayor longevidad."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Silne relacje są ściśle powiązane z dobrostanem. Mogą pomóc ludziom czuć się mniej samotnie, bardziej wspieranymi i lepiej radzić sobie ze stresem. Z biegiem czasu więzi społeczne wiążą się też z lepszym zdrowiem i dłuższym życiem."
           }
         }
       }
@@ -4691,6 +6245,12 @@
             "state": "translated",
             "value": "¿Por qué importa tanto la calidad de las relaciones?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego jakość relacji ma tak duże znaczenie?"
+          }
         }
       }
     },
@@ -4708,6 +6268,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Patrones como detenerse, guardar favoritos o profundizar pueden indicar que algo significativo estaba abriéndose. Cuando eso sucede, puede valer la pena continuar con otra sesión mientras el hilo sigue vivo."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wzorce takie jak zatrzymywanie się, zapisywanie do ulubionych lub zagłębianie się mogą sugerować, że coś ważnego się otwierało. Gdy tak się dzieje, kolejna sesja może być warta podjęcia, dopóki wątek jest jeszcze żywy."
           }
         }
       }
@@ -4727,6 +6293,12 @@
             "state": "translated",
             "value": "¿Por qué la app a veces sugiere otra sesión?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego aplikacja czasami sugeruje kolejną sesję?"
+          }
         }
       }
     },
@@ -4744,6 +6316,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "No. Esta app es para la conversación y la reflexión. Puede apoyar la conexión, pero no es un sustituto de la terapia, la atención médica o el apoyo en crisis."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie. Ta aplikacja służy do rozmowy i refleksji. Może wspierać więź, ale nie zastępuje terapii, opieki medycznej ani wsparcia kryzysowego."
           }
         }
       }
@@ -4763,6 +6341,12 @@
             "state": "translated",
             "value": "¿Esto reemplaza la terapia o la atención médica?"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czy to zastępstwo terapii lub opieki medycznej?"
+          }
         }
       }
     },
@@ -4780,6 +6364,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Por qué esto importa"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dlaczego to ważne"
           }
         }
       }
@@ -4799,6 +6389,12 @@
             "state": "translated",
             "value": "Sobre este modo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacje o tym trybie"
+          }
         }
       }
     },
@@ -4816,6 +6412,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Estas preguntas siguen una progresión estructurada — comenzando con compartir algo más ligero y avanzando gradualmente hacia una mayor vulnerabilidad — diseñada para construir cercanía naturalmente entre dos personas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Te pytania postępują według ustrukturyzowanej progresji — zaczynając od lżejszego dzielenia się i stopniowo przechodząc do głębszej wrażliwości — zaprojektowanej do naturalnego budowania bliskości między dwiema osobami"
           }
         }
       }
@@ -4835,6 +6437,12 @@
             "state": "translated",
             "value": "Este formato se basa en un modelo de cercanía interpersonal ampliamente estudiado que ha mostrado resultados consistentes en aumentar la conexión, incluso entre personas que acaban de conocerse"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ten format opiera się na dobrze zbadanym modelu interpersonalnej bliskości, który wykazał stałe wyniki w zwiększaniu więzi, nawet między osobami, które dopiero co się poznały"
+          }
         }
       }
     },
@@ -4852,6 +6460,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Funciona porque la cercanía no es aleatoria — surge de la honestidad mutua, la atención genuina y la disposición de estar presentes el uno con el otro"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Działa, bo bliskość nie jest przypadkowa — wynika z wzajemnej szczerości, prawdziwej uwagi i gotowości do bycia obecnym przy sobie nawzajem"
           }
         }
       }
@@ -4871,6 +6485,12 @@
             "state": "translated",
             "value": "Las preguntas más profundas pueden ser sorprendentemente poderosas. Abórdalas con cuidado e intención — funciona mejor cuando ambas personas se sienten lo suficientemente seguras para ser honestas"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Głębsze pytania mogą być nieoczekiwanie silne. Podchodź do nich z troską i intencją — to działa najlepiej, gdy obie osoby czują się bezpiecznie wystarczająco, by być szczerymi"
+          }
         }
       }
     },
@@ -4888,6 +6508,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Entendido"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozumiem"
           }
         }
       }
@@ -4907,6 +6533,12 @@
             "state": "translated",
             "value": "Esto no es charla superficial.\nTrátalo como si importara, y lo hará."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To nie jest small talk.\nTraktuj to poważnie, a ma znaczenie."
+          }
         }
       }
     },
@@ -4924,6 +6556,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Sobre este modo"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Informacje o tym trybie"
           }
         }
       }
@@ -4943,6 +6581,12 @@
             "state": "translated",
             "value": "Ninguna experiencia coincide con este filtro"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Żadne doświadczenia nie pasują do tego filtra"
+          }
         }
       }
     },
@@ -4960,6 +6604,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Todas"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wszystkie"
           }
         }
       }
@@ -4979,6 +6629,12 @@
             "state": "translated",
             "value": "Filtro de todas las intensidades"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtr wszystkich intensywności"
+          }
         }
       }
     },
@@ -4996,6 +6652,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Filtro de intensidad %1$@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtr intensywności %1$@"
           }
         }
       }
@@ -5015,6 +6677,12 @@
             "state": "translated",
             "value": "Agregar a favoritos"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dodaj do ulubionych"
+          }
         }
       }
     },
@@ -5032,6 +6700,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Eliminar de favoritos"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Usuń z ulubionych"
           }
         }
       }
@@ -5051,6 +6725,12 @@
             "state": "translated",
             "value": "Comparte una experiencia"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Share an Experience"
+          }
         }
       }
     },
@@ -5068,6 +6748,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Llegaste hasta el fondo. Date crédito por eso."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dotarłeś do głębiny. Daj sobie za to uznanie."
           }
         }
       }
@@ -5087,6 +6773,12 @@
             "state": "translated",
             "value": "Te gusta ir profundo. El modo %1$@ puede ser tu velocidad."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lubisz sięgać głęboko. Tryb %1$@ może być dla ciebie."
+          }
         }
       }
     },
@@ -5104,6 +6796,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Cuando estés listo, el modo %1$@ tiene más por ofrecer."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W swoim czasie tryb %1$@ ma więcej do zaoferowania."
           }
         }
       }
@@ -5123,6 +6821,12 @@
             "state": "translated",
             "value": "La próxima vez, intenta quedarte con una pregunta que te haga pausar."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Następnym razem spróbuj zostać przy pytaniu, które powoduje pauzę."
+          }
         }
       }
     },
@@ -5140,6 +6844,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Te mantuviste curioso y seguiste adentrándote."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciekawość prowadziła coraz dalej."
           }
         }
       }
@@ -5159,6 +6869,12 @@
             "state": "translated",
             "value": "Hubo honestidad real en esta sesión."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W tej sesji była prawdziwa szczerość."
+          }
         }
       }
     },
@@ -5176,6 +6892,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Confiaste en tu instinto sobre qué quedarte."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instynkt wiedział, przy czym zostać."
           }
         }
       }
@@ -5195,6 +6917,12 @@
             "state": "translated",
             "value": "La conversación se fue abriendo a medida que avanzaban."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowa otwierała się w miarę, jak szło."
+          }
         }
       }
     },
@@ -5212,6 +6940,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Te mantuviste presente con cada pregunta."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przy każdym pytaniu — pełna obecność."
           }
         }
       }
@@ -5231,6 +6965,12 @@
             "state": "translated",
             "value": "Le dedicaste tiempo a esto. Eso importa."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tej sesji dano czas. To ma znaczenie."
+          }
         }
       }
     },
@@ -5248,6 +6988,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Dejaste que la conversación tomara el camino."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowa prowadziła sama."
           }
         }
       }
@@ -5267,6 +7013,12 @@
             "state": "translated",
             "value": "Se quedaron con lo que se abrió entre ustedes."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zostaliście z tym, co otworzyło się między wami."
+          }
         }
       }
     },
@@ -5284,6 +7036,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Algo cambió en cómo se ven el uno al otro."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Coś zmieniło się w tym, jak się widzicie."
           }
         }
       }
@@ -5303,6 +7061,12 @@
             "state": "translated",
             "value": "Ese es el tipo de conversación que cambia las cosas."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Taka rozmowa zmienia rzeczy."
+          }
         }
       }
     },
@@ -5320,6 +7084,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fuiste honesto contigo mismo."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wobec siebie — szczerość."
           }
         }
       }
@@ -5339,6 +7109,12 @@
             "state": "translated",
             "value": "La conversación encontró su propio ritmo."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozmowa znalazła swój własny rytm."
+          }
         }
       }
     },
@@ -5356,6 +7132,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Creaste espacio para algo real."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zrobiło się miejsce na coś prawdziwego."
           }
         }
       }
@@ -5375,6 +7157,12 @@
             "state": "translated",
             "value": "Fueron más lejos de lo que va la mayoría."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Poszliście dalej niż robi to większość."
+          }
         }
       }
     },
@@ -5392,6 +7180,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Estuviste presente para ti mismo."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stanąłeś po swojej stronie."
           }
         }
       }
@@ -5411,6 +7205,12 @@
             "state": "translated",
             "value": "Eso es más lejos de lo que llegan la mayoría de las conversaciones."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To dalej, niż sięga większość rozmów."
+          }
         }
       }
     },
@@ -5428,6 +7228,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Confiaste en tu instinto sobre qué quedarte."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Instynkt prowadził."
           }
         }
       }
@@ -5447,6 +7253,12 @@
             "state": "translated",
             "value": "Querías más de cada momento."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Z każdej chwili chciało się więcej."
+          }
         }
       }
     },
@@ -5464,6 +7276,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Llegaste hasta lo profundo."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dotarło do głębiny."
           }
         }
       }
@@ -5483,6 +7301,12 @@
             "state": "translated",
             "value": "Fuiste ahí."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dotarło tam."
+          }
         }
       }
     },
@@ -5500,6 +7324,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Un momento entre ustedes."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chwila między wami."
           }
         }
       }
@@ -5519,6 +7349,12 @@
             "state": "translated",
             "value": "Se construyó un puente."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zbudował się most."
+          }
         }
       }
     },
@@ -5536,6 +7372,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Más que charla superficial."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Więcej niż small talk."
           }
         }
       }
@@ -5555,6 +7397,12 @@
             "state": "translated",
             "value": "Tiempo bien invertido contigo mismo."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Czas dobrze spędzony ze sobą."
+          }
         }
       }
     },
@@ -5572,6 +7420,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Seguiste adentrándote."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ciągle głębiej."
           }
         }
       }
@@ -5591,6 +7445,12 @@
             "state": "translated",
             "value": "Algo real ocurrió."
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wydarzyło się coś prawdziwego."
+          }
         }
       }
     },
@@ -5608,6 +7468,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Fuiste selectivo esta noche."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tej nocy — selektywnie."
           }
         }
       }
@@ -5627,6 +7493,12 @@
             "state": "translated",
             "value": "Apreciación"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Docenienie"
+          }
         }
       }
     },
@@ -5644,6 +7516,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Comunicación"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Komunikacja"
           }
         }
       }
@@ -5663,6 +7541,12 @@
             "state": "translated",
             "value": "Conflicto"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Konflikt"
+          }
         }
       }
     },
@@ -5680,6 +7564,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Vida cotidiana"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Codzienność"
           }
         }
       }
@@ -5699,6 +7589,12 @@
             "state": "translated",
             "value": "Emociones"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Emocje"
+          }
         }
       }
     },
@@ -5716,6 +7612,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Enamorarse"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fall in Love"
           }
         }
       }
@@ -5735,6 +7637,12 @@
             "state": "translated",
             "value": "Acercarse"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zbliżcie się"
+          }
         }
       }
     },
@@ -5752,6 +7660,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Crecimiento"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozwój"
           }
         }
       }
@@ -5771,6 +7685,12 @@
             "state": "translated",
             "value": "Identidad"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tożsamość"
+          }
         }
       }
     },
@@ -5788,6 +7708,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Intimidad"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Intymność"
           }
         }
       }
@@ -5807,6 +7733,12 @@
             "state": "translated",
             "value": "Crianza"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rodzicielstwo"
+          }
         }
       }
     },
@@ -5824,6 +7756,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Pasado"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przeszłość"
           }
         }
       }
@@ -5843,6 +7781,12 @@
             "state": "translated",
             "value": "Sexo"
           }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seks"
+          }
         }
       }
     },
@@ -5860,6 +7804,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "Valores"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wartości"
           }
         }
       }

--- a/Connections/Views/HomeView.swift
+++ b/Connections/Views/HomeView.swift
@@ -7,7 +7,6 @@ import SwiftUI
 
 struct HomeView: View {
     @State private var navigateToSettings = false
-    @State private var navigateToSession = false
 
     var body: some View {
         GeometryReader { geo in
@@ -46,15 +45,6 @@ struct HomeView: View {
                             .primaryButtonStyle()
                     }
 
-                    if session.isSessionActive {
-                        Button {
-                            navigateToSession = true
-                        } label: {
-                            Text("Continue Session")
-                                .secondaryButtonStyle()
-                        }
-                    }
-
                 }
                 .padding(.horizontal, AppSpacing.buttonHorizontal)
 
@@ -80,9 +70,6 @@ struct HomeView: View {
             }
             .navigationDestination(isPresented: $navigateToSettings) {
                 SettingsView()
-            }
-            .navigationDestination(isPresented: $navigateToSession) {
-                SessionPlayView()
             }
             } // ZStack
         }

--- a/Connections/Views/SettingsView.swift
+++ b/Connections/Views/SettingsView.swift
@@ -235,7 +235,14 @@ struct SettingsView: View {
 
     private var privacyPolicyURL: URL? {
         let language = Bundle.main.preferredLocalizations.first?.lowercased() ?? "en"
-        let path = language.hasPrefix("es") ? "privacy-es" : "privacy"
+        let path: String
+        if language.hasPrefix("es") {
+            path = "privacy-es"
+        } else if language.hasPrefix("pl") {
+            path = "privacy-pl"
+        } else {
+            path = "privacy"
+        }
         return URL(string: "https://skytan4.github.io/Connections/\(path)")
     }
 }

--- a/Tests/ConnectionsTests/JSONBankLoaderTests.swift
+++ b/Tests/ConnectionsTests/JSONBankLoaderTests.swift
@@ -26,6 +26,10 @@ final class JSONBankLoaderTests: XCTestCase {
         XCTAssertEqual(JSONBankLoader.localeCandidates(preferredLocale: "zh-Hans"), ["zh-Hans", "zh", "en"])
     }
 
+    func testPlPlProducesPlPlPlAndEn() {
+        XCTAssertEqual(JSONBankLoader.localeCandidates(preferredLocale: "pl-PL"), ["pl-PL", "pl", "en"])
+    }
+
     // MARK: - Fallback Behavior (exercises real bundle files)
 
     func testEnglishFileLoadsDirectly() {

--- a/Tests/ConnectionsTests/LocalizationTestHelper.swift
+++ b/Tests/ConnectionsTests/LocalizationTestHelper.swift
@@ -1,0 +1,319 @@
+//
+//  LocalizationTestHelper.swift
+//  ConnectionsTests
+//
+
+import XCTest
+@testable import Connections
+
+/// Reusable static assertions for localization test coverage.
+/// This is a plain struct — XCTestCase discovery lives in locale-specific test classes only.
+struct LocalizationTestHelper {
+
+    // MARK: - xcstrings path (resolved relative to this source file)
+
+    private static let xcstringsURL: URL = URL(fileURLWithPath: #file)
+        .deletingLastPathComponent()   // ConnectionsTests/
+        .deletingLastPathComponent()   // Tests/
+        .deletingLastPathComponent()   // project root
+        .appendingPathComponent("Connections/Localizable.xcstrings")
+
+    private static let xcstringsJSON: [String: Any]? = {
+        guard let data = try? Data(contentsOf: xcstringsURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return json
+    }()
+
+    // MARK: - xcstrings assertions
+
+    static func assertXcstringsFileExists(file: StaticString = #file, line: UInt = #line) {
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: xcstringsURL.path),
+            "Localizable.xcstrings not found at \(xcstringsURL.path)",
+            file: file, line: line
+        )
+    }
+
+    static func assertAllTranslatableKeysHaveValues(
+        locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        guard let strings = xcstringsJSON?["strings"] as? [String: Any] else {
+            XCTFail("Localizable.xcstrings: could not read 'strings' dictionary", file: file, line: line)
+            return
+        }
+        for (key, entry) in strings {
+            guard let entryDict = entry as? [String: Any] else { continue }
+            if let shouldTranslate = entryDict["shouldTranslate"] as? Bool, !shouldTranslate { continue }
+            let localizations = entryDict["localizations"] as? [String: Any] ?? [:]
+            XCTAssertNotNil(
+                localizations[locale],
+                "Key '\(key)' is missing \(locale) localization",
+                file: file, line: line
+            )
+        }
+    }
+
+    static func assertNoLocaleValuesAreEmpty(
+        locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        guard let strings = xcstringsJSON?["strings"] as? [String: Any] else { return }
+        for (key, entry) in strings {
+            guard let entryDict = entry as? [String: Any],
+                  let localizations = entryDict["localizations"] as? [String: Any],
+                  let localeEntry = localizations[locale] as? [String: Any],
+                  let unit = localeEntry["stringUnit"] as? [String: Any],
+                  let value = unit["value"] as? String else { continue }
+            XCTAssertFalse(
+                value.isEmpty,
+                "\(locale) value for key '\(key)' is empty",
+                file: file, line: line
+            )
+        }
+    }
+
+    static func assertBrandTermIsNonTranslatable(
+        key: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        guard let strings = xcstringsJSON?["strings"] as? [String: Any],
+              let entry = strings[key] as? [String: Any] else {
+            XCTFail("'\(key)' key not found in xcstrings", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(
+            entry["shouldTranslate"] as? Bool, false,
+            "'\(key)' should have shouldTranslate=false",
+            file: file, line: line
+        )
+    }
+
+    static func assertBrandTermHasNoLocalizationBlock(
+        key: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        guard let strings = xcstringsJSON?["strings"] as? [String: Any],
+              let entry = strings[key] as? [String: Any],
+              let localizations = entry["localizations"] as? [String: Any] else { return }
+        XCTAssertNil(
+            localizations[locale],
+            "'\(key)' should not have a '\(locale)' localization block",
+            file: file, line: line
+        )
+    }
+
+    static func assertFormatPlaceholderParity(
+        locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        guard let strings = xcstringsJSON?["strings"] as? [String: Any] else { return }
+        for (key, entry) in strings {
+            guard let entryDict = entry as? [String: Any] else { continue }
+            if let shouldTranslate = entryDict["shouldTranslate"] as? Bool, !shouldTranslate { continue }
+            guard let localizations = entryDict["localizations"] as? [String: Any],
+                  let en = localizations["en"] as? [String: Any],
+                  let enUnit = en["stringUnit"] as? [String: Any],
+                  let enValue = enUnit["value"] as? String,
+                  let localeEntry = localizations[locale] as? [String: Any],
+                  let localeUnit = localeEntry["stringUnit"] as? [String: Any],
+                  let localeValue = localeUnit["value"] as? String else { continue }
+            let enPH = formatPlaceholders(in: enValue).sorted()
+            let localePH = formatPlaceholders(in: localeValue).sorted()
+            XCTAssertEqual(
+                localePH, enPH,
+                "Placeholder mismatch for '\(key)': en=\(enPH) \(locale)=\(localePH)",
+                file: file, line: line
+            )
+        }
+    }
+
+    // MARK: - JSON bank assertions
+
+    static func assertBankLoads(
+        bankName: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let result = JSONBankLoader.load(bankName: bankName, preferredLocale: locale)
+        XCTAssertFalse(result.data.isEmpty, "\(bankName)_\(locale): data is empty", file: file, line: line)
+        XCTAssertEqual(result.locale, locale, "\(bankName): loaded locale mismatch", file: file, line: line)
+    }
+
+    static func assertBankCountMatchesEnglish(
+        bankName: String, arrayKey: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let en = loadJSON(bankName: bankName, locale: "en")
+        let loc = loadJSON(bankName: bankName, locale: locale)
+        let enCount = (en[arrayKey] as? [[String: Any]])?.count ?? 0
+        let locCount = (loc[arrayKey] as? [[String: Any]])?.count ?? 0
+        XCTAssertEqual(
+            locCount, enCount,
+            "\(bankName)_\(locale): count mismatch (expected \(enCount), got \(locCount))",
+            file: file, line: line
+        )
+    }
+
+    static func assertBankIDsMatchEnglish(
+        bankName: String, arrayKey: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let en = loadJSON(bankName: bankName, locale: "en")
+        let loc = loadJSON(bankName: bankName, locale: locale)
+        let enIDs = (en[arrayKey] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
+        let locIDs = (loc[arrayKey] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
+        XCTAssertEqual(locIDs, enIDs, "\(bankName)_\(locale): IDs don't match English", file: file, line: line)
+    }
+
+    /// Iterates paired English and locale arrays, calling `check` for each pair.
+    /// Assertions written inside `check` closures will attribute to the caller's file/line.
+    static func assertBankArrays(
+        bankName: String, arrayKey: String, locale: String,
+        check: ([String: Any], [String: Any]) -> Void,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let en = loadJSON(bankName: bankName, locale: "en")
+        let loc = loadJSON(bankName: bankName, locale: locale)
+        guard let enArr = en[arrayKey] as? [[String: Any]],
+              let locArr = loc[arrayKey] as? [[String: Any]] else {
+            XCTFail("\(bankName): could not read '\(arrayKey)' array", file: file, line: line)
+            return
+        }
+        for (enItem, locItem) in zip(enArr, locArr) { check(enItem, locItem) }
+    }
+
+    static func assertNoEmptyField(
+        _ field: String, bankName: String, arrayKey: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let loc = loadJSON(bankName: bankName, locale: locale)
+        guard let items = loc[arrayKey] as? [[String: Any]] else { return }
+        for item in items {
+            XCTAssertFalse(
+                (item[field] as? String ?? "").isEmpty,
+                "\(bankName)_\(locale): empty '\(field)' for id=\(item["id"] ?? "?")",
+                file: file, line: line
+            )
+        }
+    }
+
+    /// Checks follow-up count, id, style, and non-empty text parity for the array-based `followUps` structure.
+    static func assertPromptFollowUpParity(
+        bankName: String, arrayKey: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        assertBankArrays(bankName: bankName, arrayKey: arrayKey, locale: locale, file: file, line: line) { enP, locP in
+            let id = enP["id"] as? String ?? "?"
+            let enFUs = enP["followUps"] as? [[String: Any]] ?? []
+            let locFUs = locP["followUps"] as? [[String: Any]] ?? []
+            XCTAssertEqual(locFUs.count, enFUs.count, "followUp count id=\(id)", file: file, line: line)
+            for (enFU, locFU) in zip(enFUs, locFUs) {
+                XCTAssertEqual(locFU["id"] as? String, enFU["id"] as? String,
+                               "fu id mismatch prompt=\(id)", file: file, line: line)
+                XCTAssertEqual(locFU["style"] as? String, enFU["style"] as? String,
+                               "fu style mismatch prompt=\(id)", file: file, line: line)
+                XCTAssertFalse(
+                    (locFU["text"] as? String ?? "").isEmpty,
+                    "empty fu text prompt=\(id) fu=\(enFU["id"] ?? "?")",
+                    file: file, line: line
+                )
+            }
+        }
+    }
+
+    /// Checks that `followUp1` and `followUp2` string fields are non-empty (life_story bank structure).
+    static func assertLifeStoryFollowUpsNonEmpty(
+        locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let loc = loadJSON(bankName: "life_story", locale: locale)
+        guard let prompts = loc["prompts"] as? [[String: Any]] else { return }
+        for p in prompts {
+            let id = p["id"] as? String ?? "?"
+            XCTAssertFalse((p["followUp1"] as? String ?? "").isEmpty,
+                           "empty followUp1 id=\(id)", file: file, line: line)
+            XCTAssertFalse((p["followUp2"] as? String ?? "").isEmpty,
+                           "empty followUp2 id=\(id)", file: file, line: line)
+        }
+    }
+
+    /// Asserts that each translated text differs from its English source (regression against untranslated placeholders).
+    static func assertTranslatedTextDiffersFromEnglish(
+        bankName: String, arrayKey: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        let en = loadJSON(bankName: bankName, locale: "en")
+        let loc = loadJSON(bankName: bankName, locale: locale)
+        guard let enArr = en[arrayKey] as? [[String: Any]],
+              let locArr = loc[arrayKey] as? [[String: Any]] else {
+            XCTFail("Could not load \(bankName) arrays", file: file, line: line)
+            return
+        }
+        for (enP, locP) in zip(enArr, locArr) {
+            let id = enP["id"] as? String ?? "?"
+            if let enText = enP["text"] as? String, let locText = locP["text"] as? String {
+                XCTAssertNotEqual(
+                    locText, enText,
+                    "\(bankName)_\(locale) prompt '\(id)' text is still English placeholder",
+                    file: file, line: line
+                )
+            }
+            let enFUs = enP["followUps"] as? [[String: Any]] ?? []
+            let locFUs = locP["followUps"] as? [[String: Any]] ?? []
+            for (enFU, locFU) in zip(enFUs, locFUs) {
+                if let enT = enFU["text"] as? String, let locT = locFU["text"] as? String {
+                    XCTAssertNotEqual(
+                        locT, enT,
+                        "\(bankName)_\(locale) followUp '\(locFU["id"] ?? "?")' text is still English placeholder",
+                        file: file, line: line
+                    )
+                }
+            }
+        }
+    }
+
+    static func assertSchemaVersion(
+        _ version: Int = 1, bankName: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            loadJSON(bankName: bankName, locale: locale)["schemaVersion"] as? Int, version,
+            "\(bankName)_\(locale).json: schemaVersion must be \(version)",
+            file: file, line: line
+        )
+    }
+
+    static func assertLanguageField(
+        bankName: String, locale: String,
+        file: StaticString = #file, line: UInt = #line
+    ) {
+        XCTAssertEqual(
+            loadJSON(bankName: bankName, locale: locale)["language"] as? String, locale,
+            "\(bankName)_\(locale).json: language must be '\(locale)'",
+            file: file, line: line
+        )
+    }
+
+    // MARK: - Internal helpers
+
+    static func loadJSON(bankName: String, locale: String) -> [String: Any] {
+        let result = JSONBankLoader.load(bankName: bankName, preferredLocale: locale)
+        guard let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] else {
+            XCTFail("Could not parse \(bankName)_\(locale).json")
+            return [:]
+        }
+        return json
+    }
+
+    // MARK: - Private helpers
+
+    private static func formatPlaceholders(in text: String) -> [String] {
+        let pattern = #"%\d+\$[a-zA-Z@]+"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.matches(in: text, range: range).compactMap { match in
+            Range(match.range, in: text).map { String(text[$0]) }
+        }
+    }
+}

--- a/Tests/ConnectionsTests/LocalizationTestHelper.swift
+++ b/Tests/ConnectionsTests/LocalizationTestHelper.swift
@@ -203,23 +203,27 @@ struct LocalizationTestHelper {
         bankName: String, arrayKey: String, locale: String,
         file: StaticString = #file, line: UInt = #line
     ) {
-        assertBankArrays(bankName: bankName, arrayKey: arrayKey, locale: locale, file: file, line: line) { enP, locP in
-            let id = enP["id"] as? String ?? "?"
-            let enFUs = enP["followUps"] as? [[String: Any]] ?? []
-            let locFUs = locP["followUps"] as? [[String: Any]] ?? []
-            XCTAssertEqual(locFUs.count, enFUs.count, "followUp count id=\(id)", file: file, line: line)
-            for (enFU, locFU) in zip(enFUs, locFUs) {
-                XCTAssertEqual(locFU["id"] as? String, enFU["id"] as? String,
-                               "fu id mismatch prompt=\(id)", file: file, line: line)
-                XCTAssertEqual(locFU["style"] as? String, enFU["style"] as? String,
-                               "fu style mismatch prompt=\(id)", file: file, line: line)
-                XCTAssertFalse(
-                    (locFU["text"] as? String ?? "").isEmpty,
-                    "empty fu text prompt=\(id) fu=\(enFU["id"] ?? "?")",
-                    file: file, line: line
-                )
-            }
-        }
+        assertBankArrays(
+            bankName: bankName, arrayKey: arrayKey, locale: locale,
+            check: { enP, locP in
+                let id = enP["id"] as? String ?? "?"
+                let enFUs = enP["followUps"] as? [[String: Any]] ?? []
+                let locFUs = locP["followUps"] as? [[String: Any]] ?? []
+                XCTAssertEqual(locFUs.count, enFUs.count, "followUp count id=\(id)", file: file, line: line)
+                for (enFU, locFU) in zip(enFUs, locFUs) {
+                    XCTAssertEqual(locFU["id"] as? String, enFU["id"] as? String,
+                                   "fu id mismatch prompt=\(id)", file: file, line: line)
+                    XCTAssertEqual(locFU["style"] as? String, enFU["style"] as? String,
+                                   "fu style mismatch prompt=\(id)", file: file, line: line)
+                    XCTAssertFalse(
+                        (locFU["text"] as? String ?? "").isEmpty,
+                        "empty fu text prompt=\(id) fu=\(enFU["id"] ?? "?")",
+                        file: file, line: line
+                    )
+                }
+            },
+            file: file, line: line
+        )
     }
 
     /// Checks that `followUp1` and `followUp2` string fields are non-empty (life_story bank structure).

--- a/Tests/ConnectionsTests/PolishLocalizationTests.swift
+++ b/Tests/ConnectionsTests/PolishLocalizationTests.swift
@@ -1,0 +1,241 @@
+//
+//  PolishLocalizationTests.swift
+//  ConnectionsTests
+//
+//  Tests are pre-translation safe: each test that depends on a Polish
+//  JSON bank calls skipIfBankMissing(_:) first. If the file does not
+//  exist yet, the test is marked Skipped (not Failed).
+//  Once the Polish files are committed, all tests run and enforce the
+//  same parity checks as SpanishLocalizationTests.
+//
+
+import XCTest
+@testable import Connections
+
+final class PolishLocalizationTests: XCTestCase {
+
+    private static let locale = "pl"
+
+    // MARK: - Skip guards
+
+    /// Skip the calling test if <bankName>_pl.json is not in the bundle yet.
+    /// JSONBankLoader falls back to "en" when the Polish file is absent,
+    /// so a locale mismatch is the reliable signal.
+    private func skipIfBankMissing(_ bankName: String) throws {
+        let result = JSONBankLoader.load(bankName: bankName, preferredLocale: Self.locale)
+        guard result.locale == Self.locale else {
+            throw XCTSkip("\(bankName)_\(Self.locale).json not yet available — skipping until Polish translation is committed")
+        }
+    }
+
+    /// Skip the calling test if no Polish entries exist in Localizable.xcstrings yet.
+    private func skipIfPolishXcstringsMissing() throws {
+        let xcstringsURL = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()   // ConnectionsTests/
+            .deletingLastPathComponent()   // Tests/
+            .deletingLastPathComponent()   // project root
+            .appendingPathComponent("Connections/Localizable.xcstrings")
+        guard let data = try? Data(contentsOf: xcstringsURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let strings = json["strings"] as? [String: Any] else { return }
+        let hasPolish = strings.values
+            .compactMap { $0 as? [String: Any] }
+            .compactMap { $0["localizations"] as? [String: Any] }
+            .flatMap { $0.keys }
+            .contains(Self.locale)
+        guard hasPolish else {
+            throw XCTSkip("No Polish entries in Localizable.xcstrings yet — skipping until Polish UI strings are added")
+        }
+    }
+
+    // MARK: - Localizable.xcstrings (always-run — do not require Polish to be present)
+
+    func testXcstringsSourceFileExists() {
+        LocalizationTestHelper.assertXcstringsFileExists()
+    }
+
+    func testDeeperConversationsIsNonTranslatable() {
+        LocalizationTestHelper.assertBrandTermIsNonTranslatable(key: "Deeper Conversations")
+    }
+
+    func testDeeperConversationsHasNoPolishEntry() {
+        LocalizationTestHelper.assertBrandTermHasNoLocalizationBlock(key: "Deeper Conversations", locale: Self.locale)
+    }
+
+    // MARK: - Localizable.xcstrings (skip until Polish UI strings are added)
+
+    func testAllTranslatableKeysHavePolishValues() throws {
+        try skipIfPolishXcstringsMissing()
+        LocalizationTestHelper.assertAllTranslatableKeysHaveValues(locale: Self.locale)
+    }
+
+    func testNoPolishValuesAreEmpty() throws {
+        try skipIfPolishXcstringsMissing()
+        LocalizationTestHelper.assertNoLocaleValuesAreEmpty(locale: Self.locale)
+    }
+
+    func testFormatPlaceholderParityBetweenEnglishAndPolish() throws {
+        try skipIfPolishXcstringsMissing()
+        LocalizationTestHelper.assertFormatPlaceholderParity(locale: Self.locale)
+    }
+
+    // MARK: - JSON bank loading
+
+    func testPolishFallInLoveLoads() throws {
+        try skipIfBankMissing("fall_in_love")
+        LocalizationTestHelper.assertBankLoads(bankName: "fall_in_love", locale: Self.locale)
+    }
+
+    func testPolishLifeStoryLoads() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertBankLoads(bankName: "life_story", locale: Self.locale)
+    }
+
+    func testPolishShareExperienceLoads() throws {
+        try skipIfBankMissing("share_experience")
+        LocalizationTestHelper.assertBankLoads(bankName: "share_experience", locale: Self.locale)
+    }
+
+    func testPolishPromptsLoads() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertBankLoads(bankName: "prompts", locale: Self.locale)
+    }
+
+    // MARK: - fall_in_love parity
+
+    func testFallInLovePolishCountMatchesEnglish() throws {
+        try skipIfBankMissing("fall_in_love")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "fall_in_love", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testFallInLovePolishIDsMatchEnglish() throws {
+        try skipIfBankMissing("fall_in_love")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "fall_in_love", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testFallInLovePolishMetadataMatchesEnglish() throws {
+        try skipIfBankMissing("fall_in_love")
+        LocalizationTestHelper.assertBankArrays(bankName: "fall_in_love", arrayKey: "prompts", locale: Self.locale) { enP, plP in
+            let id = enP["id"] as? String ?? "?"
+            XCTAssertEqual(plP["intensity"] as? String, enP["intensity"] as? String, "intensity id=\(id)")
+            XCTAssertEqual(plP["depth"] as? String,     enP["depth"] as? String,     "depth id=\(id)")
+            XCTAssertEqual(plP["order"] as? Int,        enP["order"] as? Int,         "order id=\(id)")
+        }
+    }
+
+    func testFallInLovePolishNoEmptyText() throws {
+        try skipIfBankMissing("fall_in_love")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "fall_in_love", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    // MARK: - life_story parity
+
+    func testLifeStoryPolishCountMatchesEnglish() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "life_story", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testLifeStoryPolishIDsMatchEnglish() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "life_story", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testLifeStoryPolishMetadataMatchesEnglish() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertBankArrays(bankName: "life_story", arrayKey: "prompts", locale: Self.locale) { enP, plP in
+            let id = enP["id"] as? String ?? "?"
+            XCTAssertEqual(plP["chapter"] as? String, enP["chapter"] as? String, "chapter id=\(id)")
+            XCTAssertEqual(plP["order"] as? Int,      enP["order"] as? Int,       "order id=\(id)")
+        }
+    }
+
+    func testLifeStoryPolishNoEmptyText() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "life_story", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testLifeStoryPolishFollowUpsNonEmpty() throws {
+        try skipIfBankMissing("life_story")
+        LocalizationTestHelper.assertLifeStoryFollowUpsNonEmpty(locale: Self.locale)
+    }
+
+    // MARK: - share_experience parity
+
+    func testShareExperiencePolishCountMatchesEnglish() throws {
+        try skipIfBankMissing("share_experience")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "share_experience", arrayKey: "experiences", locale: Self.locale)
+    }
+
+    func testShareExperiencePolishIDsMatchEnglish() throws {
+        try skipIfBankMissing("share_experience")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "share_experience", arrayKey: "experiences", locale: Self.locale)
+    }
+
+    func testShareExperiencePolishMetadataMatchesEnglish() throws {
+        try skipIfBankMissing("share_experience")
+        LocalizationTestHelper.assertBankArrays(bankName: "share_experience", arrayKey: "experiences", locale: Self.locale) { enE, plE in
+            let id = enE["id"] as? String ?? "?"
+            XCTAssertEqual(plE["intensity"] as? String, enE["intensity"] as? String, "intensity id=\(id)")
+            XCTAssertEqual(plE["topic"] as? String,     enE["topic"] as? String,     "topic id=\(id)")
+        }
+    }
+
+    func testShareExperiencePolishNoEmptyFullText() throws {
+        try skipIfBankMissing("share_experience")
+        LocalizationTestHelper.assertNoEmptyField("fullText", bankName: "share_experience", arrayKey: "experiences", locale: Self.locale)
+    }
+
+    // MARK: - prompts parity
+
+    func testPromptsPolishCountMatchesEnglish() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "prompts", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testPromptsPolishIDsMatchEnglish() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "prompts", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testPromptsPolishMetadataMatchesEnglish() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertBankArrays(bankName: "prompts", arrayKey: "prompts", locale: Self.locale) { enP, plP in
+            let id = enP["id"] as? String ?? "?"
+            XCTAssertEqual(plP["mode"] as? String,      enP["mode"] as? String,      "mode id=\(id)")
+            XCTAssertEqual(plP["intensity"] as? String, enP["intensity"] as? String, "intensity id=\(id)")
+            XCTAssertEqual(plP["depth"] as? String,     enP["depth"] as? String,     "depth id=\(id)")
+            XCTAssertEqual(plP["topic"] as? String,     enP["topic"] as? String,     "topic id=\(id)")
+        }
+    }
+
+    func testPromptsPolishNoEmptyText() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "prompts", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    func testPromptsPolishFollowUpParityWithEnglish() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertPromptFollowUpParity(bankName: "prompts", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    // MARK: - Translation regression
+
+    func testPromptsPlTextDiffersFromEnglish() throws {
+        try skipIfBankMissing("prompts")
+        LocalizationTestHelper.assertTranslatedTextDiffersFromEnglish(bankName: "prompts", arrayKey: "prompts", locale: Self.locale)
+    }
+
+    // MARK: - Schema metadata
+
+    func testAllPolishJsonFilesHaveSchemaVersion1() throws {
+        let banks = ["fall_in_love", "life_story", "share_experience", "prompts"]
+        for bank in banks { try skipIfBankMissing(bank) }
+        for bank in banks { LocalizationTestHelper.assertSchemaVersion(1, bankName: bank, locale: Self.locale) }
+    }
+
+    func testAllPolishJsonFilesHaveLanguagePl() throws {
+        let banks = ["fall_in_love", "life_story", "share_experience", "prompts"]
+        for bank in banks { try skipIfBankMissing(bank) }
+        for bank in banks { LocalizationTestHelper.assertLanguageField(bankName: bank, locale: Self.locale) }
+    }
+}

--- a/Tests/ConnectionsTests/SpanishLocalizationTests.swift
+++ b/Tests/ConnectionsTests/SpanishLocalizationTests.swift
@@ -15,135 +15,62 @@ final class SpanishLocalizationTests: XCTestCase {
                       "App bundle is missing 'es' in knownRegions")
     }
 
-    // MARK: - Localizable.xcstrings (source-level)
-
-    // The xcstrings file lives in source; locate it relative to this test file.
-    private static let xcstringsURL: URL = URL(fileURLWithPath: #filePath)
-        .deletingLastPathComponent()   // ConnectionsTests/
-        .deletingLastPathComponent()   // Tests/
-        .deletingLastPathComponent()   // project root
-        .appendingPathComponent("Connections/Localizable.xcstrings")
-
-    private static var xcstringsJSON: [String: Any]? = {
-        guard let data = try? Data(contentsOf: xcstringsURL),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return nil }
-        return json
-    }()
+    // MARK: - Localizable.xcstrings
 
     func testXcstringsSourceFileExists() {
-        XCTAssertTrue(FileManager.default.fileExists(atPath: Self.xcstringsURL.path),
-                      "Localizable.xcstrings not found at \(Self.xcstringsURL.path)")
+        LocalizationTestHelper.assertXcstringsFileExists()
     }
 
     func testAllTranslatableKeysHaveSpanishValues() {
-        guard let strings = Self.xcstringsJSON?["strings"] as? [String: Any] else {
-            XCTFail("Localizable.xcstrings: could not read 'strings' dictionary"); return
-        }
-        for (key, entry) in strings {
-            guard let entryDict = entry as? [String: Any] else { continue }
-            if let shouldTranslate = entryDict["shouldTranslate"] as? Bool, !shouldTranslate { continue }
-            let localizations = entryDict["localizations"] as? [String: Any] ?? [:]
-            XCTAssertNotNil(localizations["es"], "Key '\(key)' is missing Spanish localization")
-        }
+        LocalizationTestHelper.assertAllTranslatableKeysHaveValues(locale: "es")
     }
 
     func testNoSpanishValuesAreEmpty() {
-        guard let strings = Self.xcstringsJSON?["strings"] as? [String: Any] else { return }
-        for (key, entry) in strings {
-            guard let entryDict = entry as? [String: Any],
-                  let localizations = entryDict["localizations"] as? [String: Any],
-                  let es = localizations["es"] as? [String: Any],
-                  let unit = es["stringUnit"] as? [String: Any],
-                  let value = unit["value"] as? String else { continue }
-            XCTAssertFalse(value.isEmpty, "Spanish value for key '\(key)' is empty")
-        }
+        LocalizationTestHelper.assertNoLocaleValuesAreEmpty(locale: "es")
     }
 
     func testDeeperConversationsIsNonTranslatable() {
-        guard let strings = Self.xcstringsJSON?["strings"] as? [String: Any],
-              let entry = strings["Deeper Conversations"] as? [String: Any] else {
-            XCTFail("'Deeper Conversations' key not found in xcstrings"); return
-        }
-        XCTAssertEqual(entry["shouldTranslate"] as? Bool, false,
-                       "'Deeper Conversations' should have shouldTranslate=false")
+        LocalizationTestHelper.assertBrandTermIsNonTranslatable(key: "Deeper Conversations")
     }
 
     func testDeeperConversationsHasNoSpanishEntry() {
-        guard let strings = Self.xcstringsJSON?["strings"] as? [String: Any],
-              let entry = strings["Deeper Conversations"] as? [String: Any],
-              let localizations = entry["localizations"] as? [String: Any] else { return }
-        XCTAssertNil(localizations["es"],
-                     "'Deeper Conversations' should not have an 'es' localization block")
+        LocalizationTestHelper.assertBrandTermHasNoLocalizationBlock(key: "Deeper Conversations", locale: "es")
     }
 
     func testFormatPlaceholderParityBetweenEnglishAndSpanish() {
-        guard let strings = Self.xcstringsJSON?["strings"] as? [String: Any] else { return }
-        for (key, entry) in strings {
-            guard let entryDict = entry as? [String: Any] else { continue }
-            if let shouldTranslate = entryDict["shouldTranslate"] as? Bool, !shouldTranslate { continue }
-            guard let localizations = entryDict["localizations"] as? [String: Any],
-                  let en = localizations["en"] as? [String: Any],
-                  let enUnit = en["stringUnit"] as? [String: Any],
-                  let enValue = enUnit["value"] as? String,
-                  let es = localizations["es"] as? [String: Any],
-                  let esUnit = es["stringUnit"] as? [String: Any],
-                  let esValue = esUnit["value"] as? String else { continue }
-            let enPH = formatPlaceholders(in: enValue).sorted()
-            let esPH = formatPlaceholders(in: esValue).sorted()
-            XCTAssertEqual(esPH, enPH,
-                           "Placeholder mismatch for '\(key)': en=\(enPH) es=\(esPH)")
-        }
-    }
-
-    private func formatPlaceholders(in text: String) -> [String] {
-        // Matches numbered specifiers: %1$@, %2$lld, %1$d, etc.
-        let pattern = #"%\d+\$[a-zA-Z@]+"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
-        let range = NSRange(text.startIndex..., in: text)
-        return regex.matches(in: text, range: range).compactMap { match in
-            Range(match.range, in: text).map { String(text[$0]) }
-        }
+        LocalizationTestHelper.assertFormatPlaceholderParity(locale: "es")
     }
 
     // MARK: - Spanish JSON Loading
 
     func testSpanishFallInLoveLoads() {
-        let result = JSONBankLoader.load(bankName: "fall_in_love", preferredLocale: "es")
-        XCTAssertFalse(result.data.isEmpty)
-        XCTAssertEqual(result.locale, "es")
+        LocalizationTestHelper.assertBankLoads(bankName: "fall_in_love", locale: "es")
     }
 
     func testSpanishLifeStoryLoads() {
-        let result = JSONBankLoader.load(bankName: "life_story", preferredLocale: "es")
-        XCTAssertFalse(result.data.isEmpty)
-        XCTAssertEqual(result.locale, "es")
+        LocalizationTestHelper.assertBankLoads(bankName: "life_story", locale: "es")
     }
 
     func testSpanishShareExperienceLoads() {
-        let result = JSONBankLoader.load(bankName: "share_experience", preferredLocale: "es")
-        XCTAssertFalse(result.data.isEmpty)
-        XCTAssertEqual(result.locale, "es")
+        LocalizationTestHelper.assertBankLoads(bankName: "share_experience", locale: "es")
     }
 
     func testSpanishPromptsLoads() {
-        let result = JSONBankLoader.load(bankName: "prompts", preferredLocale: "es")
-        XCTAssertFalse(result.data.isEmpty)
-        XCTAssertEqual(result.locale, "es")
+        LocalizationTestHelper.assertBankLoads(bankName: "prompts", locale: "es")
     }
 
     // MARK: - fall_in_love parity
 
     func testFallInLoveSpanishCountMatchesEnglish() {
-        verifyCount(bankName: "fall_in_love", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "fall_in_love", arrayKey: "prompts", locale: "es")
     }
 
     func testFallInLoveSpanishIDsMatchEnglish() {
-        verifyIDs(bankName: "fall_in_love", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "fall_in_love", arrayKey: "prompts", locale: "es")
     }
 
     func testFallInLoveSpanishMetadataMatchesEnglish() {
-        verifyArrays(bankName: "fall_in_love", arrayKey: "prompts") { enP, esP in
+        LocalizationTestHelper.assertBankArrays(bankName: "fall_in_love", arrayKey: "prompts", locale: "es") { enP, esP in
             let id = enP["id"] as? String ?? "?"
             XCTAssertEqual(esP["intensity"] as? String, enP["intensity"] as? String, "intensity id=\(id)")
             XCTAssertEqual(esP["depth"] as? String,     enP["depth"] as? String,     "depth id=\(id)")
@@ -152,21 +79,21 @@ final class SpanishLocalizationTests: XCTestCase {
     }
 
     func testFallInLoveSpanishNoEmptyText() {
-        verifyNoEmptyField("text", bankName: "fall_in_love", arrayKey: "prompts")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "fall_in_love", arrayKey: "prompts", locale: "es")
     }
 
     // MARK: - life_story parity
 
     func testLifeStorySpanishCountMatchesEnglish() {
-        verifyCount(bankName: "life_story", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "life_story", arrayKey: "prompts", locale: "es")
     }
 
     func testLifeStorySpanishIDsMatchEnglish() {
-        verifyIDs(bankName: "life_story", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "life_story", arrayKey: "prompts", locale: "es")
     }
 
     func testLifeStorySpanishMetadataMatchesEnglish() {
-        verifyArrays(bankName: "life_story", arrayKey: "prompts") { enP, esP in
+        LocalizationTestHelper.assertBankArrays(bankName: "life_story", arrayKey: "prompts", locale: "es") { enP, esP in
             let id = enP["id"] as? String ?? "?"
             XCTAssertEqual(esP["chapter"] as? String, enP["chapter"] as? String, "chapter id=\(id)")
             XCTAssertEqual(esP["order"] as? Int,      enP["order"] as? Int,       "order id=\(id)")
@@ -174,31 +101,25 @@ final class SpanishLocalizationTests: XCTestCase {
     }
 
     func testLifeStorySpanishNoEmptyText() {
-        verifyNoEmptyField("text", bankName: "life_story", arrayKey: "prompts")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "life_story", arrayKey: "prompts", locale: "es")
     }
 
     func testLifeStorySpanishFollowUpsNonEmpty() {
-        let es = loadJSON(bankName: "life_story", locale: "es")
-        guard let prompts = es["prompts"] as? [[String: Any]] else { return }
-        for p in prompts {
-            let id = p["id"] as? String ?? "?"
-            XCTAssertFalse((p["followUp1"] as? String ?? "").isEmpty, "empty followUp1 id=\(id)")
-            XCTAssertFalse((p["followUp2"] as? String ?? "").isEmpty, "empty followUp2 id=\(id)")
-        }
+        LocalizationTestHelper.assertLifeStoryFollowUpsNonEmpty(locale: "es")
     }
 
     // MARK: - share_experience parity
 
     func testShareExperienceSpanishCountMatchesEnglish() {
-        verifyCount(bankName: "share_experience", arrayKey: "experiences")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "share_experience", arrayKey: "experiences", locale: "es")
     }
 
     func testShareExperienceSpanishIDsMatchEnglish() {
-        verifyIDs(bankName: "share_experience", arrayKey: "experiences")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "share_experience", arrayKey: "experiences", locale: "es")
     }
 
     func testShareExperienceSpanishMetadataMatchesEnglish() {
-        verifyArrays(bankName: "share_experience", arrayKey: "experiences") { enE, esE in
+        LocalizationTestHelper.assertBankArrays(bankName: "share_experience", arrayKey: "experiences", locale: "es") { enE, esE in
             let id = enE["id"] as? String ?? "?"
             XCTAssertEqual(esE["intensity"] as? String, enE["intensity"] as? String, "intensity id=\(id)")
             XCTAssertEqual(esE["topic"] as? String,     enE["topic"] as? String,     "topic id=\(id)")
@@ -206,21 +127,21 @@ final class SpanishLocalizationTests: XCTestCase {
     }
 
     func testShareExperienceSpanishNoEmptyFullText() {
-        verifyNoEmptyField("fullText", bankName: "share_experience", arrayKey: "experiences")
+        LocalizationTestHelper.assertNoEmptyField("fullText", bankName: "share_experience", arrayKey: "experiences", locale: "es")
     }
 
     // MARK: - prompts parity
 
     func testPromptsSpanishCountMatchesEnglish() {
-        verifyCount(bankName: "prompts", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankCountMatchesEnglish(bankName: "prompts", arrayKey: "prompts", locale: "es")
     }
 
     func testPromptsSpanishIDsMatchEnglish() {
-        verifyIDs(bankName: "prompts", arrayKey: "prompts")
+        LocalizationTestHelper.assertBankIDsMatchEnglish(bankName: "prompts", arrayKey: "prompts", locale: "es")
     }
 
     func testPromptsSpanishMetadataMatchesEnglish() {
-        verifyArrays(bankName: "prompts", arrayKey: "prompts") { enP, esP in
+        LocalizationTestHelper.assertBankArrays(bankName: "prompts", arrayKey: "prompts", locale: "es") { enP, esP in
             let id = enP["id"] as? String ?? "?"
             XCTAssertEqual(esP["mode"] as? String,      enP["mode"] as? String,      "mode id=\(id)")
             XCTAssertEqual(esP["intensity"] as? String, enP["intensity"] as? String, "intensity id=\(id)")
@@ -230,111 +151,30 @@ final class SpanishLocalizationTests: XCTestCase {
     }
 
     func testPromptsSpanishNoEmptyText() {
-        verifyNoEmptyField("text", bankName: "prompts", arrayKey: "prompts")
+        LocalizationTestHelper.assertNoEmptyField("text", bankName: "prompts", arrayKey: "prompts", locale: "es")
     }
 
     func testPromptsSpanishFollowUpParityWithEnglish() {
-        verifyArrays(bankName: "prompts", arrayKey: "prompts") { enP, esP in
-            let id = enP["id"] as? String ?? "?"
-            let enFUs = enP["followUps"] as? [[String: Any]] ?? []
-            let esFUs = esP["followUps"] as? [[String: Any]] ?? []
-            XCTAssertEqual(esFUs.count, enFUs.count, "followUp count id=\(id)")
-            for (enFU, esFU) in zip(enFUs, esFUs) {
-                XCTAssertEqual(esFU["id"] as? String,    enFU["id"] as? String,    "fu id mismatch prompt=\(id)")
-                XCTAssertEqual(esFU["style"] as? String, enFU["style"] as? String, "fu style mismatch prompt=\(id)")
-                XCTAssertFalse((esFU["text"] as? String ?? "").isEmpty,
-                               "empty fu text prompt=\(id) fu=\(enFU["id"] ?? "?")")
-            }
-        }
+        LocalizationTestHelper.assertPromptFollowUpParity(bankName: "prompts", arrayKey: "prompts", locale: "es")
     }
 
-    // MARK: - Translation regression (prompts_es must not be English placeholders)
+    // MARK: - Translation regression
 
     func testPromptsEsTextDiffersFromEnglish() {
-        let en = loadJSON(bankName: "prompts", locale: "en")
-        let es = loadJSON(bankName: "prompts", locale: "es")
-        guard let enArr = en["prompts"] as? [[String: Any]],
-              let esArr = es["prompts"] as? [[String: Any]] else {
-            XCTFail("Could not load prompts arrays"); return
-        }
-        var identical = 0
-        for (enP, esP) in zip(enArr, esArr) {
-            let id = enP["id"] as? String ?? "?"
-            if let enText = enP["text"] as? String, let esText = esP["text"] as? String {
-                if enText == esText { identical += 1 }
-                XCTAssertNotEqual(esText, enText,
-                    "prompts_es prompt '\(id)' text is still English placeholder")
-            }
-            let enFUs = enP["followUps"] as? [[String: Any]] ?? []
-            let esFUs = esP["followUps"] as? [[String: Any]] ?? []
-            for (enFU, esFU) in zip(enFUs, esFUs) {
-                if let enT = enFU["text"] as? String, let esT = esFU["text"] as? String {
-                    XCTAssertNotEqual(esT, enT,
-                        "prompts_es followUp '\(esFU["id"] ?? "?")' text is still English placeholder")
-                }
-            }
-        }
+        LocalizationTestHelper.assertTranslatedTextDiffersFromEnglish(bankName: "prompts", arrayKey: "prompts", locale: "es")
     }
 
     // MARK: - Schema metadata
 
     func testAllSpanishJsonFilesHaveSchemaVersion1() {
         for bank in ["fall_in_love", "life_story", "share_experience", "prompts"] {
-            XCTAssertEqual(loadJSON(bankName: bank, locale: "es")["schemaVersion"] as? Int, 1,
-                           "\(bank)_es.json: schemaVersion must be 1")
+            LocalizationTestHelper.assertSchemaVersion(1, bankName: bank, locale: "es")
         }
     }
 
     func testAllSpanishJsonFilesHaveLanguageEs() {
         for bank in ["fall_in_love", "life_story", "share_experience", "prompts"] {
-            XCTAssertEqual(loadJSON(bankName: bank, locale: "es")["language"] as? String, "es",
-                           "\(bank)_es.json: language must be 'es'")
-        }
-    }
-
-    // MARK: - Helpers
-
-    private func loadJSON(bankName: String, locale: String) -> [String: Any] {
-        let result = JSONBankLoader.load(bankName: bankName, preferredLocale: locale)
-        guard let json = try? JSONSerialization.jsonObject(with: result.data) as? [String: Any] else {
-            XCTFail("Could not parse \(bankName)_\(locale).json"); return [:]
-        }
-        return json
-    }
-
-    private func verifyCount(bankName: String, arrayKey: String) {
-        let en = loadJSON(bankName: bankName, locale: "en")
-        let es = loadJSON(bankName: bankName, locale: "es")
-        let enCount = (en[arrayKey] as? [[String: Any]])?.count ?? 0
-        let esCount = (es[arrayKey] as? [[String: Any]])?.count ?? 0
-        XCTAssertEqual(esCount, enCount, "\(bankName)_es: count mismatch (expected \(enCount), got \(esCount))")
-    }
-
-    private func verifyIDs(bankName: String, arrayKey: String) {
-        let en = loadJSON(bankName: bankName, locale: "en")
-        let es = loadJSON(bankName: bankName, locale: "es")
-        let enIDs = (en[arrayKey] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
-        let esIDs = (es[arrayKey] as? [[String: Any]])?.compactMap { $0["id"] as? String } ?? []
-        XCTAssertEqual(esIDs, enIDs, "\(bankName)_es: IDs don't match English")
-    }
-
-    private func verifyArrays(bankName: String, arrayKey: String,
-                               check: ([String: Any], [String: Any]) -> Void) {
-        let en = loadJSON(bankName: bankName, locale: "en")
-        let es = loadJSON(bankName: bankName, locale: "es")
-        guard let enArr = en[arrayKey] as? [[String: Any]],
-              let esArr = es[arrayKey] as? [[String: Any]] else {
-            XCTFail("\(bankName): could not read '\(arrayKey)' array"); return
-        }
-        for (enItem, esItem) in zip(enArr, esArr) { check(enItem, esItem) }
-    }
-
-    private func verifyNoEmptyField(_ field: String, bankName: String, arrayKey: String) {
-        let es = loadJSON(bankName: bankName, locale: "es")
-        guard let items = es[arrayKey] as? [[String: Any]] else { return }
-        for item in items {
-            XCTAssertFalse((item[field] as? String ?? "").isEmpty,
-                           "\(bankName)_es: empty '\(field)' for id=\(item["id"] ?? "?")")
+            LocalizationTestHelper.assertLanguageField(bankName: bank, locale: "es")
         }
     }
 }

--- a/docs/localization/polish-brief.md
+++ b/docs/localization/polish-brief.md
@@ -1,0 +1,139 @@
+# Polish Localization Brief
+
+## Purpose
+
+This document defines the translation standards, policies, and glossary for the Polish (`pl`) localization of Deeper Conversations. All translators and translation agents must read this brief before producing any Polish content.
+
+---
+
+## Register
+
+- **Warm, natural, emotionally intelligent Polish.** Write as a thoughtful friend would speak, not as a form or instruction manual.
+- **Informal singular `ty` throughout.** Never use `Pan/Pani` or any formal register.
+- **Avoid bureaucratic or literal English phrasing.** Polish has its own idioms for emotional and relational concepts — use them.
+- **Direct but not harsh.** Honest questions should feel inviting, not interrogative.
+- **Tender but not sentimental.** Emotional warmth is appropriate; overwrought or flowery language is not.
+- **Preserve ellipses (`…`) in sentence-completion prompts.** If the English prompt ends with `…`, the Polish must too.
+
+---
+
+## Gender Policy — Option B
+
+Polish verb and adjective forms change by grammatical gender. This is a real challenge for prompts that address the user directly.
+
+**Policy:**
+
+1. **Prefer gender-neutral constructions first.** Infinitives, noun phrases, and second-person present-tense verb forms are often naturally gender-neutral in Polish and should be used wherever they sound natural.
+   - Example: `"Czy zdarzyło ci się…"` (Has it happened to you…) is gender-neutral.
+   - Example: `"Co czujesz, gdy…"` (What do you feel when…) is gender-neutral.
+
+2. **Avoid slash notation** (`zmęczony/a`, `gotowy/a`). It is grammatically awkward and visually cluttered in running text.
+
+3. **Use masculine fallback only where a neutral construction is not practical.** This applies primarily to past-tense verb phrases and certain adjective predicates where gender is grammatically required and no natural workaround exists.
+   - Example: `"Byłeś kiedyś…"` (Have you ever been… [masc.]) is acceptable as fallback.
+
+4. **Flag for human review** any prompt where gender awkwardness remains after best effort. Add a comment in the review Markdown noting the specific gender issue.
+
+> **Important note on scope:** Gender policy applies almost entirely to `prompts_pl.json`, where verbs directly address the user. UI strings in `Localizable.xcstrings` (button labels, section headers, titles) are almost always noun phrases or infinitives and are naturally gender-neutral — no special handling needed there.
+
+---
+
+## Sensitive Content Guidance
+
+### Couples / Intimacy
+- Tender, adult, and emotionally safe.
+- Not clinical (avoid medical vocabulary for emotional closeness).
+- Not crude (avoid vulgar expressions).
+- Use warm relational language: *bliskość*, *czułość*, *intymność*.
+
+### Sex / Unfiltered
+- Direct but not vulgar.
+- Polish has a range of registers for sexuality — stay in the emotionally honest, adult register.
+- Avoid clinical terms (*stosunek płciowy*) and slang. Prefer natural adult language.
+
+### Hardship / Grief / Regret
+- Gentle, respectful, and spacious.
+- Leave room for the user to sit with difficulty without feeling pressed.
+- Avoid minimizing language (*to nic wielkiego*, *każdemu się zdarza*).
+
+### Family / Intergenerational
+- Respectful and grounded.
+- Polish family language carries strong cultural weight — use it with care.
+- Appropriate warmth for parents, grandparents, siblings; avoid flattening into generic "family."
+
+### Friends
+- Warm and casual, not romance-coded unless the prompt intentionally addresses romantic friendship.
+- Playful where the English is playful. Earnest where the English is earnest.
+
+---
+
+## Brand Terms — Keep in English
+
+The following are product feature names and must remain in English in all Polish strings:
+
+| Term | Policy |
+|---|---|
+| Deeper Conversations | English only (`shouldTranslate: false` in xcstrings) |
+| Life Story | English only |
+| Fall in Love | English only |
+| Share an Experience | English only |
+
+---
+
+## Polish-Specific Risks
+
+### Plural Forms
+Polish has four plural forms (1 / 2–4 / 5+ / genitive plural). Any UI string that includes a count (e.g., `%lld sessions`) requires plural rules. Before finalizing `Localizable.xcstrings` translations, verify no keys use `%lld` or `%d` format specifiers with count semantics. If found, they require `.stringsdict`-style plural handling.
+
+### Verb Aspect
+Polish verbs carry perfective/imperfective aspect.
+- Use **imperfective** for ongoing states, habits, and reflection prompts (`mówisz`, `czujesz`, `myślisz`).
+- Use **perfective** only when describing a specific completed event (`powiedziałeś`, `zdecydowałeś`).
+- When in doubt, imperfective is safer and more open-ended, which suits conversational prompts.
+
+### Word Length
+Polish words and phrases run approximately 20–40% longer than their English equivalents. After the first build with Polish active, do a visual pass on all fixed-width UI components (buttons, tab labels, segment controls) for truncation.
+
+---
+
+## Glossary
+
+Preferred Polish translations for recurring terms. All agents must use these consistently.
+
+| English term | Polish | Notes |
+|---|---|---|
+| prompt | pytanie | "Question" — most natural for a conversation prompt. Avoid *monit* (technical). |
+| session | sesja | Direct equivalent. Widely understood in app contexts. |
+| Go Deeper | Zagłęb się | Idiomatic. Prefer over literal *Idź głębiej*. |
+| Unfiltered | Bez filtrów | "Without filters" — modern, clean. |
+| Honest | Szczery | Adjective. In prose: *szczerze* (adverb). |
+| Light | Lekki / Lekko | Adjective (*lekki*) for labels, adverb (*lekko*) in flowing text. |
+| Warm Up | Rozgrzewka | Standard Polish term for warm-up. Natural in this context. |
+| Real Talk | Szczera rozmowa | "Honest conversation." More natural than a literal translation. |
+| Deep Dive | W głąb | "Into the depths." Evocative and natural. |
+| partner | partner / partnerka | Modern and neutral. Use *partner* when gender is unknown; *partnerka* when referring to a female partner. Do not use *ukochany/a* (too romantic) or *chłopak/dziewczyna* (too casual). |
+| intimacy | intymność | Direct equivalent. |
+| values | wartości | Direct equivalent. |
+| growth | rozwój | Personal development/growth. |
+| conflict | konflikt | Direct equivalent. |
+| appreciation | docenienie | Valuing / appreciating someone or something. Use *wdzięczność* (gratitude) only when the English specifically means gratitude rather than appreciation. |
+| communication | komunikacja | Direct equivalent. |
+| vulnerability | wrażliwość | Emotional openness/sensitivity. More natural in Polish emotional contexts than *podatność na zranienie* (literal). |
+| connection | więź | Relational bond. More emotionally resonant than *połączenie* (link/connection in a technical sense). |
+| closeness | bliskość | Direct equivalent. |
+| Life Story | Life Story | **English only — brand term.** |
+| Fall in Love | Fall in Love | **English only — brand term.** |
+| Share an Experience | Share an Experience | **English only — brand term.** |
+
+---
+
+## Decisions Still Open
+
+None — all policy decisions above are settled. The table below documents the key choices and their rationale for the record.
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Gender policy | Option B (neutral-first, masculine fallback) | Slash notation is unnatural in Polish running text |
+| `partner` term | partner / partnerka | Modern, neutral, appropriate for couples app |
+| Brand terms | All English | Feature names; translating adds scope without user benefit |
+| Verb aspect default | Imperfective | More open-ended; suits reflective prompts |

--- a/docs/localization/polish-review-workflow.md
+++ b/docs/localization/polish-review-workflow.md
@@ -1,0 +1,110 @@
+# Polish Localization Review Workflow
+
+## Purpose
+
+This document defines the review process for Polish (`pl`) translations produced by automated agents. It is intended for human reviewers checking translation quality before translations are merged into the app.
+
+---
+
+## Reviewer Rules
+
+1. **Do not edit JSON files directly.** The source translation files (`prompts_pl.json`, `fall_in_love_pl.json`, etc.) are generated and applied programmatically. Manual edits to those files will be overwritten or cause merge conflicts.
+
+2. **Return all corrections as patch JSON.** See the Patch Format section below.
+
+3. **Do not change metadata fields.** `id`, `mode`, `intensity`, `depth`, `topic`, `order`, `chapter`, `style`, `schemaVersion`, `language` — these are structural and must never be altered by a reviewer.
+
+4. **Do not leave empty `text` fields.** An empty or whitespace-only string is invalid and will fail automated tests.
+
+5. **Consult the brief first.** All decisions about register, gender, glossary terms, and sensitive content are settled in `docs/localization/polish-brief.md`. Do not introduce new approaches that contradict the brief.
+
+---
+
+## Patch Format
+
+Submit corrections as a JSON object keyed by prompt ID. Only include prompts that need changes — do not include unchanged entries.
+
+```json
+{
+  "p_couples_light_warmUp_dailyLife_001": {
+    "text": "Corrected Polish prompt text here…",
+    "followUps": [
+      { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Corrected follow-up 1 text" },
+      { "id": "p_couples_light_warmUp_dailyLife_001_fu_2", "text": "Corrected follow-up 2 text" }
+    ]
+  },
+  "p_friends_honest_realTalk_values_042": {
+    "text": "Corrected Polish prompt text here"
+  }
+}
+```
+
+### Patch Rules
+
+| Rule | Detail |
+|---|---|
+| Prompt ID must exist | The key must match an `id` field in the source JSON. Unknown IDs are rejected. |
+| Follow-up IDs must match | Each `id` inside `followUps` must match the original follow-up `id`. Do not add, remove, or renumber follow-ups. |
+| `followUps` is optional | If only the prompt text needs fixing, omit `followUps`. If one or more follow-up texts need fixing, include only those follow-up corrections, each with its original follow-up `id`. The patcher applies follow-up corrections by `id`, not by array position. |
+| Metadata is never edited | Do not include `mode`, `intensity`, `depth`, `topic`, `order`, `style`, or any non-text field. |
+| Empty text is invalid | A `text` value of `""` or whitespace will be rejected by automated tests. |
+
+---
+
+## Review Table Format
+
+When reviewing a batch, copy this Markdown table structure and fill it in. Submit the completed table alongside your patch JSON.
+
+```markdown
+| id | mode | intensity | depth | topic | English | Polish (generated) | Reviewer notes |
+|---|---|---|---|---|---|---|---|
+| p_couples_light_warmUp_dailyLife_001 | couples | light | warmUp | dailyLife | What's one small thing I did today that you noticed? | Jaką jedną małą rzecz, którą dziś zrobiłem(-am), zauważyłeś(-aś)? | Slash notation — use gender-neutral rewrite |
+```
+
+Leave the **Reviewer notes** column blank for entries that need no change. For entries needing correction, note the specific issue (e.g., "wrong verb aspect", "too formal", "brand term should be English", "gender awkwardness").
+
+---
+
+## Sensitive Packet Routing
+
+The full prompt set is divided into thematic review packets. Sensitive packets are reviewed separately and may go to a different reviewer than the general-tone packets.
+
+| Packet name | Contents | Notes |
+|---|---|---|
+| `general` | All non-sensitive prompts | Default reviewer |
+| `couples_intimacy` | Couples mode, intimacy topic | Tender, adult, emotionally safe — see brief |
+| `sex_unfiltered` | Unfiltered intensity, sex topic | Direct but not vulgar — see brief |
+| `hardship_grief_regret` | Hardship, grief, or regret topics across all modes | Gentle, spacious — avoid minimizing language |
+| `family_intergenerational` | Family mode and Life Story prompts | Respectful, culturally grounded Polish family language |
+
+Each packet will be distributed as a standalone Markdown file containing the review table for that group, plus a corresponding patch JSON template. Reviewers should return:
+
+1. The completed review table (notes column filled in)
+2. A patch JSON containing only the entries that need correction
+
+---
+
+## Common Issues to Watch For
+
+- **Slash notation** (`gotowy/a`, `zmęczony/a`) — not allowed per brief; flag and suggest a neutral rewrite
+- **Wrong verb aspect** — imperfective for ongoing states and reflection prompts; perfective only for specific completed events
+- **Formal register** (`Pan/Pani`) — all prompts use informal `ty`; flag any formal forms
+- **Brand terms translated** — `Life Story`, `Fall in Love`, `Share an Experience`, `Deeper Conversations` must remain in English
+- **Glossary deviations** — check against the glossary in `polish-brief.md`; e.g., `więź` not `połączenie`, `wrażliwość` not `podatność na zranienie`
+- **Missing or altered ellipsis** — if English prompt ends with `…`, Polish must too
+- **Truncation risk** — Polish runs 20–40% longer than English; flag phrases that may overflow buttons or labels in the UI
+
+---
+
+## Review Completion Checklist
+
+Before submitting your review packet, confirm:
+
+- [ ] Patch JSON keys match real prompt IDs
+- [ ] No metadata fields included in patch
+- [ ] No empty `text` values in patch
+- [ ] Follow-up IDs match originals (not renumbered)
+- [ ] Slash notation eliminated or flagged
+- [ ] Sensitive prompts reviewed against the brief's guidance for that category
+- [ ] Brand terms left in English
+- [ ] Glossary terms consistent with `polish-brief.md`

--- a/docs/privacy-pl.md
+++ b/docs/privacy-pl.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Polityka prywatności
+---
+
+# Polityka prywatności
+
+**Deeper Conversations**  
+Ostatnia aktualizacja: 24 kwietnia 2026 r.
+
+## Przegląd
+
+Deeper Conversations pomaga ludziom prowadzić bardziej znaczące rozmowy. Twoja prywatność jest prosta: nie zbieramy twoich danych.
+
+## Co zbieramy
+
+Nic. Deeper Conversations nie zbiera, nie przesyła ani nie udostępnia żadnych danych osobowych.
+
+## Co jest przechowywane na twoim urządzeniu
+
+Aplikacja przechowuje lokalnie na twoim urządzeniu następujące dane, aby obsługiwać swoje funkcje:
+
+- Twoje preferencje (domyślne ustawienia sesji i ustawienia aplikacji)
+- Ulubione pytania
+- Postępy w prowadzonych doświadczeniach (Fall in Love, Life Story)
+- Podstawowe liczniki użycia, które pomagają określić, kiedy pokazać opcjonalną prośbę o ocenę w App Store
+
+Te dane nigdy nie opuszczają twojego urządzenia. Nie są wysyłane do nas, do Apple ani do żadnej strony trzeciej.
+
+## Konta i logowanie
+
+Deeper Conversations nie wymaga kont użytkownika i ich nie obsługuje. Nie ma logowania, zbierania adresów e-mail ani rejestracji.
+
+## Analityka i śledzenie
+
+Deeper Conversations nie zawiera narzędzi analitycznych, śledzenia ani frameworków reklamowych. Nie używamy plików cookie, odcisków urządzenia ani żadnych identyfikatorów.
+
+## Zakupy w aplikacji
+
+Deeper Conversations oferuje jednorazowy zakup w aplikacji, który odblokowuje dodatkowe funkcje. Ta transakcja jest w całości przetwarzana przez Apple przez App Store. Nie otrzymujemy ani nie przechowujemy żadnych informacji płatniczych.
+
+## Usługi firm trzecich
+
+Deeper Conversations nie integruje się z żadnymi usługami, API ani SDK firm trzecich poza własnymi frameworkami Apple (StoreKit do zakupów oraz natywną prośbą o ocenę w App Store).
+
+## Prywatność dzieci
+
+Deeper Conversations nie jest skierowana do dzieci poniżej 13 lat. Część treści w aplikacji (na przykład temat Sex) jest przeznaczona dla dorosłych. Nie zbieramy świadomie żadnych informacji od nikogo, w tym od dzieci.
+
+## Usuwanie danych
+
+Ponieważ wszystkie dane są przechowywane lokalnie na twoim urządzeniu, możesz je usunąć w dowolnym momencie, usuwając aplikację. Nie istnieją żadne dane po stronie serwera, które trzeba byłoby usunąć.
+
+## Zmiany w tej polityce
+
+Jeśli zaktualizujemy tę politykę, zmienimy datę u góry tej strony. Ponieważ nie zbieramy danych kontaktowych, nie możemy powiadomić użytkowników bezpośrednio. Zachęcamy do okresowego sprawdzania tej strony.
+
+## Kontakt
+
+Jeśli masz pytania dotyczące tej polityki prywatności, możesz napisać do nas na:
+
+oldmandevs@gmail.com

--- a/scripts/localization/README.md
+++ b/scripts/localization/README.md
@@ -1,0 +1,135 @@
+# scripts/localization — Polish Localization Tooling
+
+Scripts to support the Polish (`pl`) localization of Deeper Conversations.
+These scripts do **not** perform translation. They prepare batches for
+translation agents, apply human corrections, validate candidates, and
+generate reviewer packets.
+
+---
+
+## Intended Order
+
+### Before translation agents run
+
+**Step 1 — Extract batch files for translation agents**
+
+```bash
+python3 scripts/localization/extract_polish_batches.py
+```
+
+Reads `Connections/Data/prompts_en.json` and writes one JSON batch file per
+tone/context group to `/tmp/polish_batches/`. No Polish file is created.
+
+Each batch file contains:
+- `group` — group name
+- `tone_note` — guidance for the translation agent
+- `brief_ref` — path to the Polish localization brief
+- `count` — number of prompts in this batch
+- `prompts` — array of prompts with id, mode, intensity, depth, topic, text, followUps
+
+### After translation agents produce corrections
+
+**Step 2 — Apply patch corrections**
+
+```bash
+python3 scripts/localization/apply_polish_patch.py \
+    --patch /tmp/my_agent_output.json
+```
+
+Applies explicit patch JSON to `Connections/Data/prompts_pl.json`.
+If the Polish file does not exist, it is **created** from the English
+structure (language set to `pl`) before the patch is applied.
+
+The patch file format is:
+```json
+{
+  "p_couples_light_warmUp_dailyLife_001": {
+    "text": "Polish prompt text here…",
+    "followUps": [
+      { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Follow-up text" }
+    ]
+  }
+}
+```
+
+Corrections are applied by id, not by array position. Metadata fields
+(mode, intensity, depth, topic, style, order) are rejected.
+
+### After all patches are applied
+
+**Step 3 — Validate the candidate file**
+
+```bash
+python3 scripts/localization/validate_polish_candidate.py
+```
+
+Checks `Connections/Data/prompts_pl.json` against the English source.
+Exits non-zero if any check fails. Run this before committing.
+
+### For human review
+
+**Step 4 — Generate Markdown review packets**
+
+```bash
+python3 scripts/localization/generate_polish_review_packets.py \
+    --output /tmp/polish_review_packets
+```
+
+Generates Markdown files with English/Polish comparison tables,
+organized by sensitive group. Reviewers return corrections as patch JSON
+(see `docs/localization/polish-review-workflow.md`).
+
+---
+
+## Script Reference
+
+| Script | Purpose |
+|---|---|
+| `extract_polish_batches.py` | Split English prompts into agent batches |
+| `apply_polish_patch.py` | Apply patch JSON to prompts_pl.json |
+| `validate_polish_candidate.py` | Validate prompts_pl.json against English |
+| `generate_polish_review_packets.py` | Generate Markdown review tables |
+
+All scripts accept `--help` for full usage.
+
+---
+
+## Where files go
+
+| Artifact | Location |
+|---|---|
+| Agent batch files | `/tmp/polish_batches/` (not committed) |
+| Review packets | `/tmp/polish_review_packets/` (not committed) |
+| Polish prompts file | `Connections/Data/prompts_pl.json` (committed when ready) |
+
+---
+
+## Tone/Context Groups (extract script)
+
+Prompts are assigned to exactly one group. Rules are checked in order;
+first match wins. All 598 English prompts must be assigned.
+
+| Group | Rule | Count |
+|---|---|---|
+| `sex_unfiltered` | topic = sex | 41 |
+| `couples_intimacy` | mode = couples AND topic = intimacy | 13 |
+| `family_intergenerational` | mode = family | 132 |
+| `friends_playful_closeness` | mode = friends | 122 |
+| `solo_reflection` | mode = soloReflection | 145 |
+| `communication_conflict` | topic in {communication, conflict} | 38 |
+| `connection_appreciation` | topic in {appreciation, emotions} | 42 |
+| `identity_values_growth` | topic in {identity, values, growth} | 21 |
+| `past_family_memory` | topic in {past, parenting} | 25 |
+| `light_warmup_everyday` | intensity = light AND depth = warmUp | 12 |
+| `hardship_grief_regret` | catch-all (couples/dailyLife deeper levels) | 7 |
+| **Total** | | **598** |
+
+---
+
+## Notes
+
+- These scripts do not alter Spanish translation files.
+- `apply_polish_patch.py` is the only script that creates `prompts_pl.json`.
+- All other Polish JSON banks (`fall_in_love_pl.json`, etc.) are handled
+  separately and are not covered by these scripts.
+- The Xcode build does not depend on these scripts.

--- a/scripts/localization/README.md
+++ b/scripts/localization/README.md
@@ -1,9 +1,9 @@
-# scripts/localization — Polish Localization Tooling
+# scripts/localization — Localization Tooling
 
-Scripts to support the Polish (`pl`) localization of Deeper Conversations.
-These scripts do **not** perform translation. They prepare batches for
-translation agents, apply human corrections, validate candidates, and
-generate reviewer packets.
+Scripts to support locale translations (Polish `pl`, Spanish `es`, and future locales)
+of Deeper Conversations. These scripts do **not** perform translation. They prepare
+batches for translation agents, apply corrections, validate candidates, generate reviewer
+packets, and merge UI strings into `Localizable.xcstrings`.
 
 ---
 
@@ -18,33 +18,33 @@ python3 scripts/localization/extract_polish_batches.py
 ```
 
 Reads `Connections/Data/prompts_en.json` and writes one JSON batch file per
-tone/context group to `/tmp/polish_batches/`. No Polish file is created.
+tone/context group to `/tmp/polish_batches/`. No locale file is created.
 
 Each batch file contains:
 - `group` — group name
 - `tone_note` — guidance for the translation agent
-- `brief_ref` — path to the Polish localization brief
+- `brief_ref` — path to the localization brief
 - `count` — number of prompts in this batch
 - `prompts` — array of prompts with id, mode, intensity, depth, topic, text, followUps
 
 ### After translation agents produce corrections
 
-**Step 2 — Apply patch corrections**
+**Step 2 — Apply patch corrections to a prompt bank**
 
 ```bash
 python3 scripts/localization/apply_polish_patch.py \
     --patch /tmp/my_agent_output.json
 ```
 
-Applies explicit patch JSON to `Connections/Data/prompts_pl.json`.
-If the Polish file does not exist, it is **created** from the English
-structure (language set to `pl`) before the patch is applied.
+Applies explicit patch JSON to `Connections/Data/prompts_pl.json` (or any target
+locale file via `--target`). If the target file does not exist, it is **created**
+from the English structure before the patch is applied.
 
 The patch file format is:
 ```json
 {
   "p_couples_light_warmUp_dailyLife_001": {
-    "text": "Polish prompt text here…",
+    "text": "Translated prompt text here…",
     "followUps": [
       { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Follow-up text" }
     ]
@@ -55,27 +55,50 @@ The patch file format is:
 Corrections are applied by id, not by array position. Metadata fields
 (mode, intensity, depth, topic, style, order) are rejected.
 
-### After all patches are applied
-
-**Step 3 — Validate the candidate file**
+**Step 3 — Merge UI strings into Localizable.xcstrings**
 
 ```bash
-python3 scripts/localization/validate_polish_candidate.py
+python3 scripts/localization/merge_xcstrings_locale.py \
+    --locale pl \
+    --translations /tmp/polish_ui_translations.json
 ```
 
-Checks `Connections/Data/prompts_pl.json` against the English source.
+Inserts a locale entry for each key in the translations file into
+`Connections/Localizable.xcstrings`. Validates placeholder parity, rejects
+unknown keys, rejects empty values, and never touches `shouldTranslate: false`
+entries or existing localizations for other locales.
+
+Translations file format (key → value):
+```json
+{
+  "common.button.back": "Wstecz",
+  "lifeStoryChapter.progress": "Rozdział %1$lld z %2$lld · %3$@"
+}
+```
+
+### After all patches are applied
+
+**Step 4 — Validate the candidate prompt bank**
+
+```bash
+python3 scripts/localization/validate_polish_candidate.py \
+    --candidate Connections/Data/prompts_pl.json
+```
+
+Checks a translated prompt bank against the English source.
 Exits non-zero if any check fails. Run this before committing.
+Accepts `--locale` to validate non-Polish files (default: `pl`).
 
 ### For human review
 
-**Step 4 — Generate Markdown review packets**
+**Step 5 — Generate Markdown review packets**
 
 ```bash
 python3 scripts/localization/generate_polish_review_packets.py \
     --output /tmp/polish_review_packets
 ```
 
-Generates Markdown files with English/Polish comparison tables,
+Generates Markdown files with English/translated comparison tables,
 organized by sensitive group. Reviewers return corrections as patch JSON
 (see `docs/localization/polish-review-workflow.md`).
 
@@ -83,12 +106,13 @@ organized by sensitive group. Reviewers return corrections as patch JSON
 
 ## Script Reference
 
-| Script | Purpose |
-|---|---|
-| `extract_polish_batches.py` | Split English prompts into agent batches |
-| `apply_polish_patch.py` | Apply patch JSON to prompts_pl.json |
-| `validate_polish_candidate.py` | Validate prompts_pl.json against English |
-| `generate_polish_review_packets.py` | Generate Markdown review tables |
+| Script | Purpose | Key flags |
+|---|---|---|
+| `extract_polish_batches.py` | Split English prompts into agent batches | `--source`, `--output`, `--dry-run` |
+| `apply_polish_patch.py` | Apply patch JSON to a translated prompt bank | `--source`, `--target`, `--patch`, `--dry-run` |
+| `merge_xcstrings_locale.py` | Merge UI translations into Localizable.xcstrings | `--catalog`, `--locale`, `--translations`, `--dry-run` |
+| `validate_polish_candidate.py` | Validate a translated prompt bank against English | `--source`, `--candidate`, `--locale`, `--verbose` |
+| `generate_polish_review_packets.py` | Generate Markdown review tables | `--source-en`, `--source-pl`, `--output` |
 
 All scripts accept `--help` for full usage.
 
@@ -100,7 +124,9 @@ All scripts accept `--help` for full usage.
 |---|---|
 | Agent batch files | `/tmp/polish_batches/` (not committed) |
 | Review packets | `/tmp/polish_review_packets/` (not committed) |
-| Polish prompts file | `Connections/Data/prompts_pl.json` (committed when ready) |
+| Polish prompts | `Connections/Data/prompts_pl.json` (committed when ready) |
+| Spanish prompts | `Connections/Data/prompts_es.json` (committed) |
+| UI strings | `Connections/Localizable.xcstrings` (committed) |
 
 ---
 
@@ -128,8 +154,8 @@ first match wins. All 598 English prompts must be assigned.
 
 ## Notes
 
-- These scripts do not alter Spanish translation files.
-- `apply_polish_patch.py` is the only script that creates `prompts_pl.json`.
-- All other Polish JSON banks (`fall_in_love_pl.json`, etc.) are handled
-  separately and are not covered by these scripts.
+- `apply_polish_patch.py` is the only script that creates `prompts_pl.json` from scratch.
+- `merge_xcstrings_locale.py` never creates new xcstrings keys — it only adds locale entries to existing keys.
+- `validate_polish_candidate.py` works for any locale via `--locale`; defaults to `pl`.
+- All other locale JSON banks (`fall_in_love_pl.json`, `life_story_pl.json`, etc.) are handled separately and are not covered by `apply_polish_patch.py`.
 - The Xcode build does not depend on these scripts.

--- a/scripts/localization/apply_polish_patch.py
+++ b/scripts/localization/apply_polish_patch.py
@@ -2,16 +2,17 @@
 """
 apply_polish_patch.py
 
-Apply an explicit patch JSON to prompts_pl.json. If the target Polish file
-does not exist, it is created by copying the English structure with language
-set to "pl" (text fields are preserved as-is from English until translated).
+Apply an explicit patch JSON to a translated prompt bank (e.g. prompts_pl.json,
+prompts_es.json). If the target file does not exist, it is created by copying
+the English structure with language set to the target locale (text fields are
+preserved as-is from English until translated).
 
 Patch format:
   {
     "p_couples_light_warmUp_dailyLife_001": {
-      "text": "Poprawiony tekst promptu…",
+      "text": "Translated prompt text…",
       "followUps": [
-        { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Poprawiony follow-up" }
+        { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Translated follow-up" }
       ]
     }
   }
@@ -34,6 +35,11 @@ Usage:
       --target Connections/Data/prompts_pl.json \\
       --patch /tmp/my_batch_corrections.json \\
       --dry-run
+
+  python3 scripts/localization/apply_polish_patch.py \\
+      --source Connections/Data/prompts_en.json \\
+      --target Connections/Data/prompts_es.json \\
+      --patch /tmp/es_corrections.json
 """
 
 import argparse
@@ -168,7 +174,7 @@ def apply_patch(target: dict, patch: dict, dry_run: bool = False) -> tuple[int, 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Apply explicit patch JSON corrections to prompts_pl.json."
+        description="Apply explicit patch JSON corrections to a translated prompt bank."
     )
     parser.add_argument(
         "--source",

--- a/scripts/localization/apply_polish_patch.py
+++ b/scripts/localization/apply_polish_patch.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""
+apply_polish_patch.py
+
+Apply an explicit patch JSON to prompts_pl.json. If the target Polish file
+does not exist, it is created by copying the English structure with language
+set to "pl" (text fields are preserved as-is from English until translated).
+
+Patch format:
+  {
+    "p_couples_light_warmUp_dailyLife_001": {
+      "text": "Poprawiony tekst promptu…",
+      "followUps": [
+        { "id": "p_couples_light_warmUp_dailyLife_001_fu_1", "text": "Poprawiony follow-up" }
+      ]
+    }
+  }
+
+Rules:
+  - Prompt id must exist in the target file.
+  - Follow-up corrections are applied by id, not by array position.
+  - Follow-up id must exist in the target prompt.
+  - Empty or whitespace-only text is rejected.
+  - Metadata fields (mode, intensity, depth, topic, style, order) are never accepted.
+  - A patch entry must contain "text", "followUps", or both — empty objects are rejected.
+  - A patch file must apply at least one correction — zero-correction runs are rejected.
+
+Usage:
+  python3 scripts/localization/apply_polish_patch.py \\
+      --patch /tmp/my_batch_corrections.json
+
+  python3 scripts/localization/apply_polish_patch.py \\
+      --source Connections/Data/prompts_en.json \\
+      --target Connections/Data/prompts_pl.json \\
+      --patch /tmp/my_batch_corrections.json \\
+      --dry-run
+"""
+
+import argparse
+import copy
+import json
+import os
+import sys
+
+METADATA_FIELDS = {"mode", "intensity", "depth", "topic", "style", "order",
+                   "id", "schemaVersion", "language"}
+
+
+def load_json(path: str) -> dict:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: str, data: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+        f.write("\n")
+
+
+def create_polish_from_english(en_data: dict) -> dict:
+    """Copy English structure and set language to pl."""
+    pl = copy.deepcopy(en_data)
+    pl["language"] = "pl"
+    return pl
+
+
+def apply_patch(target: dict, patch: dict, dry_run: bool = False) -> tuple[int, list[str]]:
+    """
+    Apply patch entries to target in-place.
+
+    Returns (applied_count, warnings_list). Raises SystemExit on fatal errors.
+    """
+    # Build prompt index by id
+    prompt_index: dict[str, dict] = {}
+    for p in target.get("prompts", []):
+        prompt_index[p["id"]] = p
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    applied = 0
+
+    for prompt_id, corrections in patch.items():
+        # --- Validate prompt id ---
+        if prompt_id not in prompt_index:
+            errors.append(f"UNKNOWN prompt id: {prompt_id}")
+            continue
+
+        # --- Reject metadata fields in patch ---
+        bad_fields = METADATA_FIELDS & set(corrections.keys())
+        if bad_fields:
+            errors.append(
+                f"{prompt_id}: patch must not include metadata fields: {sorted(bad_fields)}"
+            )
+            continue
+
+        # --- Reject no-op entries ---
+        if "text" not in corrections and "followUps" not in corrections:
+            errors.append(
+                f"{prompt_id}: patch entry contains neither 'text' nor 'followUps' — no-op entries are not allowed"
+            )
+            continue
+
+        prompt = prompt_index[prompt_id]
+
+        # --- Apply prompt text ---
+        if "text" in corrections:
+            new_text = corrections["text"]
+            if not isinstance(new_text, str) or not new_text.strip():
+                errors.append(f"{prompt_id}: 'text' is empty or whitespace")
+                continue
+            if not dry_run:
+                prompt["text"] = new_text
+            applied += 1
+
+        # --- Apply follow-up corrections ---
+        if "followUps" in corrections:
+            fu_index: dict[str, dict] = {fu["id"]: fu for fu in prompt.get("followUps", [])}
+            fu_corrections = corrections["followUps"]
+
+            if not isinstance(fu_corrections, list):
+                errors.append(f"{prompt_id}: 'followUps' must be a list")
+                continue
+
+            for fu_patch in fu_corrections:
+                if not isinstance(fu_patch, dict):
+                    errors.append(f"{prompt_id}: follow-up entry must be an object")
+                    continue
+
+                fu_id = fu_patch.get("id")
+                if not fu_id:
+                    errors.append(f"{prompt_id}: follow-up patch is missing 'id'")
+                    continue
+
+                if fu_id not in fu_index:
+                    errors.append(f"{prompt_id}: UNKNOWN follow-up id: {fu_id}")
+                    continue
+
+                fu_text = fu_patch.get("text")
+                if fu_text is None:
+                    warnings.append(f"{prompt_id} / {fu_id}: no 'text' in follow-up patch — skipped")
+                    continue
+
+                if not isinstance(fu_text, str) or not fu_text.strip():
+                    errors.append(f"{prompt_id} / {fu_id}: follow-up 'text' is empty or whitespace")
+                    continue
+
+                # Reject metadata in follow-up patch
+                bad_fu_fields = METADATA_FIELDS & set(fu_patch.keys()) - {"id"}
+                if bad_fu_fields:
+                    errors.append(
+                        f"{prompt_id} / {fu_id}: follow-up patch must not include "
+                        f"metadata fields: {sorted(bad_fu_fields)}"
+                    )
+                    continue
+
+                if not dry_run:
+                    fu_index[fu_id]["text"] = fu_text
+                applied += 1
+
+    if errors:
+        print("\nERRORS (patch not fully applied):", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return applied, warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Apply explicit patch JSON corrections to prompts_pl.json."
+    )
+    parser.add_argument(
+        "--source",
+        default="Connections/Data/prompts_en.json",
+        help="English source file (used to create target if it does not exist)",
+    )
+    parser.add_argument(
+        "--target",
+        default="Connections/Data/prompts_pl.json",
+        help="Polish target file to patch (created from source if absent)",
+    )
+    parser.add_argument(
+        "--patch",
+        required=True,
+        help="Path to patch JSON file",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report without writing the target file",
+    )
+    args = parser.parse_args()
+
+    # Load patch
+    if not os.path.exists(args.patch):
+        print(f"ERROR: patch file not found: {args.patch}", file=sys.stderr)
+        return 1
+
+    with open(args.patch, encoding="utf-8") as f:
+        patch = json.load(f)
+
+    if not isinstance(patch, dict):
+        print("ERROR: patch file must be a JSON object keyed by prompt id", file=sys.stderr)
+        return 1
+
+    if not patch:
+        print("ERROR: patch file is empty — nothing to apply", file=sys.stderr)
+        return 1
+
+    # Load or create target
+    if os.path.exists(args.target):
+        target = load_json(args.target)
+        print(f"Loaded target: {args.target}")
+    else:
+        if not os.path.exists(args.source):
+            print(f"ERROR: source file not found: {args.source}", file=sys.stderr)
+            return 1
+        source = load_json(args.source)
+        target = create_polish_from_english(source)
+        print(f"Target {args.target} does not exist — created from English source.")
+
+    # Apply
+    applied, warnings = apply_patch(target, patch, dry_run=args.dry_run)
+
+    for w in warnings:
+        print(f"WARNING: {w}")
+
+    if applied == 0:
+        print(
+            "ERROR: patch applied 0 corrections — ensure entries contain valid 'text' or 'followUps'.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.dry_run:
+        print(f"\nDry run — {applied} correction(s) validated. No file written.")
+        return 0
+
+    save_json(args.target, target)
+    print(f"\nApplied {applied} correction(s). Saved: {args.target}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/localization/extract_polish_batches.py
+++ b/scripts/localization/extract_polish_batches.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""
+extract_polish_batches.py
+
+Read prompts_en.json and split all prompts into tone/context batch files
+for Polish translation agents. Each batch file contains the prompts a single
+agent should translate, plus a tone note for that agent.
+
+Output: /tmp/polish_batches/<group_name>.json  (one file per group)
+
+Usage:
+  python3 scripts/localization/extract_polish_batches.py
+  python3 scripts/localization/extract_polish_batches.py --source Connections/Data/prompts_en.json
+  python3 scripts/localization/extract_polish_batches.py --output /tmp/polish_batches
+  python3 scripts/localization/extract_polish_batches.py --dry-run
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# ---------------------------------------------------------------------------
+# Group definitions — must be mutually exclusive and exhaustive.
+# Assignment rules are evaluated in order; the first match wins.
+# ---------------------------------------------------------------------------
+
+GROUP_META = {
+    "light_warmup_everyday": {
+        "tone_note": (
+            "Warm, playful, low-pressure. These are light-intensity warm-up prompts about "
+            "everyday shared life. Use informal ty. Keep the energy easy and conversational. "
+            "Avoid heavy vocabulary. Imperfective verbs throughout."
+        ),
+    },
+    "connection_appreciation": {
+        "tone_note": (
+            "Warm and emotionally affirming. Topics cover appreciation, gratitude, and emotional "
+            "connection. Use tender language: więź, bliskość, docenienie. Imperfective verbs. "
+            "Register is sincere but not sentimental."
+        ),
+    },
+    "communication_conflict": {
+        "tone_note": (
+            "Direct but not harsh. Topics cover how partners communicate and navigate conflict. "
+            "Honest register. Avoid confrontational framing — prompts are invitations, not accusations. "
+            "Imperfective verbs for ongoing patterns; perfective only for specific completed events."
+        ),
+    },
+    "identity_values_growth": {
+        "tone_note": (
+            "Reflective and grounded. Topics cover personal identity, core values, and growth. "
+            "Thoughtful register. Use natural Polish for introspective questions. "
+            "Imperfective verbs for ongoing states and reflection."
+        ),
+    },
+    "past_family_memory": {
+        "tone_note": (
+            "Gentle and spacious. Topics include the past, memory, parenting, and family history. "
+            "Leave room for the respondent to sit with difficulty. Avoid minimizing language. "
+            "Polish family language carries cultural weight — use it with care."
+        ),
+    },
+    "couples_intimacy": {
+        "tone_note": (
+            "Tender, adult, and emotionally safe. Couples mode, intimacy topic. "
+            "Use warm relational language: bliskość, czułość, intymność. "
+            "Not clinical and not crude. See polish-brief.md section 'Couples / Intimacy'."
+        ),
+    },
+    "sex_unfiltered": {
+        "tone_note": (
+            "Direct but not vulgar. All sex-topic prompts, all modes. "
+            "Polish has a range of registers — stay in the emotionally honest adult register. "
+            "Avoid clinical terms (stosunek płciowy) and slang. "
+            "See polish-brief.md section 'Sex / Unfiltered'."
+        ),
+    },
+    "hardship_grief_regret": {
+        "tone_note": (
+            "Emotionally honest and spacious. These prompts address daily tension, invisible "
+            "expectations, and emotional strain at deeper intensity levels. "
+            "Gentle and non-minimizing. Imperfective verbs. "
+            "See polish-brief.md section 'Hardship / Grief / Regret'."
+        ),
+    },
+    "solo_reflection": {
+        "tone_note": (
+            "Introspective and self-directed. Solo Reflection mode — the respondent reflects "
+            "on themselves, not a partner. Use informal ty. Warm but not effusive. "
+            "Imperfective verbs for ongoing states and habits."
+        ),
+    },
+    "friends_playful_closeness": {
+        "tone_note": (
+            "Warm and casual, not romance-coded. Friends mode — playful where the English is "
+            "playful, earnest where earnest. Use informal ty. Avoid overly formal or stiff phrasing. "
+            "See polish-brief.md section 'Friends'."
+        ),
+    },
+    "family_intergenerational": {
+        "tone_note": (
+            "Respectful and grounded. Family mode — prompts may address parents, grandparents, "
+            "or siblings. Polish family language carries strong cultural weight — use it with care. "
+            "See polish-brief.md section 'Family / Intergenerational'."
+        ),
+    },
+}
+
+# Evaluation order matters — first matching rule wins.
+_ORDERED_GROUP_NAMES = [
+    "sex_unfiltered",
+    "couples_intimacy",
+    "family_intergenerational",
+    "friends_playful_closeness",
+    "solo_reflection",
+    "communication_conflict",
+    "connection_appreciation",
+    "identity_values_growth",
+    "past_family_memory",
+    "light_warmup_everyday",
+    "hardship_grief_regret",   # catch-all — must be last
+]
+
+
+def assign_group(prompt: dict) -> str:
+    """Return the group name for a single prompt. Never returns None."""
+    mode      = prompt["mode"]
+    intensity = prompt["intensity"]
+    depth     = prompt["depth"]
+    topic     = prompt["topic"]
+
+    # 1. Sex prompts — sensitive, isolated regardless of mode
+    if topic == "sex":
+        return "sex_unfiltered"
+
+    # 2. Couples-specific intimacy — tender adult content, smaller packet
+    if mode == "couples" and topic == "intimacy":
+        return "couples_intimacy"
+
+    # 3-5. Mode-based groups — all remaining prompts for that mode
+    if mode == "family":
+        return "family_intergenerational"
+    if mode == "friends":
+        return "friends_playful_closeness"
+    if mode == "soloReflection":
+        return "solo_reflection"
+
+    # 6-11. Remaining prompts are all couples mode at this point.
+    if topic in ("communication", "conflict"):
+        return "communication_conflict"
+    if topic in ("appreciation", "emotions"):
+        return "connection_appreciation"
+    if topic in ("identity", "values", "growth"):
+        return "identity_values_growth"
+    if topic in ("past", "parenting"):
+        return "past_family_memory"
+    if intensity == "light" and depth == "warmUp":
+        return "light_warmup_everyday"
+
+    # Catch-all: couples/dailyLife at honest or unfiltered depths
+    return "hardship_grief_regret"
+
+
+def build_prompt_entry(p: dict) -> dict:
+    """Return only the fields a translation agent needs."""
+    return {
+        "id":        p["id"],
+        "mode":      p["mode"],
+        "intensity": p["intensity"],
+        "depth":     p["depth"],
+        "topic":     p["topic"],
+        "text":      p["text"],
+        "followUps": [
+            {"id": fu["id"], "style": fu["style"], "text": fu["text"]}
+            for fu in p.get("followUps", [])
+        ],
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Split prompts_en.json into tone/context batches for Polish translation agents."
+    )
+    parser.add_argument(
+        "--source",
+        default="Connections/Data/prompts_en.json",
+        help="Path to prompts_en.json (default: Connections/Data/prompts_en.json)",
+    )
+    parser.add_argument(
+        "--output",
+        default="/tmp/polish_batches",
+        help="Output directory for batch files (default: /tmp/polish_batches)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print group counts without writing files",
+    )
+    args = parser.parse_args()
+
+    # Load source
+    if not os.path.exists(args.source):
+        print(f"ERROR: source file not found: {args.source}", file=sys.stderr)
+        return 1
+
+    with open(args.source, encoding="utf-8") as f:
+        source = json.load(f)
+
+    prompts = source.get("prompts", [])
+    total_en = len(prompts)
+
+    # Assign groups
+    groups: dict[str, list] = {name: [] for name in _ORDERED_GROUP_NAMES}
+    review_required: list = []
+
+    for p in prompts:
+        group = assign_group(p)
+        if group in groups:
+            groups[group].append(build_prompt_entry(p))
+        else:
+            review_required.append(p)
+
+    # Verify coverage
+    total_assigned = sum(len(v) for v in groups.values())
+    unmatched = total_assigned + len(review_required)
+
+    print(f"\nPrompt counts by group:")
+    print(f"  {'Group':<32} {'Count':>5}")
+    print(f"  {'-'*32} {'-'*5}")
+    for name in _ORDERED_GROUP_NAMES:
+        print(f"  {name:<32} {len(groups[name]):>5}")
+    print(f"  {'-'*32} {'-'*5}")
+    print(f"  {'TOTAL ASSIGNED':<32} {total_assigned:>5}")
+    print(f"  {'English source total':<32} {total_en:>5}")
+
+    if review_required:
+        print(f"\nWARNING: {len(review_required)} prompt(s) placed in review_required:")
+        for p in review_required:
+            print(f"  {p['id']}")
+
+    if total_assigned != total_en:
+        print(
+            f"\nFAIL: assigned {total_assigned} but English has {total_en} — mismatch!",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nAll {total_en} prompts assigned. Coverage verified.")
+
+    if args.dry_run:
+        print("\nDry run — no files written.")
+        return 0
+
+    # Write output
+    os.makedirs(args.output, exist_ok=True)
+
+    for name in _ORDERED_GROUP_NAMES:
+        batch = {
+            "group":      name,
+            "tone_note":  GROUP_META[name]["tone_note"],
+            "brief_ref":  "docs/localization/polish-brief.md",
+            "count":      len(groups[name]),
+            "prompts":    groups[name],
+        }
+        out_path = os.path.join(args.output, f"{name}.json")
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(batch, f, ensure_ascii=False, indent=2)
+
+    if review_required:
+        out_path = os.path.join(args.output, "review_required.json")
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump({"group": "review_required", "prompts": review_required}, f,
+                      ensure_ascii=False, indent=2)
+
+    print(f"\nBatch files written to: {args.output}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/localization/generate_polish_review_packets.py
+++ b/scripts/localization/generate_polish_review_packets.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+generate_polish_review_packets.py
+
+Generate Markdown review packets for Polish-speaking reviewers after
+prompts_pl.json has been produced by translation agents.
+
+Each packet contains a table:
+  id | mode | intensity | depth | topic | English | Polish | Reviewer notes
+
+Packets generated:
+  - general.md           (all prompts not in other packets)
+  - couples_intimacy.md  (mode=couples, topic=intimacy)
+  - sex_unfiltered.md    (topic=sex)
+  - hardship_grief_regret.md
+  - family_intergenerational.md (mode=family)
+
+Usage:
+  python3 scripts/localization/generate_polish_review_packets.py \\
+      --output /tmp/polish_review_packets
+
+  python3 scripts/localization/generate_polish_review_packets.py \\
+      --source-en Connections/Data/prompts_en.json \\
+      --source-pl Connections/Data/prompts_pl.json \\
+      --output /tmp/polish_review_packets
+"""
+
+import argparse
+import json
+import os
+import sys
+
+BRIEF_PATH = "docs/localization/polish-brief.md"
+
+PACKET_DEFS = [
+    {
+        "name":     "sex_unfiltered",
+        "heading":  "Sex / Unfiltered",
+        "guidance": (
+            "These prompts address sexual topics directly. "
+            "Use the emotionally honest adult register — not clinical, not vulgar. "
+            "See polish-brief.md section 'Sex / Unfiltered'."
+        ),
+        "filter":   lambda p: p["topic"] == "sex",
+    },
+    {
+        "name":     "couples_intimacy",
+        "heading":  "Couples / Intimacy",
+        "guidance": (
+            "Tender, adult, emotionally safe. "
+            "Use warm relational language: bliskość, czułość, intymność. "
+            "See polish-brief.md section 'Couples / Intimacy'."
+        ),
+        "filter":   lambda p: p["mode"] == "couples" and p["topic"] == "intimacy",
+    },
+    {
+        "name":     "hardship_grief_regret",
+        "heading":  "Hardship / Grief / Regret",
+        "guidance": (
+            "Gentle, respectful, and spacious. Leave room for difficulty. "
+            "Avoid minimizing language (to nic wielkiego, każdemu się zdarza). "
+            "See polish-brief.md section 'Hardship / Grief / Regret'."
+        ),
+        "filter":   lambda p: (
+            p["mode"] == "couples"
+            and p["topic"] == "dailyLife"
+            and not (p["intensity"] == "light" and p["depth"] == "warmUp")
+        ),
+    },
+    {
+        "name":     "family_intergenerational",
+        "heading":  "Family / Intergenerational",
+        "guidance": (
+            "Respectful and grounded. Polish family language carries strong cultural weight. "
+            "Appropriate warmth for parents, grandparents, siblings. "
+            "See polish-brief.md section 'Family / Intergenerational'."
+        ),
+        "filter":   lambda p: p["mode"] == "family",
+    },
+]
+
+# 'general' catches everything not matched by the named packets above
+def is_named_packet(p: dict) -> bool:
+    return any(pkt["filter"](p) for pkt in PACKET_DEFS)
+
+
+def escape_cell(text: str) -> str:
+    """Escape pipe characters so they don't break Markdown table cells."""
+    return text.replace("|", "\\|")
+
+
+def build_table(pairs: list[tuple[dict, dict]]) -> str:
+    lines = [
+        "| id | mode | intensity | depth | topic | English | Polish | Reviewer notes |",
+        "|---|---|---|---|---|---|---|---|",
+    ]
+    for en_p, pl_p in pairs:
+        row = "| {} | {} | {} | {} | {} | {} | {} | |".format(
+            escape_cell(en_p.get("id", "")),
+            escape_cell(en_p.get("mode", "")),
+            escape_cell(en_p.get("intensity", "")),
+            escape_cell(en_p.get("depth", "")),
+            escape_cell(en_p.get("topic", "")),
+            escape_cell(en_p.get("text", "")),
+            escape_cell(pl_p.get("text", "")),
+        )
+        lines.append(row)
+        # Follow-up rows (indented id to distinguish)
+        en_fus = en_p.get("followUps", [])
+        pl_fus = pl_p.get("followUps", [])
+        for en_fu, pl_fu in zip(en_fus, pl_fus):
+            fu_row = "| ↳ {} | | | | | {} | {} | |".format(
+                escape_cell(en_fu.get("id", "")),
+                escape_cell(en_fu.get("text", "")),
+                escape_cell(pl_fu.get("text", "")),
+            )
+            lines.append(fu_row)
+    return "\n".join(lines)
+
+
+def write_packet(
+    path: str,
+    heading: str,
+    guidance: str,
+    pairs: list[tuple[dict, dict]],
+) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(f"# Polish Review Packet: {heading}\n\n")
+        f.write("## Instructions for Reviewers\n\n")
+        f.write(f"- **Always read** `{BRIEF_PATH}` before reviewing.\n")
+        f.write("- **Do not edit JSON files directly** — they are applied programmatically.\n")
+        f.write(
+            "- **Return corrections** as explicit patch JSON "
+            "(see `polish-review-workflow.md` for format).\n\n"
+        )
+        f.write(f"## Tone Guidance\n\n{guidance}\n\n")
+        f.write(f"## Prompts ({len(pairs)})\n\n")
+        if pairs:
+            f.write(build_table(pairs))
+        else:
+            f.write("_No prompts in this packet._")
+        f.write("\n")
+
+
+def load_json(path: str) -> dict:
+    if not os.path.exists(path):
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate Markdown review packets from prompts_en.json + prompts_pl.json."
+    )
+    parser.add_argument(
+        "--source-en",
+        default="Connections/Data/prompts_en.json",
+        help="English source file",
+    )
+    parser.add_argument(
+        "--source-pl",
+        default="Connections/Data/prompts_pl.json",
+        help="Polish candidate file (must exist before running this script)",
+    )
+    parser.add_argument(
+        "--output",
+        default="/tmp/polish_review_packets",
+        help="Output directory for Markdown packets (default: /tmp/polish_review_packets)",
+    )
+    args = parser.parse_args()
+
+    en_data = load_json(args.source_en)
+    pl_data = load_json(args.source_pl)
+
+    en_prompts = en_data.get("prompts", [])
+    pl_prompts = pl_data.get("prompts", [])
+
+    if len(en_prompts) != len(pl_prompts):
+        print(
+            f"ERROR: prompt count mismatch — en={len(en_prompts)}, pl={len(pl_prompts)}. "
+            "Run validate_polish_candidate.py first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Build id → pl lookup
+    pl_by_id = {p["id"]: p for p in pl_prompts}
+
+    os.makedirs(args.output, exist_ok=True)
+
+    written_ids: set[str] = set()
+
+    # Named packets
+    for pkt in PACKET_DEFS:
+        pairs = [
+            (en_p, pl_by_id[en_p["id"]])
+            for en_p in en_prompts
+            if pkt["filter"](en_p) and en_p["id"] in pl_by_id
+        ]
+        out_path = os.path.join(args.output, f"{pkt['name']}.md")
+        write_packet(out_path, pkt["heading"], pkt["guidance"], pairs)
+        for en_p, _ in pairs:
+            written_ids.add(en_p["id"])
+        print(f"  {pkt['name']}.md — {len(pairs)} prompts")
+
+    # General packet: everything not in a named packet
+    general_pairs = [
+        (en_p, pl_by_id[en_p["id"]])
+        for en_p in en_prompts
+        if en_p["id"] not in written_ids and en_p["id"] in pl_by_id
+    ]
+    out_path = os.path.join(args.output, "general.md")
+    write_packet(
+        out_path,
+        "General",
+        (
+            "These prompts cover the full range of non-sensitive topics and modes. "
+            "Follow the register guidance in polish-brief.md: warm, natural, informal ty, "
+            "no bureaucratic or literal English phrasing."
+        ),
+        general_pairs,
+    )
+    print(f"  general.md — {len(general_pairs)} prompts")
+
+    total = sum(
+        len([
+            en_p for en_p in en_prompts if pkt["filter"](en_p)
+        ])
+        for pkt in PACKET_DEFS
+    ) + len(general_pairs)
+
+    print(f"\nTotal prompts across all packets: {total} / {len(en_prompts)}")
+    print(f"Review packets written to: {args.output}/")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/localization/merge_xcstrings_locale.py
+++ b/scripts/localization/merge_xcstrings_locale.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+merge_xcstrings_locale.py
+
+Merge a JSON translation map into a Localizable.xcstrings catalog.
+For each key in the translations file, inserts a <locale> stringUnit entry
+under `localizations` in the catalog.
+
+Safety rules (all enforced):
+  - Unknown keys (not in the catalog) → rejected, exit 1.
+  - Keys with shouldTranslate: false → skipped with a warning.
+  - Empty or whitespace-only values → rejected, exit 1.
+  - Format placeholder parity: every specifier found in the English value
+    (%@, %1$@, %lld, %1$lld, %d, etc.) must appear the same number of times
+    in the translated value. Mismatch → rejected, exit 1.
+  - extractionState is never modified.
+  - Existing localizations for other locales (en, es, …) are never touched.
+  - A run that would write zero keys is rejected.
+  - --dry-run validates everything without writing.
+
+Translations file format:
+  A JSON object mapping xcstrings key → translated string value.
+  {
+    "common.button.back":        "Wstecz",
+    "lifeStoryChapter.progress": "Rozdział %1$lld z %2$lld · %3$@"
+  }
+
+  Keys whose values should stay in English (brand terms, etc.) must still
+  appear in the file with their English text — the script does not skip them
+  for being identical to English. Omit them from the file to leave them
+  untranslated.
+
+Usage:
+  python3 scripts/localization/merge_xcstrings_locale.py \\
+      --locale pl \\
+      --translations /tmp/polish_ui_translations.json
+
+  python3 scripts/localization/merge_xcstrings_locale.py \\
+      --catalog Connections/Localizable.xcstrings \\
+      --locale es \\
+      --translations /tmp/es_ui_corrections.json \\
+      --dry-run
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+
+DEFAULT_CATALOG = "Connections/Localizable.xcstrings"
+
+# Regex for printf-style format specifiers (iOS / NSString style).
+# Captures positional (%1$@) and non-positional (%@, %d, %lld, %f, %ld, %lu).
+_SPECIFIER_RE = re.compile(
+    r"%(?:\d+\$)?(?:[-+ #0]*\d*(?:\.\d+)?)?(?:hh|h|ll|l|q|z|t|j)?[diouxXeEfFgGcCsSpaAn@]"
+)
+
+
+def extract_specifiers(text: str) -> list[str]:
+    """Return all format specifiers found in text (including duplicates)."""
+    return _SPECIFIER_RE.findall(text)
+
+
+def normalize_specifier(spec: str) -> str:
+    """Strip positional index from a specifier so %1$@ and %@ compare as the same type."""
+    return re.sub(r"^\%\d+\$", "%", spec)
+
+
+def specifier_multiset(text: str) -> dict[str, int]:
+    """Return a count-by-type map of format specifiers in text (position-agnostic)."""
+    counts: dict[str, int] = {}
+    for s in extract_specifiers(text):
+        key = normalize_specifier(s)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def load_json(path: str) -> dict:
+    if not os.path.exists(path):
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_xcstrings(path: str, data: dict) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def validate_and_merge(
+    catalog: dict,
+    translations: dict[str, str],
+    locale: str,
+    dry_run: bool,
+) -> tuple[int, int, int]:
+    """
+    Validate translations against the catalog and merge them in-place.
+
+    Returns (added_count, updated_count, skipped_count).
+    Exits with code 1 on any error.
+    """
+    strings = catalog.get("strings", {})
+    errors: list[str] = []
+    warnings: list[str] = []
+    added = 0
+    updated = 0
+    skipped = 0
+
+    for key, value in translations.items():
+        # --- Unknown key ---
+        if key not in strings:
+            errors.append(f"UNKNOWN key: {key!r} — not found in catalog")
+            continue
+
+        entry = strings[key]
+
+        # --- shouldTranslate: false ---
+        if entry.get("shouldTranslate") is False:
+            warnings.append(f"SKIP {key!r} — shouldTranslate is false")
+            skipped += 1
+            continue
+
+        # --- Empty value ---
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"EMPTY value for key: {key!r}")
+            continue
+
+        # --- Placeholder parity ---
+        en_value = (
+            entry.get("localizations", {})
+            .get("en", {})
+            .get("stringUnit", {})
+            .get("value", "")
+        )
+        en_specs = specifier_multiset(en_value)
+        tr_specs = specifier_multiset(value)
+
+        if en_specs != tr_specs:
+            errors.append(
+                f"PLACEHOLDER MISMATCH for {key!r}:\n"
+                f"  English:  {en_value!r}  →  specifiers: {en_specs}\n"
+                f"  {locale}:  {value!r}  →  specifiers: {tr_specs}"
+            )
+            continue
+
+        # --- Merge (track add vs. update) ---
+        already_has_locale = locale in entry.get("localizations", {})
+        if not dry_run:
+            if "localizations" not in entry:
+                entry["localizations"] = {}
+            entry["localizations"][locale] = {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": value,
+                }
+            }
+        if already_has_locale:
+            updated += 1
+        else:
+            added += 1
+
+    for w in warnings:
+        print(f"WARNING: {w}")
+    sys.stdout.flush()  # ensure warnings appear before any subsequent stderr output
+
+    if errors:
+        print(f"\n{len(errors)} error(s) — no changes written:", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        sys.exit(1)
+
+    return added, updated, skipped
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge a JSON translation map into a Localizable.xcstrings catalog."
+    )
+    parser.add_argument(
+        "--catalog",
+        default=DEFAULT_CATALOG,
+        help=f"Path to Localizable.xcstrings (default: {DEFAULT_CATALOG})",
+    )
+    parser.add_argument(
+        "--locale",
+        required=True,
+        help='Locale code to add, e.g. "pl" or "es"',
+    )
+    parser.add_argument(
+        "--translations",
+        required=True,
+        help="Path to JSON file mapping xcstrings key → translated string",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report without writing the catalog",
+    )
+    args = parser.parse_args()
+
+    catalog = load_json(args.catalog)
+    translations_raw = load_json(args.translations)
+
+    if not isinstance(translations_raw, dict):
+        print("ERROR: translations file must be a JSON object (key → string)", file=sys.stderr)
+        return 1
+
+    if not translations_raw:
+        print("ERROR: translations file is empty — nothing to apply", file=sys.stderr)
+        return 1
+
+    # Enforce string values only
+    non_string = [k for k, v in translations_raw.items() if not isinstance(v, str)]
+    if non_string:
+        print(
+            f"ERROR: {len(non_string)} translation value(s) are not strings: "
+            f"{non_string[:5]}{'…' if len(non_string) > 5 else ''}",
+            file=sys.stderr,
+        )
+        return 1
+
+    translations: dict[str, str] = translations_raw
+
+    print(f"Catalog:      {args.catalog}")
+    print(f"Locale:       {args.locale}")
+    print(f"Translations: {args.translations} ({len(translations)} keys)")
+    if args.dry_run:
+        print("Mode:         dry-run (no file will be written)")
+    sys.stdout.flush()  # ensure header appears before any error output
+
+    added, updated, skipped = validate_and_merge(catalog, translations, args.locale, args.dry_run)
+
+    if added + updated == 0:
+        if skipped:
+            print(
+                f"ERROR: all {skipped} key(s) skipped (shouldTranslate=false) — nothing to write.",
+                file=sys.stderr,
+            )
+        else:
+            print("ERROR: 0 keys would be written — nothing to do.", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        parts = []
+        if added:
+            parts.append(f"{added} new")
+        if updated:
+            parts.append(f"{updated} updated")
+        if skipped:
+            parts.append(f"{skipped} skipped (shouldTranslate=false)")
+        print(f"\nDry run complete — {', '.join(parts)}. No file written.")
+        return 0
+
+    save_xcstrings(args.catalog, catalog)
+    parts = []
+    if added:
+        parts.append(f"{added} added")
+    if updated:
+        parts.append(f"{updated} updated")
+    if skipped:
+        parts.append(f"{skipped} skipped (shouldTranslate=false)")
+    print(f"\nDone — {', '.join(parts)}. Wrote: {args.catalog}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/localization/validate_polish_candidate.py
+++ b/scripts/localization/validate_polish_candidate.py
@@ -2,12 +2,12 @@
 """
 validate_polish_candidate.py
 
-Validate a candidate prompts_pl.json against prompts_en.json before
-the XCTest suite exists for Polish. Exits non-zero if any check fails.
+Validate a translated prompt bank (e.g. prompts_pl.json, prompts_es.json)
+against the English source. Exits non-zero if any check fails.
 
 Checks:
   - schemaVersion == 1
-  - language == "pl"
+  - language field matches --locale (default: "pl")
   - prompt count matches English
   - prompt IDs match English in order
   - metadata fields match exactly: mode, intensity, depth, topic
@@ -23,8 +23,9 @@ Usage:
       --candidate Connections/Data/prompts_pl.json
 
   python3 scripts/localization/validate_polish_candidate.py \\
-      --source   Connections/Data/prompts_en.json \\
-      --candidate Connections/Data/prompts_pl.json \\
+      --source    Connections/Data/prompts_en.json \\
+      --candidate Connections/Data/prompts_es.json \\
+      --locale    es \\
       --verbose
 """
 
@@ -33,8 +34,8 @@ import json
 import os
 import sys
 
-# Strings that are legitimately identical between English and Polish
-# (brand terms kept in English per polish-brief.md).
+# Strings that are legitimately identical between English and any locale
+# (brand terms kept in English per localization briefs).
 # Only exact matches are allowed. A sentence that merely *contains* a brand
 # term is NOT allowlisted — it must still be translated.
 ENGLISH_ALLOWLIST = {
@@ -60,7 +61,7 @@ def is_allowlisted(text: str) -> bool:
     return text.strip() in ENGLISH_ALLOWLIST
 
 
-def validate(en_data: dict, pl_data: dict, verbose: bool) -> list[str]:
+def validate(en_data: dict, loc_data: dict, locale: str, verbose: bool) -> list[str]:
     errors: list[str] = []
 
     def err(msg: str) -> None:
@@ -73,78 +74,77 @@ def validate(en_data: dict, pl_data: dict, verbose: bool) -> list[str]:
             print(f"  pass  {msg}")
 
     # --- Top-level metadata ---
-    if pl_data.get("schemaVersion") != 1:
-        err(f"schemaVersion is {pl_data.get('schemaVersion')!r}, expected 1")
+    if loc_data.get("schemaVersion") != 1:
+        err(f"schemaVersion is {loc_data.get('schemaVersion')!r}, expected 1")
     else:
         ok("schemaVersion == 1")
 
-    if pl_data.get("language") != "pl":
-        err(f"language is {pl_data.get('language')!r}, expected 'pl'")
+    if loc_data.get("language") != locale:
+        err(f"language is {loc_data.get('language')!r}, expected {locale!r}")
     else:
-        ok("language == 'pl'")
+        ok(f"language == {locale!r}")
 
     en_prompts = en_data.get("prompts", [])
-    pl_prompts = pl_data.get("prompts", [])
+    loc_prompts = loc_data.get("prompts", [])
 
     # --- Count ---
-    if len(pl_prompts) != len(en_prompts):
-        err(f"prompt count: expected {len(en_prompts)}, got {len(pl_prompts)}")
+    if len(loc_prompts) != len(en_prompts):
+        err(f"prompt count: expected {len(en_prompts)}, got {len(loc_prompts)}")
         # Can't do per-prompt checks reliably if counts differ
         return errors
     else:
         ok(f"prompt count == {len(en_prompts)}")
 
     # --- Per-prompt checks ---
-    for i, (en_p, pl_p) in enumerate(zip(en_prompts, pl_prompts)):
+    for i, (en_p, loc_p) in enumerate(zip(en_prompts, loc_prompts)):
         pid = en_p.get("id", f"index_{i}")
 
         # ID order
-        if pl_p.get("id") != pid:
-            err(f"[{i}] id mismatch: expected '{pid}', got '{pl_p.get('id')}'")
+        if loc_p.get("id") != pid:
+            err(f"[{i}] id mismatch: expected '{pid}', got '{loc_p.get('id')}'")
             continue   # skip deeper checks for mismatched entry
 
         # Metadata parity
         for field in METADATA_FIELDS:
-            if pl_p.get(field) != en_p.get(field):
-                err(f"{pid}: {field} mismatch: en={en_p.get(field)!r} pl={pl_p.get(field)!r}")
+            if loc_p.get(field) != en_p.get(field):
+                err(f"{pid}: {field} mismatch: en={en_p.get(field)!r} {locale}={loc_p.get(field)!r}")
 
         # Non-empty text
-        pl_text = pl_p.get("text", "")
-        if not pl_text or not pl_text.strip():
+        loc_text = loc_p.get("text", "")
+        if not loc_text or not loc_text.strip():
             err(f"{pid}: prompt text is empty")
         else:
-            # Not identical to English
             en_text = en_p.get("text", "")
-            if pl_text == en_text and not is_allowlisted(pl_text):
+            if loc_text == en_text and not is_allowlisted(loc_text):
                 err(f"{pid}: prompt text is still English (not translated)")
 
         # Follow-ups
         en_fus = en_p.get("followUps", [])
-        pl_fus = pl_p.get("followUps", [])
+        loc_fus = loc_p.get("followUps", [])
 
-        if len(pl_fus) != len(en_fus):
-            err(f"{pid}: follow-up count: expected {len(en_fus)}, got {len(pl_fus)}")
+        if len(loc_fus) != len(en_fus):
+            err(f"{pid}: follow-up count: expected {len(en_fus)}, got {len(loc_fus)}")
             continue
 
-        for j, (en_fu, pl_fu) in enumerate(zip(en_fus, pl_fus)):
+        for j, (en_fu, loc_fu) in enumerate(zip(en_fus, loc_fus)):
             fu_id = en_fu.get("id", f"{pid}_fu_{j}")
 
-            if pl_fu.get("id") != fu_id:
-                err(f"{pid}: follow-up[{j}] id mismatch: expected '{fu_id}', got '{pl_fu.get('id')}'")
+            if loc_fu.get("id") != fu_id:
+                err(f"{pid}: follow-up[{j}] id mismatch: expected '{fu_id}', got '{loc_fu.get('id')}'")
                 continue
 
-            if pl_fu.get("style") != en_fu.get("style"):
+            if loc_fu.get("style") != en_fu.get("style"):
                 err(
                     f"{pid} / {fu_id}: style mismatch: "
-                    f"en={en_fu.get('style')!r} pl={pl_fu.get('style')!r}"
+                    f"en={en_fu.get('style')!r} {locale}={loc_fu.get('style')!r}"
                 )
 
-            pl_fu_text = pl_fu.get("text", "")
-            if not pl_fu_text or not pl_fu_text.strip():
+            loc_fu_text = loc_fu.get("text", "")
+            if not loc_fu_text or not loc_fu_text.strip():
                 err(f"{pid} / {fu_id}: follow-up text is empty")
             else:
                 en_fu_text = en_fu.get("text", "")
-                if pl_fu_text == en_fu_text and not is_allowlisted(pl_fu_text):
+                if loc_fu_text == en_fu_text and not is_allowlisted(loc_fu_text):
                     err(f"{pid} / {fu_id}: follow-up text is still English (not translated)")
 
     return errors
@@ -152,7 +152,7 @@ def validate(en_data: dict, pl_data: dict, verbose: bool) -> list[str]:
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Validate a candidate prompts_pl.json against prompts_en.json."
+        description="Validate a translated prompt bank against the English source."
     )
     parser.add_argument(
         "--source",
@@ -162,7 +162,12 @@ def main() -> int:
     parser.add_argument(
         "--candidate",
         default="Connections/Data/prompts_pl.json",
-        help="Polish candidate file to validate (default: Connections/Data/prompts_pl.json)",
+        help="Translated candidate file to validate (default: Connections/Data/prompts_pl.json)",
+    )
+    parser.add_argument(
+        "--locale",
+        default="pl",
+        help='Expected value of the "language" field in the candidate file (default: pl)',
     )
     parser.add_argument(
         "--verbose",
@@ -172,13 +177,14 @@ def main() -> int:
     args = parser.parse_args()
 
     en_data = load_json(args.source)
-    pl_data = load_json(args.candidate)
+    loc_data = load_json(args.candidate)
 
     if args.verbose:
         print(f"\nValidating: {args.candidate}")
-        print(f"Against:    {args.source}\n")
+        print(f"Against:    {args.source}")
+        print(f"Locale:     {args.locale}\n")
 
-    errors = validate(en_data, pl_data, verbose=args.verbose)
+    errors = validate(en_data, loc_data, locale=args.locale, verbose=args.verbose)
 
     if errors:
         print(f"\n{len(errors)} error(s) found:")

--- a/scripts/localization/validate_polish_candidate.py
+++ b/scripts/localization/validate_polish_candidate.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+validate_polish_candidate.py
+
+Validate a candidate prompts_pl.json against prompts_en.json before
+the XCTest suite exists for Polish. Exits non-zero if any check fails.
+
+Checks:
+  - schemaVersion == 1
+  - language == "pl"
+  - prompt count matches English
+  - prompt IDs match English in order
+  - metadata fields match exactly: mode, intensity, depth, topic
+  - follow-up count matches per prompt
+  - follow-up IDs and styles match per prompt
+  - no empty prompt text
+  - no empty follow-up text
+  - no translated prompt/follow-up text is identical to English
+    (allowlist: brand terms that must stay in English)
+
+Usage:
+  python3 scripts/localization/validate_polish_candidate.py \\
+      --candidate Connections/Data/prompts_pl.json
+
+  python3 scripts/localization/validate_polish_candidate.py \\
+      --source   Connections/Data/prompts_en.json \\
+      --candidate Connections/Data/prompts_pl.json \\
+      --verbose
+"""
+
+import argparse
+import json
+import os
+import sys
+
+# Strings that are legitimately identical between English and Polish
+# (brand terms kept in English per polish-brief.md).
+# Only exact matches are allowed. A sentence that merely *contains* a brand
+# term is NOT allowlisted — it must still be translated.
+ENGLISH_ALLOWLIST = {
+    "Life Story",
+    "Fall in Love",
+    "Share an Experience",
+    "Deeper Conversations",
+}
+
+METADATA_FIELDS = ("mode", "intensity", "depth", "topic")
+
+
+def load_json(path: str) -> dict:
+    if not os.path.exists(path):
+        print(f"ERROR: file not found: {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def is_allowlisted(text: str) -> bool:
+    """Return True only if text is exactly a protected brand term (after stripping whitespace)."""
+    return text.strip() in ENGLISH_ALLOWLIST
+
+
+def validate(en_data: dict, pl_data: dict, verbose: bool) -> list[str]:
+    errors: list[str] = []
+
+    def err(msg: str) -> None:
+        errors.append(msg)
+        if verbose:
+            print(f"  FAIL  {msg}")
+
+    def ok(msg: str) -> None:
+        if verbose:
+            print(f"  pass  {msg}")
+
+    # --- Top-level metadata ---
+    if pl_data.get("schemaVersion") != 1:
+        err(f"schemaVersion is {pl_data.get('schemaVersion')!r}, expected 1")
+    else:
+        ok("schemaVersion == 1")
+
+    if pl_data.get("language") != "pl":
+        err(f"language is {pl_data.get('language')!r}, expected 'pl'")
+    else:
+        ok("language == 'pl'")
+
+    en_prompts = en_data.get("prompts", [])
+    pl_prompts = pl_data.get("prompts", [])
+
+    # --- Count ---
+    if len(pl_prompts) != len(en_prompts):
+        err(f"prompt count: expected {len(en_prompts)}, got {len(pl_prompts)}")
+        # Can't do per-prompt checks reliably if counts differ
+        return errors
+    else:
+        ok(f"prompt count == {len(en_prompts)}")
+
+    # --- Per-prompt checks ---
+    for i, (en_p, pl_p) in enumerate(zip(en_prompts, pl_prompts)):
+        pid = en_p.get("id", f"index_{i}")
+
+        # ID order
+        if pl_p.get("id") != pid:
+            err(f"[{i}] id mismatch: expected '{pid}', got '{pl_p.get('id')}'")
+            continue   # skip deeper checks for mismatched entry
+
+        # Metadata parity
+        for field in METADATA_FIELDS:
+            if pl_p.get(field) != en_p.get(field):
+                err(f"{pid}: {field} mismatch: en={en_p.get(field)!r} pl={pl_p.get(field)!r}")
+
+        # Non-empty text
+        pl_text = pl_p.get("text", "")
+        if not pl_text or not pl_text.strip():
+            err(f"{pid}: prompt text is empty")
+        else:
+            # Not identical to English
+            en_text = en_p.get("text", "")
+            if pl_text == en_text and not is_allowlisted(pl_text):
+                err(f"{pid}: prompt text is still English (not translated)")
+
+        # Follow-ups
+        en_fus = en_p.get("followUps", [])
+        pl_fus = pl_p.get("followUps", [])
+
+        if len(pl_fus) != len(en_fus):
+            err(f"{pid}: follow-up count: expected {len(en_fus)}, got {len(pl_fus)}")
+            continue
+
+        for j, (en_fu, pl_fu) in enumerate(zip(en_fus, pl_fus)):
+            fu_id = en_fu.get("id", f"{pid}_fu_{j}")
+
+            if pl_fu.get("id") != fu_id:
+                err(f"{pid}: follow-up[{j}] id mismatch: expected '{fu_id}', got '{pl_fu.get('id')}'")
+                continue
+
+            if pl_fu.get("style") != en_fu.get("style"):
+                err(
+                    f"{pid} / {fu_id}: style mismatch: "
+                    f"en={en_fu.get('style')!r} pl={pl_fu.get('style')!r}"
+                )
+
+            pl_fu_text = pl_fu.get("text", "")
+            if not pl_fu_text or not pl_fu_text.strip():
+                err(f"{pid} / {fu_id}: follow-up text is empty")
+            else:
+                en_fu_text = en_fu.get("text", "")
+                if pl_fu_text == en_fu_text and not is_allowlisted(pl_fu_text):
+                    err(f"{pid} / {fu_id}: follow-up text is still English (not translated)")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a candidate prompts_pl.json against prompts_en.json."
+    )
+    parser.add_argument(
+        "--source",
+        default="Connections/Data/prompts_en.json",
+        help="English source file (default: Connections/Data/prompts_en.json)",
+    )
+    parser.add_argument(
+        "--candidate",
+        default="Connections/Data/prompts_pl.json",
+        help="Polish candidate file to validate (default: Connections/Data/prompts_pl.json)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print each check result (pass/fail) as it runs",
+    )
+    args = parser.parse_args()
+
+    en_data = load_json(args.source)
+    pl_data = load_json(args.candidate)
+
+    if args.verbose:
+        print(f"\nValidating: {args.candidate}")
+        print(f"Against:    {args.source}\n")
+
+    errors = validate(en_data, pl_data, verbose=args.verbose)
+
+    if errors:
+        print(f"\n{len(errors)} error(s) found:")
+        for e in errors:
+            print(f"  {e}")
+        print("\nValidation FAILED.")
+        return 1
+
+    count = len(en_data.get("prompts", []))
+    print(f"\nValidation passed — {count} prompts OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **4 Polish JSON prompt banks** — 598 main prompts, Fall in Love, Life Story, Share Experience; all translated with gender-neutral constructions per `docs/localization/polish-brief.md`
- **325 Polish UI strings** in `Localizable.xcstrings` — covers all translatable keys; 19 coordinator corrections + 9 QA-pass fixes applied to remove masculine fallbacks from session summary copy; brand terms (Fall in Love, Life Story, Share an Experience) kept in English
- **31-test PolishLocalizationTests suite** — JSON bank structure/count/metadata/no-empty, xcstrings completeness, placeholder parity; all 31 pass
- **Privacy policy routing** — `SettingsView` routes to `privacy-pl` for Polish locale; `docs/privacy-pl.md` added for GitHub Pages
- **Localization tooling** — new `merge_xcstrings_locale.py` (generic xcstrings locale merger with `--locale`, `--dry-run`, placeholder parity validation); `validate_polish_candidate.py` and `apply_polish_patch.py` generalized to accept `--locale` for future locales; README updated

## Test plan

- [ ] Run `PolishLocalizationTests` — expect 31/31 pass
- [ ] Run `SpanishLocalizationTests` — expect no regressions
- [ ] Build succeeds with no errors
- [ ] On-device: switch device language to Polish, verify all UI strings render in Polish
- [ ] Verify brand terms (Fall in Love, Life Story, Share an Experience) remain in English under Polish locale
- [ ] Verify privacy policy link opens `privacy-pl` page when app language is Polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)