### PR TITLE
Harden StoreKit error handling and localize purchase messages

### DIFF
--- a/Connections/Components/SelectionCard.swift
+++ b/Connections/Components/SelectionCard.swift
@@ -41,11 +41,11 @@ struct SelectionCard: View {
             HStack {
                 VStack(alignment: .leading, spacing: 4) {
                     Text(title)
-                        .font(.system(size: 17, weight: .medium))
+                        .font(AppFont.buttonSecondary())
                         .foregroundColor(glassEffect && colorScheme == .light ? Color.black.opacity(0.96) : Color.primary)
 
                     Text(subtitle)
-                        .font(.system(size: 14))
+                        .font(AppFont.detail())
                         .foregroundColor(glassEffect && colorScheme == .light ? Color.black.opacity(0.46) : Color.secondary)
                 }
 

--- a/Connections/Components/SummaryRow.swift
+++ b/Connections/Components/SummaryRow.swift
@@ -26,14 +26,15 @@ struct SummaryRow: View {
                 }
 
                 Text(title)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(AppFont.caption())
+                    .fontWeight(.medium)
 
                 Text("·")
                     .font(.system(size: 13))
                     .foregroundStyle(.tertiary)
 
                 Text(subtitle)
-                    .font(.system(size: 13))
+                    .font(AppFont.detail())
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
 

--- a/Connections/Components/Theme.swift
+++ b/Connections/Components/Theme.swift
@@ -19,6 +19,10 @@ enum AppFont {
     static func heroTitle() -> Font {
         .system(size: 50, weight: .regular, design: .serif)
     }
+    // Check-in question style — serif heading, scales with Dynamic Type.
+    static func checkInPrompt() -> Font {
+        .system(.title2, design: .serif, weight: .regular)
+    }
     // 28pt at default (.title) — exact match, now scales with Dynamic Type
     static func promptText() -> Font {
         .system(.title, design: .serif, weight: .regular)

--- a/Connections/Paywall.xcstrings
+++ b/Connections/Paywall.xcstrings
@@ -1824,6 +1824,66 @@
           }
         }
       }
+    },
+    "paywall.error.productUnavailable": {
+      "comment": "Shown when the StoreKit product fails to load (network issue, App Store Connect misconfig, etc.). Apple guideline: actionable, mentions Restore as backup.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Access isn't available right now. Please check your connection and try again, or use Restore Purchases if you've already bought it."
+          }
+        }
+      }
+    },
+    "paywall.error.purchaseFailed": {
+      "comment": "Shown when product.purchase() throws (network, payment method failure, etc.). Apple guideline: reassure no charge, offer retry + restore.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your purchase couldn't be completed. No charge was made. Please try again, or use Restore Purchases if you've already bought it."
+          }
+        }
+      }
+    },
+    "paywall.error.verificationFailed": {
+      "comment": "Shown when StoreKit transaction verification fails cryptographically. Apple guideline: actionable, never a dead-end \"contact support\".",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "We couldn't verify your purchase with the App Store. Please try again. If you were charged, use Restore Purchases."
+          }
+        }
+      }
+    },
+    "paywall.error.restoreFailed": {
+      "comment": "Shown when AppStore.sync() throws during Restore Purchases. Apple guideline: short, actionable, no raw error codes.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restore failed. Please check your connection and try again."
+          }
+        }
+      }
+    },
+    "paywall.info.nothingToRestore": {
+      "comment": "Informational (not an error) — shown when Restore Purchases succeeds but no entitlement exists for this Apple ID. Apple guideline: every tap needs visible, actionable feedback.",
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No previous purchases were found for this Apple ID."
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/Connections/Services/EntitlementStore.swift
+++ b/Connections/Services/EntitlementStore.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import os
 import StoreKit
 
 @Observable
@@ -15,12 +16,26 @@ final class EntitlementStore {
     /// ⚠️ Replace with your real App Store Connect non-consumable product identifier before shipping.
     static let fullAccessProductID = "connections.full_access"
 
+    private static let logger = Logger(subsystem: "com.tanner.Connections", category: "StoreKit")
+
     // MARK: - Purchase State
 
     enum PurchaseState: Equatable {
         case idle
         case loading
-        case error(String)
+        case error(ErrorKind)
+        case info(InfoKind)
+
+        enum ErrorKind: Equatable {
+            case productUnavailable
+            case purchaseFailed
+            case verificationFailed
+            case restoreFailed
+        }
+
+        enum InfoKind: Equatable {
+            case nothingToRestore
+        }
     }
 
     // MARK: - Debug Override
@@ -79,8 +94,15 @@ final class EntitlementStore {
     /// Fetches the full-access product from the App Store. Safe to call multiple times.
     func loadProduct() async {
         guard product == nil else { return }
-        if let loaded = try? await Product.products(for: [Self.fullAccessProductID]).first {
-            product = loaded
+        do {
+            let products = try await Product.products(for: [Self.fullAccessProductID])
+            if let loaded = products.first {
+                product = loaded
+            } else {
+                Self.logger.error("Product.products returned empty for ID '\(Self.fullAccessProductID, privacy: .public)'. Check App Store Connect: IAP exists with this exact ID, is in 'Ready to Submit' or higher, Paid Apps Agreement is signed, tax/banking is complete.")
+            }
+        } catch {
+            Self.logger.error("Failed to load product '\(Self.fullAccessProductID, privacy: .public)': \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -127,12 +149,11 @@ final class EntitlementStore {
     // MARK: - Purchase
 
     func purchase() async {
+        if product == nil {
+            await loadProduct()
+        }
         guard let product else {
-            #if DEBUG
-            purchaseState = .error("Purchases are not configured in this local build. Use Settings > Debug > Forced Premium to unlock for testing.")
-            #else
-            purchaseState = .error("Product unavailable. Please try again later.")
-            #endif
+            purchaseState = .error(.productUnavailable)
             return
         }
         purchaseState = .loading
@@ -141,7 +162,8 @@ final class EntitlementStore {
             switch result {
             case .success(let verification):
                 guard case .verified(let transaction) = verification else {
-                    purchaseState = .error("Purchase could not be verified. Please contact support.")
+                    Self.logger.error("Purchase verification failed for '\(Self.fullAccessProductID, privacy: .public)'")
+                    purchaseState = .error(.verificationFailed)
                     return
                 }
                 systemEntitlement = true
@@ -155,7 +177,8 @@ final class EntitlementStore {
                 purchaseState = .idle
             }
         } catch {
-            purchaseState = .error("Purchase failed. Please try again.")
+            Self.logger.error("Purchase failed: \(error.localizedDescription, privacy: .public)")
+            purchaseState = .error(.purchaseFailed)
         }
     }
 
@@ -167,9 +190,14 @@ final class EntitlementStore {
         do {
             try await AppStore.sync()
             await refreshEntitlements()
-            purchaseState = .idle
+            if systemEntitlement {
+                purchaseState = .idle
+            } else {
+                purchaseState = .info(.nothingToRestore)
+            }
         } catch {
-            purchaseState = .error("Restore failed. Please try again.")
+            Self.logger.error("Restore failed: \(error.localizedDescription, privacy: .public)")
+            purchaseState = .error(.restoreFailed)
         }
     }
 }

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -161,7 +161,8 @@ struct FallInLovePlayView: View {
                             dismiss()
                         } label: {
                             Text(String(localized: "common.button.done", defaultValue: "Done"))
-                                .font(.system(size: 17, weight: .semibold))
+                                .font(AppFont.buttonSecondary())
+                                .fontWeight(.semibold)
                                 .foregroundStyle(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 18)
@@ -172,7 +173,8 @@ struct FallInLovePlayView: View {
                             showResetConfirmation = true
                         } label: {
                             Text(String(localized: "fallInLovePlay.button.startOver", defaultValue: "Start Over"))
-                                .font(.system(size: 14, weight: .medium))
+                                .font(AppFont.detail())
+                                .fontWeight(.medium)
                                 .foregroundStyle(.tertiary)
                         }
                         .buttonStyle(.plain)

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -68,17 +68,25 @@ struct FallInLovePlayView: View {
 
                     // MARK: - Prompt
 
-                    Spacer(minLength: 40)
+                    GeometryReader { proxy in
+                        ScrollView(.vertical, showsIndicators: false) {
+                            VStack(spacing: 0) {
+                                Spacer(minLength: 40)
 
-                    if let prompt = manager.currentPrompt {
-                        Text(prompt.text)
-                            .promptTextStyle()
-                            .id(promptTransitionID)
-                            .opacity(promptVisible ? 1 : 0)
-                            .offset(y: promptVisible ? 0 : 12)
+                                if let prompt = manager.currentPrompt {
+                                    Text(prompt.text)
+                                        .promptTextStyle()
+                                        .id(promptTransitionID)
+                                        .opacity(promptVisible ? 1 : 0)
+                                        .offset(y: promptVisible ? 0 : 12)
+                                }
+
+                                Spacer(minLength: 24)
+                            }
+                            .frame(minHeight: proxy.size.height)
+                        }
                     }
-
-                    Spacer()
+                    .safeAreaInset(edge: .bottom) {
 
                     // MARK: - Actions
 
@@ -145,6 +153,8 @@ struct FallInLovePlayView: View {
                     .padding(.horizontal, AppSpacing.contentHorizontal)
                     .padding(.bottom, 48)
                     .animation(.easeOut(duration: 0.2), value: manager.canGoBack)
+
+                    } // safeAreaInset
 
                 } else {
 

--- a/Connections/Views/FallInLovePlayView.swift
+++ b/Connections/Views/FallInLovePlayView.swift
@@ -236,17 +236,18 @@ struct FallInLovePlayView: View {
             Text(isFriends
                  ? String(localized: "fallInLovePlay.complete.title.friends", defaultValue: "Something shifted")
                  : String(localized: "fallInLovePlay.complete.title.couples", defaultValue: "Something was built here"))
-                .font(.system(size: 28, weight: .regular, design: .serif))
+                .font(AppFont.promptText())
                 .multilineTextAlignment(.center)
 
             Text(String(localized: "fallInLovePlay.complete.subtitle", defaultValue: "You stayed for all 36 questions"))
-                .font(.system(size: 15))
+                .font(AppFont.caption())
                 .foregroundStyle(.tertiary)
 
             Text(isFriends
                  ? String(localized: "fallInLovePlay.complete.body.friends", defaultValue: "You made space for a deeper kind of conversation.")
                  : String(localized: "fallInLovePlay.complete.body.couples", defaultValue: "Take a moment to appreciate the connection you've built."))
-                .font(.system(size: 15, weight: .regular, design: .serif))
+                .font(AppFont.caption())
+                .fontDesign(.serif)
                 .foregroundStyle(.secondary)
                 .italic()
                 .multilineTextAlignment(.center)

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -21,6 +21,11 @@ struct FavoritesPlayView: View {
     @State private var justUnfavorited = false
     @State private var isTransitioning = false
 
+    private enum ScrollAnchor {
+        static let top = "favoritesPromptTop"
+        static let bottom = "favoritesPromptBottom"
+    }
+
     private var currentEntry: FavoritesStore.FavoriteEntry? {
         guard !localFavorites.isEmpty, currentIndex < localFavorites.count else { return nil }
         return localFavorites[currentIndex]
@@ -72,15 +77,36 @@ struct FavoritesPlayView: View {
 
                     // MARK: - Content Area
 
-                    Spacer(minLength: 40)
+                    GeometryReader { proxy in
+                        ScrollViewReader { scrollProxy in
+                            ScrollView(.vertical, showsIndicators: false) {
+                                VStack(spacing: 0) {
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.top)
 
-                    promptContent
+                                    Spacer(minLength: 40)
+                                    promptContent
+                                    Spacer(minLength: 24)
 
-                    Spacer()
-
-                    // MARK: - Actions
-
-                    actionButtons
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.bottom)
+                                }
+                                .frame(minHeight: proxy.size.height)
+                            }
+                            .onChange(of: shownFollowUps.count) { _, count in
+                                guard count > 0 else { return }
+                                scrollToPromptBottom(scrollProxy)
+                            }
+                            .onChange(of: promptTransitionID) { _, _ in
+                                resetPromptScroll(scrollProxy)
+                            }
+                        }
+                    }
+                    .safeAreaInset(edge: .bottom) {
+                        actionButtons
+                    }
                 }
             }
         }
@@ -357,6 +383,20 @@ struct FavoritesPlayView: View {
         guard let next = remaining.first else { return }
         shownFollowUps.append(next)
         showGoDeeperHint = false
+    }
+
+    private func scrollToPromptBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo(ScrollAnchor.bottom, anchor: .bottom)
+            }
+        }
+    }
+
+    private func resetPromptScroll(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            proxy.scrollTo(ScrollAnchor.top, anchor: .top)
+        }
     }
 }
 

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -112,7 +112,7 @@ struct FavoritesPlayView: View {
                     VStack(spacing: 8) {
                         ForEach(shownFollowUps) { followUp in
                             Text(followUp.text)
-                                .font(.system(size: 15))
+                                .font(AppFont.caption())
                                 .foregroundStyle(.secondary)
                                 .padding(.horizontal, 20)
                                 .padding(.vertical, 10)
@@ -314,7 +314,7 @@ struct FavoritesPlayView: View {
                 .foregroundStyle(.secondary)
 
             Text(String(localized: "favoritesPlay.emptyState.title", defaultValue: "No favorites yet"))
-                .font(.system(size: 28, weight: .regular, design: .serif))
+                .font(AppFont.promptText())
 
             Text(String(localized: "favoritesPlay.emptyState.body", defaultValue: "Tap the heart on any prompt to save it here for later."))
                 .font(AppFont.caption())

--- a/Connections/Views/FavoritesPlayView.swift
+++ b/Connections/Views/FavoritesPlayView.swift
@@ -325,7 +325,8 @@ struct FavoritesPlayView: View {
                 dismiss()
             } label: {
                 Text(String(localized: "favoritesPlay.emptyState.returnHome", defaultValue: "Return Home"))
-                    .font(.system(size: 15, weight: .medium))
+                    .font(AppFont.caption())
+                    .fontWeight(.medium)
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 24)
                     .padding(.vertical, 12)

--- a/Connections/Views/FeelingCheckInView.swift
+++ b/Connections/Views/FeelingCheckInView.swift
@@ -16,7 +16,7 @@ struct FeelingCheckInView: View {
         VStack(spacing: 32) {
 
             Text(String(localized: "feelingCheckIn.header", defaultValue: "How did that feel?"))
-                .font(.system(size: 24, weight: .regular, design: .serif))
+                .font(AppFont.checkInPrompt())
                 .foregroundStyle(.primary)
 
             HStack(spacing: 20) {
@@ -46,7 +46,7 @@ struct FeelingCheckInView: View {
 
             if showMessage, let message = displayedMessage {
                 Text(message)
-                    .font(.system(size: 15))
+                    .font(AppFont.caption())
                     .foregroundStyle(.secondary)
                     .transition(.opacity)
             }

--- a/Connections/Views/IntensitySelectionView.swift
+++ b/Connections/Views/IntensitySelectionView.swift
@@ -26,23 +26,23 @@ struct IntensitySelectionView: View {
 
                 // MARK: - Intensity Cards
 
-                VStack(spacing: AppSpacing.cardSpacing) {
-                    ForEach(Intensity.allCases) { intensity in
-                        SelectionCard(
-                            title: intensity.localizedTitle,
-                            subtitle: intensity.localizedDescription,
-                            tintColor: intensity.toneColor,
-                            isSelected: session.selectedIntensity == intensity,
-                            glassEffect: true
-                        ) {
-                            session.selectedIntensity = intensity
-                            navigateToSetup = true
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: AppSpacing.cardSpacing) {
+                        ForEach(Intensity.allCases) { intensity in
+                            SelectionCard(
+                                title: intensity.localizedTitle,
+                                subtitle: intensity.localizedDescription,
+                                tintColor: intensity.toneColor,
+                                isSelected: session.selectedIntensity == intensity,
+                                glassEffect: true
+                            ) {
+                                session.selectedIntensity = intensity
+                                navigateToSetup = true
+                            }
                         }
                     }
+                    .padding(.horizontal, AppSpacing.screenHorizontal)
                 }
-                .padding(.horizontal, AppSpacing.screenHorizontal)
-
-                Spacer()
             }
         }
         .animation(.easeInOut(duration: 0.35), value: session.selectedIntensity)

--- a/Connections/Views/LifeStoryPlayView.swift
+++ b/Connections/Views/LifeStoryPlayView.swift
@@ -169,7 +169,8 @@ struct LifeStoryPlayView: View {
                             dismiss()
                         } label: {
                             Text(String(localized: "common.button.done", defaultValue: "Done"))
-                                .font(.system(size: 17, weight: .semibold))
+                                .font(AppFont.buttonSecondary())
+                                .fontWeight(.semibold)
                                 .foregroundStyle(.white)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 18)
@@ -180,7 +181,8 @@ struct LifeStoryPlayView: View {
                             showResetConfirmation = true
                         } label: {
                             Text(String(localized: "lifeStoryPlay.button.startOver", defaultValue: "Start Over"))
-                                .font(.system(size: 14, weight: .medium))
+                                .font(AppFont.detail())
+                                .fontWeight(.medium)
                                 .foregroundStyle(.tertiary)
                         }
                         .buttonStyle(.plain)

--- a/Connections/Views/LifeStoryPlayView.swift
+++ b/Connections/Views/LifeStoryPlayView.swift
@@ -301,15 +301,16 @@ struct LifeStoryPlayView: View {
     private var completeContent: some View {
         VStack(spacing: 12) {
             Text(String(localized: "lifeStoryPlay.complete.title", defaultValue: "A life, listened to"))
-                .font(.system(size: 28, weight: .regular, design: .serif))
+                .font(AppFont.promptText())
                 .multilineTextAlignment(.center)
 
             Text(String(localized: "lifeStoryPlay.complete.subtitle", defaultValue: "You stayed for all 50 questions"))
-                .font(.system(size: 15))
+                .font(AppFont.caption())
                 .foregroundStyle(.tertiary)
 
             Text(String(localized: "lifeStoryPlay.complete.body", defaultValue: "The conversations that matter most are the ones we almost didn't have."))
-                .font(.system(size: 15, weight: .regular, design: .serif))
+                .font(AppFont.caption())
+                .fontDesign(.serif)
                 .foregroundStyle(.secondary)
                 .italic()
                 .multilineTextAlignment(.center)

--- a/Connections/Views/LifeStoryPlayView.swift
+++ b/Connections/Views/LifeStoryPlayView.swift
@@ -18,6 +18,11 @@ struct LifeStoryPlayView: View {
     @State private var showResetConfirmation = false
     @State private var followUpsShown: Int = 0
 
+    private enum ScrollAnchor {
+        static let top = "lifeStoryPromptTop"
+        static let bottom = "lifeStoryPromptBottom"
+    }
+
     var body: some View {
         ZStack {
             AtmosphericBackground(intensity: .honest)
@@ -65,32 +70,57 @@ struct LifeStoryPlayView: View {
 
                     // MARK: - Prompt
 
-                    Spacer(minLength: 40)
+                    GeometryReader { proxy in
+                        ScrollViewReader { scrollProxy in
+                            ScrollView(.vertical, showsIndicators: false) {
+                                VStack(spacing: 0) {
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.top)
 
-                    if let prompt = manager.currentPrompt {
-                        VStack(spacing: 0) {
-                            Text(prompt.text)
-                                .promptTextStyle()
+                                    Spacer(minLength: 40)
 
-                            if followUpsShown >= 1 {
-                                VStack(spacing: 14) {
-                                    followUpRow(prompt.followUp1)
-                                    if followUpsShown >= 2 {
-                                        followUpRow(prompt.followUp2)
-                                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                    if let prompt = manager.currentPrompt {
+                                        VStack(spacing: 0) {
+                                            Text(prompt.text)
+                                                .promptTextStyle()
+
+                                            if followUpsShown >= 1 {
+                                                VStack(spacing: 14) {
+                                                    followUpRow(prompt.followUp1)
+                                                    if followUpsShown >= 2 {
+                                                        followUpRow(prompt.followUp2)
+                                                            .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                                    }
+                                                }
+                                                .padding(.top, 28)
+                                                .padding(.horizontal, AppSpacing.promptHorizontal)
+                                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                            }
+                                        }
+                                        .id(promptTransitionID)
+                                        .opacity(promptVisible ? 1 : 0)
+                                        .offset(y: promptVisible ? 0 : 12)
                                     }
+
+                                    Spacer(minLength: 24)
+
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.bottom)
                                 }
-                                .padding(.top, 28)
-                                .padding(.horizontal, AppSpacing.promptHorizontal)
-                                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                                .frame(minHeight: proxy.size.height)
+                            }
+                            .onChange(of: followUpsShown) { _, count in
+                                guard count > 0 else { return }
+                                scrollToPromptBottom(scrollProxy)
+                            }
+                            .onChange(of: promptTransitionID) { _, _ in
+                                resetPromptScroll(scrollProxy)
                             }
                         }
-                        .id(promptTransitionID)
-                        .opacity(promptVisible ? 1 : 0)
-                        .offset(y: promptVisible ? 0 : 12)
                     }
-
-                    Spacer()
+                    .safeAreaInset(edge: .bottom) {
 
                     // MARK: - Actions
 
@@ -153,6 +183,8 @@ struct LifeStoryPlayView: View {
                     .padding(.bottom, 48)
                     .animation(.easeOut(duration: 0.2), value: manager.canGoBack)
                     .animation(.easeOut(duration: 0.2), value: followUpsShown)
+
+                    } // safeAreaInset
 
                 } else {
 
@@ -232,6 +264,20 @@ struct LifeStoryPlayView: View {
                 .font(.system(.title3, design: .serif, weight: .regular))
                 .foregroundStyle(.secondary)
                 .lineSpacing(4)
+        }
+    }
+
+    private func scrollToPromptBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo(ScrollAnchor.bottom, anchor: .bottom)
+            }
+        }
+    }
+
+    private func resetPromptScroll(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            proxy.scrollTo(ScrollAnchor.top, anchor: .top)
         }
     }
 

--- a/Connections/Views/ModeSelectionView.swift
+++ b/Connections/Views/ModeSelectionView.swift
@@ -29,30 +29,30 @@ struct ModeSelectionView: View {
 
             // MARK: - Mode Cards
 
-            VStack(spacing: AppSpacing.cardSpacing) {
-                ForEach(Mode.allCases) { mode in
-                    SelectionCard(title: mode.localizedTitle, subtitle: mode.localizedDescription) {
-                        session.selectedMode = mode
-                        navigateToIntensity = true
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: AppSpacing.cardSpacing) {
+                    ForEach(Mode.allCases) { mode in
+                        SelectionCard(title: mode.localizedTitle, subtitle: mode.localizedDescription) {
+                            session.selectedMode = mode
+                            navigateToIntensity = true
+                        }
+                    }
+
+                    // MARK: - Share an Experience
+
+                    SelectionCard(
+                        title: String(localized: "modeSelection.share.title", defaultValue: "Share"),
+                        subtitle: String(localized: "modeSelection.share.subtitle", defaultValue: "Take turns sharing real experiences")
+                    ) {
+                        if entitlements.canUseShareExperience {
+                            navigateToShare = true
+                        } else {
+                            paywallVariant = .general
+                        }
                     }
                 }
-
-                // MARK: - Share an Experience
-
-                SelectionCard(
-                    title: String(localized: "modeSelection.share.title", defaultValue: "Share"),
-                    subtitle: String(localized: "modeSelection.share.subtitle", defaultValue: "Take turns sharing real experiences")
-                ) {
-                    if entitlements.canUseShareExperience {
-                        navigateToShare = true
-                    } else {
-                        paywallVariant = .general
-                    }
-                }
+                .padding(.horizontal, AppSpacing.screenHorizontal)
             }
-            .padding(.horizontal, AppSpacing.screenHorizontal)
-
-            Spacer()
         }
         } // ZStack
         .navigationBarBackButtonHidden(true)

--- a/Connections/Views/PremiumPaywallView.swift
+++ b/Connections/Views/PremiumPaywallView.swift
@@ -66,6 +66,45 @@ struct PremiumPaywallView: View {
         Bundle.main.localizedString(forKey: key, value: defaultValue, table: "Paywall")
     }
 
+    private func errorMessage(for kind: EntitlementStore.PurchaseState.ErrorKind) -> String {
+        switch kind {
+        case .productUnavailable:
+            #if DEBUG
+            return "Purchases are not configured in this local build. Use Settings > Debug > Forced Premium to unlock for testing."
+            #else
+            return paywallString(
+                "paywall.error.productUnavailable",
+                defaultValue: "Full Access isn't available right now. Please check your connection and try again, or use Restore Purchases if you've already bought it."
+            )
+            #endif
+        case .purchaseFailed:
+            return paywallString(
+                "paywall.error.purchaseFailed",
+                defaultValue: "Your purchase couldn't be completed. No charge was made. Please try again, or use Restore Purchases if you've already bought it."
+            )
+        case .verificationFailed:
+            return paywallString(
+                "paywall.error.verificationFailed",
+                defaultValue: "We couldn't verify your purchase with the App Store. Please try again. If you were charged, use Restore Purchases."
+            )
+        case .restoreFailed:
+            return paywallString(
+                "paywall.error.restoreFailed",
+                defaultValue: "Restore failed. Please check your connection and try again."
+            )
+        }
+    }
+
+    private func infoMessage(for kind: EntitlementStore.PurchaseState.InfoKind) -> String {
+        switch kind {
+        case .nothingToRestore:
+            return paywallString(
+                "paywall.info.nothingToRestore",
+                defaultValue: "No previous purchases were found for this Apple ID."
+            )
+        }
+    }
+
     private var paywallSecondaryText: Color {
         colorScheme == .dark ? Color.white.opacity(0.78) : Color.primary.opacity(0.72)
     }
@@ -190,11 +229,21 @@ struct PremiumPaywallView: View {
     private var purchaseButtons: some View {
         VStack(spacing: 10) {
 
-            // Error message — dynamic from StoreKit, not localized
-            if case .error(let message) = entitlements.purchaseState {
-                Text(message)
+            // Error message — localized via Paywall.xcstrings
+            if case .error(let kind) = entitlements.purchaseState {
+                Text(errorMessage(for: kind))
                     .font(AppFont.fine())
                     .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, AppSpacing.buttonHorizontal)
+                    .transition(.opacity)
+            }
+
+            // Informational message — e.g. "no previous purchases found"
+            if case .info(let kind) = entitlements.purchaseState {
+                Text(infoMessage(for: kind))
+                    .font(AppFont.fine())
+                    .foregroundStyle(paywallMutedText)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, AppSpacing.buttonHorizontal)
                     .transition(.opacity)

--- a/Connections/Views/SessionBuilderView.swift
+++ b/Connections/Views/SessionBuilderView.swift
@@ -11,6 +11,7 @@ struct SessionBuilderView: View {
     @Environment(EntitlementStore.self) private var entitlements
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     // MARK: - Stage
 
@@ -436,18 +437,18 @@ struct SessionBuilderView: View {
                         .tracking(0.5)
 
                     Text(String(localized: "sessionBuilder.composition.fallInLoveCount", defaultValue: "36 questions"))
-                        .font(.system(size: 20, weight: .medium, design: .serif))
+                        .font(.system(.title3, design: .serif, weight: .medium))
 
                     Text(String(localized: "sessionBuilder.composition.fallInLoveSubtitle", defaultValue: "designed to build closeness"))
-                        .font(.system(size: 14))
+                        .font(AppFont.detail())
                         .foregroundStyle(.secondary)
                 } else {
                     Text(selectedLength.localizedLabel)
                         .contentTransition(.interpolate)
-                        .font(.system(size: 20, weight: .medium, design: .serif))
+                        .font(.system(.title3, design: .serif, weight: .medium))
 
                     Text(compositionSubline)
-                        .font(.system(size: 14))
+                        .font(AppFont.detail())
                         .foregroundStyle(.secondary)
                         .contentTransition(.interpolate)
                         .id(compositionSubline)
@@ -456,39 +457,72 @@ struct SessionBuilderView: View {
             .multilineTextAlignment(.center)
 
             if selectedTopic != .fallInLove {
-                HStack(spacing: 8) {
-                    ForEach(SessionLength.allCases) { length in
-                        Button {
-                            if length == .long && !entitlements.canUseLongSessions {
-                                paywallVariant = .general
-                                return
-                            }
-                            selectedLength = length
-                            hasCustomizedLength = true
-                        } label: {
-                            VStack(spacing: 3) {
+                if dynamicTypeSize.isAccessibilitySize {
+                    VStack(spacing: 8) {
+                        ForEach(SessionLength.allCases) { length in
+                            Button {
+                                if length == .long && !entitlements.canUseLongSessions {
+                                    paywallVariant = .general
+                                    return
+                                }
+                                selectedLength = length
+                                hasCustomizedLength = true
+                            } label: {
                                 Text("\(length.rawValue)")
-                                    .font(.system(size: 15, weight: selectedLength == length ? .semibold : .regular))
+                                    .font(AppFont.caption())
+                                    .fontWeight(selectedLength == length ? .semibold : .regular)
                                     .foregroundStyle(selectedLength == length ? .white : .primary)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 10)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                            .fill(selectedLength == length
+                                                ? AppColor.primaryButtonBg(colorScheme)
+                                                : AppColor.surface(colorScheme))
+                                    )
                             }
-                            .frame(width: 52, height: 36)
-                            .padding(.vertical, 2)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 10, style: .continuous)
-                                        .fill(selectedLength == length
-                                            ? AppColor.primaryButtonBg(colorScheme)
-                                            : AppColor.surface(colorScheme))
-                                )
+                            .buttonStyle(.plain)
+                            .animation(.easeOut(duration: 0.15), value: selectedLength)
+                            .accessibilityLabel(length.localizedLabel)
+                            .accessibilityAddTraits(selectedLength == length ? .isSelected : [])
                         }
-                        .buttonStyle(.plain)
-                        .animation(.easeOut(duration: 0.15), value: selectedLength)
-                        .accessibilityLabel(length.localizedLabel)
-                        .accessibilityAddTraits(selectedLength == length ? .isSelected : [])
+                    }
+                } else {
+                    HStack(spacing: 8) {
+                        ForEach(SessionLength.allCases) { length in
+                            Button {
+                                if length == .long && !entitlements.canUseLongSessions {
+                                    paywallVariant = .general
+                                    return
+                                }
+                                selectedLength = length
+                                hasCustomizedLength = true
+                            } label: {
+                                VStack(spacing: 3) {
+                                    Text("\(length.rawValue)")
+                                        .font(AppFont.caption())
+                                        .fontWeight(selectedLength == length ? .semibold : .regular)
+                                        .foregroundStyle(selectedLength == length ? .white : .primary)
+                                }
+                                .frame(width: 52, height: 36)
+                                .padding(.vertical, 2)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                            .fill(selectedLength == length
+                                                ? AppColor.primaryButtonBg(colorScheme)
+                                                : AppColor.surface(colorScheme))
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .animation(.easeOut(duration: 0.15), value: selectedLength)
+                            .accessibilityLabel(length.localizedLabel)
+                            .accessibilityAddTraits(selectedLength == length ? .isSelected : [])
+                        }
                     }
                 }
             } else {
                 Text(String(localized: "sessionBuilder.composition.fallInLoveProgress", defaultValue: "Your progress is saved between sessions"))
-                    .font(.system(size: 13))
+                    .font(AppFont.detail())
                     .foregroundStyle(.tertiary)
             }
         }
@@ -551,10 +585,11 @@ struct SessionBuilderView: View {
                     HStack {
                         VStack(alignment: .leading, spacing: 2) {
                             Text(String(localized: "sessionBuilder.followUps.title", defaultValue: "Follow-up questions"))
-                                .font(.system(size: 15, weight: .medium))
+                                .font(AppFont.caption())
+                                .fontWeight(.medium)
 
                             Text(String(localized: "sessionBuilder.followUps.subtitle", defaultValue: "Adds gentle prompts to help you go deeper."))
-                                .font(.system(size: 13))
+                                .font(AppFont.detail())
                                 .foregroundStyle(.secondary)
                         }
 
@@ -618,7 +653,8 @@ struct SessionBuilderView: View {
                 Text(selectedTopic == .fallInLove
                      ? String(localized: "sessionSetup.button.begin", defaultValue: "Begin")
                      : String(localized: "sessionSetup.button.start", defaultValue: "Start Session"))
-                    .font(.system(size: 17, weight: .semibold))
+                    .font(AppFont.buttonSecondary())
+                    .fontWeight(.semibold)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 18)
                     .foregroundStyle(.white)

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -21,6 +21,11 @@ struct SessionPlayView: View {
     @State private var recommendation: SessionRecommendation?
     @State private var reviewPromptTask: Task<Void, Never>?
 
+    private enum ScrollAnchor {
+        static let top = "sessionPromptTop"
+        static let bottom = "sessionPromptBottom"
+    }
+
     var body: some View {
         ZStack {
             AtmosphericBackground(intensity: session.selectedIntensity)
@@ -69,16 +74,41 @@ struct SessionPlayView: View {
                         tintColor: session.selectedIntensity?.toneColor.opacity(0.45)
                     )
 
-                    Spacer(minLength: 40)
+                    GeometryReader { proxy in
+                        ScrollViewReader { scrollProxy in
+                            ScrollView(.vertical, showsIndicators: false) {
+                                VStack(spacing: 0) {
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.top)
 
-                    if let prompt = session.currentPrompt {
-                        promptContent(prompt)
+                                    Spacer(minLength: 40)
+
+                                    if let prompt = session.currentPrompt {
+                                        promptContent(prompt)
+                                    }
+
+                                    Spacer(minLength: 24)
+
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .id(ScrollAnchor.bottom)
+                                }
+                                .frame(minHeight: proxy.size.height)
+                            }
+                            .onChange(of: session.shownFollowUps.count) { _, count in
+                                guard count > 0 else { return }
+                                scrollToPromptBottom(scrollProxy)
+                            }
+                            .onChange(of: promptTransitionID) { _, _ in
+                                resetPromptScroll(scrollProxy)
+                            }
+                        }
                     }
-
-                    Spacer()
-
-                    if session.currentPrompt != nil {
-                        actionButtons
+                    .safeAreaInset(edge: .bottom) {
+                        if session.currentPrompt != nil {
+                            actionButtons
+                        }
                     }
 
                 } else {
@@ -294,6 +324,20 @@ struct SessionPlayView: View {
         .padding(.horizontal, AppSpacing.contentHorizontal)
         .padding(.bottom, 48)
         .animation(.easeOut(duration: 0.2), value: session.shownFollowUps.count)
+    }
+
+    private func scrollToPromptBottom(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            withAnimation(.easeOut(duration: 0.25)) {
+                proxy.scrollTo(ScrollAnchor.bottom, anchor: .bottom)
+            }
+        }
+    }
+
+    private func resetPromptScroll(_ proxy: ScrollViewProxy) {
+        DispatchQueue.main.async {
+            proxy.scrollTo(ScrollAnchor.top, anchor: .top)
+        }
     }
 
     // MARK: - Session Complete Content

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -157,7 +157,7 @@ struct SessionPlayView: View {
                 VStack(spacing: 8) {
                     ForEach(session.shownFollowUps) { followUp in
                         Text(followUp.text)
-                            .font(.system(size: 15))
+                            .font(AppFont.caption())
                             .foregroundStyle(.secondary)
                             .padding(.horizontal, 20)
                             .padding(.vertical, 10)
@@ -304,11 +304,12 @@ struct SessionPlayView: View {
             if let summary = session.generateSummary() {
                 VStack(spacing: 8) {
                     Text(summary.title)
-                        .font(.system(size: 28, weight: .regular, design: .serif))
+                        .font(AppFont.promptText())
                         .multilineTextAlignment(.center)
 
                     Text(summary.supportingLine)
-                        .font(.system(size: 15, weight: .regular, design: .serif))
+                        .font(AppFont.caption())
+                        .fontDesign(.serif)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                 }
@@ -323,13 +324,14 @@ struct SessionPlayView: View {
                         VStack(spacing: 8) {
                             ForEach(summary.reflectionLines, id: \.self) { line in
                                 Text(line)
-                                    .font(.system(size: 14))
+                                    .font(AppFont.detail())
                                     .foregroundStyle(.secondary)
                             }
 
                             if let nextStep = summary.nextStep {
                                 Text(nextStep)
-                                    .font(.system(size: 14, weight: .regular, design: .serif))
+                                    .font(AppFont.detail())
+                                    .fontDesign(.serif)
                                     .foregroundStyle(.tertiary)
                                     .italic()
                                     .padding(.top, 2)
@@ -337,12 +339,15 @@ struct SessionPlayView: View {
 
                             if let rec = recommendation {
                                 Text(rec.strength.label)
-                                    .font(.system(size: 16, weight: .semibold, design: .serif))
+                                    .font(AppFont.label())
+                                    .fontDesign(.serif)
+                                    .fontWeight(.semibold)
                                     .foregroundStyle(.primary)
                                     .padding(.top, 8)
 
                                 Text(rec.explanation)
-                                    .font(.system(size: 15, weight: .medium))
+                                    .font(AppFont.caption())
+                                    .fontWeight(.medium)
                                     .foregroundStyle(.primary)
                                     .padding(.top, 2)
 
@@ -354,7 +359,9 @@ struct SessionPlayView: View {
                                     }
                                 }()
                                 Text(recommendationPrompt)
-                                    .font(.system(size: 15, weight: .medium, design: .serif))
+                                    .font(AppFont.caption())
+                                    .fontDesign(.serif)
+                                    .fontWeight(.medium)
                                     .foregroundStyle(.secondary)
                                     .padding(.top, 6)
                             }
@@ -368,7 +375,8 @@ struct SessionPlayView: View {
                                     applyRecommendation()
                                 } label: {
                                     Text(String(localized: "sessionPlay.button.startNextSession", defaultValue: "Start next session"))
-                                        .font(.system(size: 17, weight: .semibold))
+                                        .font(AppFont.buttonSecondary())
+                                        .fontWeight(.semibold)
                                         .foregroundStyle(.white)
                                         .frame(maxWidth: .infinity)
                                         .padding(.vertical, 18)
@@ -380,7 +388,8 @@ struct SessionPlayView: View {
                                     dismiss()
                                 } label: {
                                     Text(String(localized: "sessionPlay.button.chooseMyself", defaultValue: "Choose myself"))
-                                        .font(.system(size: 15, weight: .medium))
+                                        .font(AppFont.caption())
+                                        .fontWeight(.medium)
                                         .foregroundStyle(.secondary)
                                         .frame(maxWidth: .infinity)
                                         .padding(.vertical, 8)
@@ -451,7 +460,8 @@ struct SessionPlayView: View {
                     ForEach(Array(moments.enumerated()), id: \.offset) { _, moment in
                         VStack(spacing: 6) {
                             Text(moment.promptText)
-                                .font(.system(size: 14, design: .serif))
+                                .font(AppFont.detail())
+                                .fontDesign(.serif)
                                 .foregroundStyle(.secondary)
                                 .multilineTextAlignment(.center)
                                 .italic()

--- a/Connections/Views/SessionPlayView.swift
+++ b/Connections/Views/SessionPlayView.swift
@@ -264,7 +264,8 @@ struct SessionPlayView: View {
                         }
                     } label: {
                         Text(String(localized: "common.button.back", defaultValue: "Back"))
-                            .font(.system(size: 20, weight: .medium))
+                            .font(AppFont.buttonSecondary())
+                            .fontWeight(.medium)
                             .foregroundStyle(.tertiary)
                     }
                     .buttonStyle(.plain)
@@ -454,7 +455,8 @@ struct SessionPlayView: View {
         if !moments.isEmpty {
             VStack(spacing: 14) {
                 Text(String(localized: "sessionPlay.moments.title", defaultValue: "Moments that stayed with you"))
-                    .font(.system(size: 16, weight: .medium, design: .serif))
+                    .font(AppFont.label())
+                    .fontDesign(.serif)
 
                 VStack(spacing: 10) {
                     ForEach(Array(moments.enumerated()), id: \.offset) { _, moment in
@@ -494,7 +496,8 @@ struct SessionPlayView: View {
             dismiss()
         } label: {
             Text(String(localized: "common.button.close", defaultValue: "Close"))
-                .font(.system(size: 17, weight: .semibold))
+                .font(AppFont.buttonSecondary())
+                .fontWeight(.semibold)
                 .foregroundStyle(.white)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 18)

--- a/Connections/Views/SessionSetupView.swift
+++ b/Connections/Views/SessionSetupView.swift
@@ -11,6 +11,7 @@ struct SessionSetupView: View {
     @Environment(EntitlementStore.self) private var entitlements
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     private var availableTopics: [Topic] {
         guard let mode = session.selectedMode, let intensity = session.selectedIntensity else {
@@ -46,146 +47,177 @@ struct SessionSetupView: View {
 
             VStack(spacing: 8) {
                 Text(String(localized: "sessionSetup.header.title", defaultValue: "Set up your session"))
-                    .font(.system(size: 28, weight: .regular, design: .serif))
+                    .font(AppFont.promptText())
 
                 if let mode = session.selectedMode, let intensity = session.selectedIntensity {
                     Text(String(format: String(localized: "sessionSetup.header.subtitle", defaultValue: "%1$@ · %2$@"), mode.localizedTitle, intensity.localizedTitle))
-                        .font(.system(size: 15))
+                        .font(AppFont.caption())
                         .foregroundStyle(.secondary)
                 }
             }
             .padding(.top, 48)
             .padding(.bottom, 36)
 
-            // MARK: - Session Length
+            // MARK: - Scrollable Content
 
-            if selectedTopic != .fallInLove {
-                VStack(alignment: .leading, spacing: 14) {
-                    Text(String(localized: "sessionSetup.questionCount.label", defaultValue: "Question count"))
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(.secondary)
-                        .padding(.leading, 4)
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack(spacing: 0) {
 
-                    HStack(spacing: 10) {
-                        ForEach(SessionLength.allCases) { length in
-                            LengthOption(
-                                label: "\(length.rawValue)",
-                                isSelected: selectedLength == length
-                            ) {
-                                if length == .long && !entitlements.canUseLongSessions {
+                    // MARK: - Session Length
+
+                    if selectedTopic != .fallInLove {
+                        VStack(alignment: .leading, spacing: 14) {
+                            Text(String(localized: "sessionSetup.questionCount.label", defaultValue: "Question count"))
+                                .font(AppFont.detail())
+                                .fontWeight(.medium)
+                                .foregroundStyle(.secondary)
+                                .padding(.leading, 4)
+
+                            if dynamicTypeSize.isAccessibilitySize {
+                                VStack(spacing: 8) {
+                                    ForEach(SessionLength.allCases) { length in
+                                        LengthOption(
+                                            label: "\(length.rawValue)",
+                                            isSelected: selectedLength == length
+                                        ) {
+                                            if length == .long && !entitlements.canUseLongSessions {
+                                                paywallVariant = .general
+                                                return
+                                            }
+                                            selectedLength = length
+                                        }
+                                    }
+                                }
+                            } else {
+                                HStack(spacing: 10) {
+                                    ForEach(SessionLength.allCases) { length in
+                                        LengthOption(
+                                            label: "\(length.rawValue)",
+                                            isSelected: selectedLength == length
+                                        ) {
+                                            if length == .long && !entitlements.canUseLongSessions {
+                                                paywallVariant = .general
+                                                return
+                                            }
+                                            selectedLength = length
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        .padding(.horizontal, 24)
+                    }
+
+                    // MARK: - Topic
+
+                    VStack(alignment: .leading, spacing: 14) {
+                        Text(String(localized: "sessionSetup.topic.label", defaultValue: "Topic"))
+                            .font(AppFont.detail())
+                            .fontWeight(.medium)
+                            .foregroundStyle(.secondary)
+                            .padding(.leading, 4)
+
+                        TopicSelector(
+                            selectedTopic: $selectedTopic,
+                            availableTopics: availableTopics,
+                            mode: session.selectedMode,
+                            onSelectTopic: { topic in
+                                if topic == .sex && !entitlements.canUseSex {
                                     paywallVariant = .general
                                     return
                                 }
-                                selectedLength = length
+                                if topic == .fallInLove && !entitlements.canUseFallInLove {
+                                    paywallVariant = .general
+                                    return
+                                }
+                                selectedTopic = topic
                             }
-                        }
+                        )
                     }
-                }
-                .padding(.horizontal, 24)
-            }
+                    .padding(.horizontal, 24)
+                    .padding(.top, 28)
 
-            // MARK: - Topic
+                    // MARK: - Follow-Ups Toggle
 
-            VStack(alignment: .leading, spacing: 14) {
-                Text(String(localized: "sessionSetup.topic.label", defaultValue: "Topic"))
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .padding(.leading, 4)
+                    if selectedTopic != .fallInLove {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(String(localized: "sessionSetup.followUps.title", defaultValue: "Follow-up prompts"))
+                                    .font(AppFont.label())
 
-                TopicSelector(
-                    selectedTopic: $selectedTopic,
-                    availableTopics: availableTopics,
-                    mode: session.selectedMode,
-                    onSelectTopic: { topic in
-                        if topic == .sex && !entitlements.canUseSex {
-                            paywallVariant = .general
-                            return
+                                Text(String(localized: "sessionSetup.followUps.subtitle", defaultValue: "Adds optional prompts to go deeper during the session"))
+                                    .font(AppFont.detail())
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Spacer()
+
+                            Toggle("", isOn: $followUps)
+                                .labelsHidden()
+                                .tint(AppColor.toggleTint)
                         }
-                        if topic == .fallInLove && !entitlements.canUseFallInLove {
-                            paywallVariant = .general
-                            return
-                        }
-                        selectedTopic = topic
-                    }
-                )
-            }
-            .padding(.horizontal, 24)
-            .padding(.top, 28)
-
-            // MARK: - Follow-Ups Toggle
-
-            if selectedTopic != .fallInLove {
-                HStack {
-                    VStack(alignment: .leading, spacing: 3) {
-                        Text(String(localized: "sessionSetup.followUps.title", defaultValue: "Follow-up prompts"))
-                            .font(.system(size: 16, weight: .medium))
-
-                        Text(String(localized: "sessionSetup.followUps.subtitle", defaultValue: "Adds optional prompts to go deeper during the session"))
-                            .font(.system(size: 13))
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Spacer()
-
-                    Toggle("", isOn: $followUps)
-                        .labelsHidden()
-                        .tint(AppColor.toggleTint)
-                }
-                .padding(.horizontal, 28)
-                .padding(.top, 32)
-            } else {
-                // Fall in Love description
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(String(localized: "sessionSetup.fallInLove.title", defaultValue: "36 questions designed to build closeness"))
-                        .font(.system(size: 15, weight: .medium))
-
-                    Text(String(localized: "sessionSetup.fallInLove.body", defaultValue: "Questions progress from casual to deeply personal. Your progress is saved so you can pause and return anytime."))
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.horizontal, 28)
-                .padding(.top, 32)
-            }
-
-            Spacer()
-
-            // MARK: - Start Button
-
-            Button {
-                if selectedTopic == .fallInLove {
-                    let skip = session.selectedMode == .friends
-                        ? settings.skipFallInLoveIntroFriends
-                        : settings.skipFallInLoveIntroCouples
-                    if skip {
-                        route = .fallInLove
+                        .padding(.horizontal, 28)
+                        .padding(.top, 32)
                     } else {
-                        route = .fallInLoveIntro
+                        // Fall in Love description
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(String(localized: "sessionSetup.fallInLove.title", defaultValue: "36 questions designed to build closeness"))
+                                .font(AppFont.caption())
+                                .fontWeight(.medium)
+
+                            Text(String(localized: "sessionSetup.fallInLove.body", defaultValue: "Questions progress from casual to deeply personal. Your progress is saved so you can pause and return anytime."))
+                                .font(AppFont.detail())
+                                .foregroundStyle(.secondary)
+                        }
+                        .padding(.horizontal, 28)
+                        .padding(.top, 32)
                     }
-                } else {
-                    if selectedLength == .long && !entitlements.canUseLongSessions {
-                        paywallVariant = .general
-                        return
-                    }
-                    session.selectedSessionLength = selectedLength
-                    session.selectedTopic = selectedTopic
-                    session.followUpsEnabled = followUps
-                    if session.selectedIntensity == .mixed {
-                        session.mixedIntensities = entitlements.mixedIntensities
-                    }
-                    route = .session
                 }
-            } label: {
-                Text(selectedTopic == .fallInLove
-                     ? String(localized: "sessionSetup.button.begin", defaultValue: "Begin")
-                     : String(localized: "sessionSetup.button.start", defaultValue: "Start Session"))
-                    .font(.system(size: 17, weight: .semibold))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 18)
-                    .foregroundColor(.white)
-                    .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                .padding(.bottom, 16)
             }
-            .padding(.horizontal, 36)
-            .padding(.bottom, 52)
+            .safeAreaInset(edge: .bottom) {
+
+                // MARK: - Start Button
+
+                Button {
+                    if selectedTopic == .fallInLove {
+                        let skip = session.selectedMode == .friends
+                            ? settings.skipFallInLoveIntroFriends
+                            : settings.skipFallInLoveIntroCouples
+                        if skip {
+                            route = .fallInLove
+                        } else {
+                            route = .fallInLoveIntro
+                        }
+                    } else {
+                        if selectedLength == .long && !entitlements.canUseLongSessions {
+                            paywallVariant = .general
+                            return
+                        }
+                        session.selectedSessionLength = selectedLength
+                        session.selectedTopic = selectedTopic
+                        session.followUpsEnabled = followUps
+                        if session.selectedIntensity == .mixed {
+                            session.mixedIntensities = entitlements.mixedIntensities
+                        }
+                        route = .session
+                    }
+                } label: {
+                    Text(selectedTopic == .fallInLove
+                         ? String(localized: "sessionSetup.button.begin", defaultValue: "Begin")
+                         : String(localized: "sessionSetup.button.start", defaultValue: "Start Session"))
+                        .font(AppFont.buttonSecondary())
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 18)
+                        .foregroundColor(.white)
+                        .background(AppColor.primaryButtonBg(colorScheme), in: .capsule)
+                }
+                .padding(.horizontal, 36)
+                .padding(.top, 10)
+                .padding(.bottom, 36)
+                .background(.ultraThinMaterial)
+            }
         }
         } // ZStack
         .navigationBarBackButtonHidden(true)
@@ -239,7 +271,8 @@ struct LengthOption: View {
     var body: some View {
         Button(action: action) {
             Text(label)
-                .font(.system(size: 16, weight: isSelected ? .semibold : .regular))
+                .font(AppFont.label())
+                .fontWeight(isSelected ? .semibold : .regular)
                 .foregroundStyle(isSelected ? .white : .primary)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 14)
@@ -306,7 +339,8 @@ struct TopicChip: View {
                         .font(.system(size: 8))
                 }
             }
-            .font(.system(size: 13, weight: state == .selected ? .semibold : .regular))
+            .font(AppFont.detail())
+            .fontWeight(state == .selected ? .semibold : .regular)
             .foregroundStyle(foregroundColor)
             .padding(.horizontal, 14)
             .padding(.vertical, 9)

--- a/ConnectionsUITests/ConnectionsUITestsLaunchTests.swift
+++ b/ConnectionsUITests/ConnectionsUITestsLaunchTests.swift
@@ -5,6 +5,7 @@
 
 import XCTest
 
+@MainActor
 final class AppStoreScreenshots: XCTestCase {
 
     var app: XCUIApplication!

--- a/Tests/ConnectionsTests/EntitlementStoreTests.swift
+++ b/Tests/ConnectionsTests/EntitlementStoreTests.swift
@@ -103,9 +103,10 @@ final class EntitlementStoreTests: XCTestCase {
     func testPurchaseStateEquatability() {
         XCTAssertEqual(EntitlementStore.PurchaseState.idle, .idle)
         XCTAssertEqual(EntitlementStore.PurchaseState.loading, .loading)
-        XCTAssertEqual(EntitlementStore.PurchaseState.error("msg"), .error("msg"))
+        XCTAssertEqual(EntitlementStore.PurchaseState.error(.productUnavailable), .error(.productUnavailable))
+        XCTAssertEqual(EntitlementStore.PurchaseState.info(.nothingToRestore), .info(.nothingToRestore))
         XCTAssertNotEqual(EntitlementStore.PurchaseState.idle, .loading)
-        XCTAssertNotEqual(EntitlementStore.PurchaseState.error("a"), .error("b"))
+        XCTAssertNotEqual(EntitlementStore.PurchaseState.error(.productUnavailable), .error(.purchaseFailed))
     }
 
     // MARK: - Product ID


### PR DESCRIPTION
## Summary

Fixes the App Store rejection (Guideline 2.1(b)) where the reviewer saw a generic error tapping "Unlock Full Access." Root cause was `loadProduct()` swallowing the empty-result case from `Product.products(for:)` via `try?`, leaving `product` nil and surfacing a dead-end message.

- Log Product.products failures + empty results via os_log so future rejections are diagnosable from Console
- Retry loadProduct() once when purchase is tapped with nil product (cold-launch race fix)
- Replace raw `localizedDescription` leaks with Apple HIG-aligned wording (actionable, offers Retry + Restore, no "contact support" dead-ends)
- Add `PurchaseState.info(.nothingToRestore)` so Restore with no prior purchase stops silently returning to idle (this tap-does-nothing pattern is a known 2.1(b) rejection vector per Apple forum 814236)
- Refactor `PurchaseState` to carry semantic `ErrorKind`/`InfoKind` enums; paywall view maps each case to a localized string via the existing `paywallString` helper
- Add 5 new keys to `Paywall.xcstrings` with English values (other locales fall back to English until translated)
- Fix pre-existing Swift concurrency error in `AppStoreScreenshots` UI test (`setupSnapshot` is @MainActor; class is now @MainActor) — unblocks `xcodebuild build-for-testing`
- Full accessibility pass: Dynamic Type font tokens, scroll resilience on setup screens, and play screen truncation fix (GeometryReader + ScrollView pattern)

## Test plan

- [ ] App target builds clean (`xcodebuild -project Connections.xcodeproj -scheme Connections -destination 'platform=iOS Simulator,name=iPhone 16' build`)
- [ ] Test target builds clean now that the UITests concurrency error is fixed (`xcodebuild ... build-for-testing`)
- [ ] Existing `EntitlementStoreTests` pass (Equatability test updated for new enum shape)
- [ ] Manually verify on simulator: tap "Unlock Full Access" with no .storekit file loaded → debug build shows the dev hint, release build shows the actionable "Full Access isn't available right now..." string
- [ ] Manually verify Restore with no prior purchase → shows muted "No previous purchases were found for this Apple ID." (not red, not silent)
- [ ] Check Console.app for os_log entries under subsystem `com.tanner.Connections`, category `StoreKit`
- [ ] Set simulator to German locale + Accessibility XXL text: prompts wrap, no "..." truncation; setup screens scroll instead of clipping

## Out of scope

- App Store Connect IAP metadata (Paid Apps Agreement, App Review Screenshot, IAP attachment to version submission) — must still be completed manually before resubmission
- Translation of the new strings into the other 12 supported locales
- Pre-existing duplicate test file at `ConnectionsTests/EntitlementStoreTests.swift` (orphaned, references nonexistent symbols)
- Pre-existing topic display name conflict: both `Topic.intimacy` and `Topic.sex` localize to "Intimacy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)