### PR TITLE
Keep invite language links on offer pages

### DIFF
--- a/docs/marketing-page/build-html.mjs
+++ b/docs/marketing-page/build-html.mjs
@@ -13,21 +13,75 @@ const researchLinks = [
 ];
 
 const redeemLabels = {
-  "en-US": "Have a code? Redeem Full Access free",
-  "es-ES": "¿Tienes un código? Canjea Acceso Completo gratis",
-  "fr": "Vous avez un code ? Débloquez l'Accès complet gratuitement",
-  "de": "Hast du einen Code? Vollzugriff gratis freischalten",
-  "pt-BR": "Tem um código? Resgate o Acesso Completo grátis",
-  "nl": "Heb je een code? Verzilver gratis Volledige toegang",
-  "it": "Hai un codice? Riscatta l'Accesso completo gratis",
-  "sv": "Har du en kod? Lös in Full åtkomst gratis",
-  "da": "Har du en kode? Indløs Fuld adgang gratis",
-  "nb": "Har du en kode? Løs inn Full tilgang gratis",
-  "fi": "Onko sinulla koodi? Lunasta Täysi käyttöoikeus ilmaiseksi",
-  "pl": "Masz kod? Odbierz Pełny dostęp za darmo",
-  "ja": "コードをお持ちですか？フルアクセスを無料で利用",
-  "zh-Hans": "有兑换码？免费解锁完整版",
-  "ru": "Есть код? Получите полный доступ бесплатно",
+  "en-US": "Redeem Full Access Free",
+  "es-ES": "Canjea Acceso Completo gratis",
+  "fr": "Débloquez l'Accès complet gratuitement",
+  "de": "Vollzugriff gratis freischalten",
+  "pt-BR": "Resgate o Acesso Completo grátis",
+  "nl": "Verzilver gratis Volledige toegang",
+  "it": "Riscatta l'Accesso completo gratis",
+  "sv": "Lös in Full åtkomst gratis",
+  "da": "Indløs Fuld adgang gratis",
+  "nb": "Løs inn Full tilgang gratis",
+  "fi": "Lunasta Täysi käyttöoikeus ilmaiseksi",
+  "pl": "Odbierz Pełny dostęp za darmo",
+  "ja": "フルアクセスを無料で利用",
+  "zh-Hans": "免费解锁完整版",
+  "ru": "Получите полный доступ бесплатно",
+};
+
+const offerEyebrows = {
+  "en-US": "Limited-time offer",
+  "es-ES": "Oferta por tiempo limitado",
+  "fr": "Offre à durée limitée",
+  "de": "Zeitlich begrenztes Angebot",
+  "pt-BR": "Oferta por tempo limitado",
+  "nl": "Tijdelijke aanbieding",
+  "it": "Offerta a tempo limitato",
+  "sv": "Tidsbegränsat erbjudande",
+  "da": "Tidsbegrænset tilbud",
+  "nb": "Tidsbegrenset tilbud",
+  "fi": "Rajoitetun ajan tarjous",
+  "pl": "Oferta ograniczona czasowo",
+  "ja": "期間限定オファー",
+  "zh-Hans": "限时优惠",
+  "ru": "Предложение ограничено по времени",
+};
+
+const offerTitles = {
+  "en-US": "Full Access is free through July 30, 2026",
+  "es-ES": "Acceso completo gratis hasta el 30 de julio de 2026",
+  "fr": "Accès complet gratuit jusqu'au 30 juillet 2026",
+  "de": "Vollzugriff gratis bis zum 30. Juli 2026",
+  "pt-BR": "Acesso Completo grátis até 30 de julho de 2026",
+  "nl": "Volledige toegang gratis tot 30 juli 2026",
+  "it": "Accesso completo gratis fino al 30 luglio 2026",
+  "sv": "Full åtkomst är gratis till 30 juli 2026",
+  "da": "Fuld adgang er gratis til 30. juli 2026",
+  "nb": "Full tilgang er gratis til 30. juli 2026",
+  "fi": "Täysi käyttöoikeus ilmaiseksi 30. heinäkuuta 2026 asti",
+  "pl": "Pełny dostęp za darmo do 30 lipca 2026",
+  "ja": "2026年7月30日までフルアクセス無料",
+  "zh-Hans": "完整版免费开放至 2026 年 7 月 30 日",
+  "ru": "Полный доступ бесплатен до 30 июля 2026 года",
+};
+
+const offerBodies = {
+  "en-US": "Unlock the premium library with 2,800+ prompts and follow-up questions.",
+  "es-ES": "Desbloquea la biblioteca premium con más de 2,800 preguntas y seguimientos.",
+  "fr": "Débloquez la bibliothèque premium avec plus de 2 800 questions et relances.",
+  "de": "Schalte die Premium-Bibliothek mit über 2.800 Prompts und Folgefragen frei.",
+  "pt-BR": "Desbloqueie a biblioteca premium com mais de 2.800 prompts e perguntas de acompanhamento.",
+  "nl": "Ontgrendel de premiumbibliotheek met 2.800+ prompts en vervolgvragen.",
+  "it": "Sblocca la libreria premium con oltre 2.800 prompt e domande di approfondimento.",
+  "sv": "Lås upp premiumbiblioteket med 2 800+ prompter och uppföljningsfrågor.",
+  "da": "Lås op for premiumbiblioteket med 2.800+ prompts og opfølgende spørgsmål.",
+  "nb": "Lås opp premiumbiblioteket med 2 800+ prompter og oppfølgingsspørsmål.",
+  "fi": "Avaa premiumkirjasto, jossa on yli 2 800 kehotetta ja jatkokysymystä.",
+  "pl": "Odblokuj bibliotekę premium z ponad 2 800 promptami i pytaniami pogłębiającymi.",
+  "ja": "2,800以上の質問とフォローアップ質問を含むプレミアムライブラリを利用できます。",
+  "zh-Hans": "解锁高级内容库，包含 2,800 多个问题和跟进问题。",
+  "ru": "Откройте премиум-библиотеку с 2 800+ вопросами и уточняющими подсказками.",
 };
 
 const locales = [
@@ -79,9 +133,29 @@ function cta(block, className = "button") {
   return `<a class="${className}" href="${appStoreUrl}">${escapeHtml(label)}</a>`;
 }
 
-function redeemCta(code) {
+function localized(map, code) {
+  return map[code] ?? map["en-US"];
+}
+
+function redeemCta(code, className = "button button-secondary") {
   const label = redeemLabels[code] ?? redeemLabels["en-US"];
-  return `<a class="button button-secondary" href="${redeemUrl}">${escapeHtml(label)}</a>`;
+  return `<a class="${className}" href="${redeemUrl}">${escapeHtml(label)}</a>`;
+}
+
+function offerBlock(code) {
+  return `<aside class="offer-card">
+            <p class="offer-eyebrow">${escapeHtml(localized(offerEyebrows, code))}</p>
+            <h2>${escapeHtml(localized(offerTitles, code))}</h2>
+            <p>${escapeHtml(localized(offerBodies, code))}</p>
+            ${redeemCta(code, "button button-offer")}
+          </aside>`;
+}
+
+function offerStrip(code) {
+  return `<aside class="offer-strip">
+      <p><strong>${escapeHtml(localized(offerEyebrows, code))}:</strong> ${escapeHtml(localized(offerTitles, code))}. ${escapeHtml(localized(offerBodies, code))}</p>
+      ${redeemCta(code, "button button-strip")}
+    </aside>`;
 }
 
 function card(block) {
@@ -142,6 +216,9 @@ function pageHtml(code, content, options = {}) {
   const ogUrl = ogHref === "./" ? ogBaseUrl : `${ogBaseUrl}${ogHref}`;
   const ogTitle = `${blocks[0]} — ${blocks[1]}`;
   const brandHref = options.brandHref ?? "./";
+  const heroAction = options.redeem
+    ? `${offerBlock(code)}\n          ${cta(blocks[3])}`
+    : cta(blocks[3]);
 
   return `<!DOCTYPE html>
 <html lang="${meta.lang}">
@@ -167,7 +244,7 @@ function pageHtml(code, content, options = {}) {
 </head>
 <body>
   <main class="page">
-    <header class="hero">
+${options.redeem ? `    ${offerStrip(code)}\n` : ""}    <header class="hero">
       <div class="topbar">
         <a class="brand" href="${escapeHtml(brandHref)}" aria-label="${escapeHtml(blocks[0])}">
           <span class="mark" aria-hidden="true"><span></span><span></span></span>
@@ -181,7 +258,7 @@ function pageHtml(code, content, options = {}) {
           <p class="eyebrow">${escapeHtml(blocks[0])}</p>
           <h1>${escapeHtml(blocks[1])}</h1>
           ${paragraph(blocks[2])}
-          ${cta(blocks[3])}
+          ${heroAction}
         </div>
         <div class="visual-card" aria-hidden="true">
           <div class="shape-square"></div>
@@ -293,6 +370,10 @@ body {
 a { color: var(--gold); text-decoration: none; }
 a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .page { width: min(1120px, calc(100% - 36px)); margin: 0 auto; padding: 28px 0 64px; }
+.offer-strip { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 0 0 26px; padding: 14px 16px; border: 1px solid rgba(242, 195, 95, 0.54); border-radius: 20px; background: linear-gradient(145deg, rgba(242, 195, 95, 0.2), rgba(255, 246, 222, 0.08)); box-shadow: 0 18px 58px rgba(0,0,0,.2); }
+.offer-strip p { margin: 0; color: var(--muted); font-size: 0.98rem; line-height: 1.35; }
+.offer-strip strong { color: var(--gold); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.82rem; }
+.button-strip { flex: 0 0 auto; min-height: 42px; margin-top: 0; background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.78); box-shadow: 0 14px 40px rgba(242, 195, 95, 0.24); }
 .topbar { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-bottom: 54px; }
 .brand { display: inline-flex; align-items: center; gap: 12px; color: var(--text); font-weight: 760; letter-spacing: -0.02em; }
 .mark { position: relative; width: 36px; height: 36px; border-radius: 12px; overflow: hidden; background: #0f251f; box-shadow: inset 0 0 0 1px var(--border); }
@@ -307,7 +388,12 @@ a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .hero-copy p { max-width: 680px; color: var(--muted); font-size: clamp(1.08rem, 2vw, 1.34rem); }
 .eyebrow { color: var(--gold) !important; font-size: 0.78rem !important; text-transform: uppercase; letter-spacing: 0.18em; font-weight: 780; margin-bottom: 12px; }
 .button { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; margin-top: 18px; padding: 0 20px; border-radius: 999px; background: var(--gold); color: #17100b; font-weight: 780; box-shadow: 0 12px 40px rgba(217, 133, 31, 0.26); }
-.button-secondary { background: transparent; color: var(--gold); border: 1px solid var(--border); box-shadow: none; margin-left: 10px; }
+.button-secondary { background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.72); box-shadow: 0 14px 42px rgba(242, 195, 95, 0.22); margin-left: 10px; }
+.offer-card { max-width: 640px; margin-top: 22px; padding: 22px; border: 1px solid rgba(242, 195, 95, 0.48); border-radius: 26px; background: linear-gradient(145deg, rgba(242, 195, 95, 0.18), rgba(255, 246, 222, 0.07)); box-shadow: 0 20px 70px rgba(0,0,0,.22); }
+.offer-card .offer-eyebrow { margin: 0 0 8px; color: var(--gold); font-size: 0.76rem; font-weight: 820; letter-spacing: 0.16em; text-transform: uppercase; }
+.offer-card h2 { margin: 0; color: var(--cream); font-size: clamp(1.42rem, 2.4vw, 2rem); line-height: 1.08; letter-spacing: -0.035em; }
+.offer-card p { margin: 10px 0 0; color: var(--muted); font-size: 1.02rem; }
+.button-offer { width: 100%; min-height: 54px; margin-top: 18px; background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.78); box-shadow: 0 18px 50px rgba(242, 195, 95, 0.26); }
 .visual-card { position: relative; min-height: 420px; border: 1px solid var(--border); border-radius: 36px; overflow: hidden; background: linear-gradient(145deg, #11251e, #08110f); box-shadow: var(--shadow); }
 .shape-square { position: absolute; width: 78%; height: 78%; left: -23%; top: 11%; border-radius: 30%; background: linear-gradient(145deg, #ffe4a7, #c99039); box-shadow: inset 0 0 18px rgba(255,255,255,.24); }
 .shape-circle { position: absolute; width: 76%; height: 76%; right: -25%; top: 12%; border-radius: 50%; background: linear-gradient(145deg, #1d4b3e, #07110f); box-shadow: inset 0 0 14px rgba(255,224,161,.16); }
@@ -335,10 +421,13 @@ a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .footer { display: flex; justify-content: center; gap: 18px; flex-wrap: wrap; color: var(--soft); padding: 34px 0 0; font-size: 0.95rem; }
 .footer a { color: var(--soft); text-decoration: underline; text-underline-offset: 0.18em; }
 @media (max-width: 820px) {
+  .offer-strip { align-items: stretch; flex-direction: column; }
+  .button-strip { width: 100%; }
   .topbar { align-items: flex-start; flex-direction: column; }
   .language-nav { justify-content: flex-start; }
   .hero-grid { grid-template-columns: 1fr; }
   .visual-card { min-height: 290px; }
+  .button-secondary { margin-left: 0; }
   .card-grid, .privacy-list { grid-template-columns: 1fr; }
   .section { border-radius: 24px; }
 }

--- a/docs/marketing-page/build-html.mjs
+++ b/docs/marketing-page/build-html.mjs
@@ -120,10 +120,14 @@ function faq(block) {
   </details>`;
 }
 
-function languageNav(currentCode) {
+function invitePageHref(code) {
+  return code === "en-US" ? "invite.html" : `invite-${code}.html`;
+}
+
+function languageNav(currentCode, options = {}) {
   return `<nav class="language-nav" aria-label="Language">
     ${locales.map(([code, label, , href]) => {
-      const target = code === "en-US" ? "./" : href;
+      const target = options.invite ? invitePageHref(code) : code === "en-US" ? "./" : href;
       const current = code === currentCode ? ` aria-current="page"` : "";
       return `<a href="${target}"${current}>${escapeHtml(label)}</a>`;
     }).join("\n")}
@@ -137,6 +141,7 @@ function pageHtml(code, content, options = {}) {
   const ogHref = options.ogHref ?? meta.href;
   const ogUrl = ogHref === "./" ? ogBaseUrl : `${ogBaseUrl}${ogHref}`;
   const ogTitle = `${blocks[0]} — ${blocks[1]}`;
+  const brandHref = options.brandHref ?? "./";
 
   return `<!DOCTYPE html>
 <html lang="${meta.lang}">
@@ -164,11 +169,11 @@ function pageHtml(code, content, options = {}) {
   <main class="page">
     <header class="hero">
       <div class="topbar">
-        <a class="brand" href="./" aria-label="${escapeHtml(blocks[0])}">
+        <a class="brand" href="${escapeHtml(brandHref)}" aria-label="${escapeHtml(blocks[0])}">
           <span class="mark" aria-hidden="true"><span></span><span></span></span>
           <span>${escapeHtml(blocks[0])}</span>
         </a>
-        ${languageNav(code)}
+        ${languageNav(code, { invite: options.inviteNav })}
       </div>
 
       <section class="hero-grid">
@@ -353,14 +358,15 @@ for (const [code] of locales) {
   }
 }
 
-const outreachPages = [
-  { sourceCode: "en-US", outFile: "invite.html" },
-];
+const outreachPages = locales.map(([sourceCode]) => ({
+  sourceCode,
+  outFile: invitePageHref(sourceCode),
+}));
 
 for (const { sourceCode, outFile } of outreachPages) {
   const sourcePath = join(sourceDir, `${sourceCode}.txt`);
   const content = readFileSync(sourcePath, "utf8");
-  const html = pageHtml(sourceCode, content, { redeem: true, ogHref: outFile });
+  const html = pageHtml(sourceCode, content, { redeem: true, ogHref: outFile, inviteNav: true, brandHref: outFile });
   writeFileSync(join(outputDir, outFile), html);
 }
 

--- a/docs/marketing/invite-da.html
+++ b/docs/marketing/invite-da.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="da">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Spørgsmål, der bringer mennesker tættere på hinanden.</title>
+  <meta name="description" content="Gennemtænkte samtaleprompts til par, venner, familie og egen refleksion. Vælg, hvem du er sammen med, sæt tonen, og lad det næste spørgsmål åbne noget ægte.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="da">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-da.html">
+  <meta property="og:title" content="Deeper Conversations — Spørgsmål, der bringer mennesker tættere på hinanden.">
+  <meta property="og:description" content="Gennemtænkte samtaleprompts til par, venner, familie og egen refleksion. Vælg, hvem du er sammen med, sæt tonen, og lad det næste spørgsmål åbne noget ægte.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Gennemtænkte samtaleprompts til par, venner, familie og egen refleksion. Vælg, hvem du er sammen med, sæt tonen, og lad det næste spørgsmål åbne noget ægte.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-da.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html" aria-current="page">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Spørgsmål, der bringer mennesker tættere på hinanden.</h1>
+          <p>Gennemtænkte samtaleprompts til par, venner, familie og egen refleksion. Vælg, hvem du er sammen med, sæt tonen, og lad det næste spørgsmål åbne noget ægte.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Hent i App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>De fleste relationer har ikke brug for flere råd.<br>De har brug for bedre åbninger.</h2>
+      <p>Det kan være svært at vide, hvordan man begynder en meningsfuld samtale. Deeper Conversations giver dig nøje udformede prompts og opfølgende spørgsmål, der hjælper mennesker videre end smalltalk uden at øjeblikket føles tvunget.</p>
+      <p>Brug den på en date, en biltur, en familiemiddag, en stille aften sammen eller et øjebliks refleksion alene.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspireret af forskning i nærhed</h2>
+      <p>Deeper Conversations bygger på en enkel, forskningsunderstøttet idé: mennesker føler sig ofte tættere på hinanden, når de deler gradvist, lytter opmærksomt og svarer med ægte nærvær.</p>
+<p>I et kendt studie fra 1997 fandt psykologen Arthur Aron og kolleger, at par af fremmede, der besvarede en række stadig mere personlige spørgsmål, rapporterede stærkere følelser af nærhed end par, der fik smalltalk-opgaver.</p>
+<p>Deeper Conversations kopierer ikke de oprindelige 36 spørgsmål. I stedet bygger appen videre på det samme grundmønster: begynd blidt, øg dybden over tid, og brug gennemtænkte opfølgninger til at hjælpe samtalen videre, når noget meningsfuldt åbner sig.</p>
+<p>Appen afspejler også bredere forskning i intimitet og forbindelse: selvafsløring betyder noget, men det gør følelsen af at blive forstået, accepteret og mødt også.</p>
+      <p>Læs forskningen:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Skabt til relationer, der betyder noget</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Par</h3>
+    <p>Føl jer tættere på hinanden, forstå hinanden bedre, og tal om det, der ofte forbliver usagt.</p>
+  </article>
+<article class="mini-card">
+    <h3>Venner</h3>
+    <p>Gå videre end opdateringer og interne jokes til samtaler, der viser, hvad der virkelig foregår.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familie</h3>
+    <p>Åbn minder, værdier, historier og samtaler mellem generationer, som måske ikke opstår af sig selv.</p>
+  </article>
+<article class="mini-card">
+    <h3>Egen refleksion</h3>
+    <p>Brug gennemtænkte spørgsmål til at forstå, hvad du føler, værdsætter, husker og ønsker.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Vælg tonen</h2>
+      <div class="tone-list">
+        <p>Begynd let, når du vil have noget enkelt.</p>
+<p>Bliv ærlig, når øjeblikket er klar.</p>
+<p>Gå dybere, når noget ægte åbner sig.</p>
+      </div>
+      <p>Hver session kan indeholde opfølgende spørgsmål, så samtalen ikke behøver at stoppe ved det første svar.</p>
+    </section>
+
+    <section class="section">
+      <h2>Guidede oplevelser inkluderet</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>En guidet spørgeoplevelse inspireret af forskning i nærhed og gradvis selvafsløring.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 spørgsmål på tværs af 9 livskapitler, designet til at spørge forældre, bedsteforældre, kære eller dig selv om minder, mening og arv.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>En enkel guidet måde at fortælle historier fra dit liv og høre historierne bag en andens.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Gennemtænkte spørgsmål om døden, omsorg, arv, familie, sorg, tilgivelse og det, der betyder mest, når tiden føles begrænset.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Hvorfor Fuld adgang er det værd</h2>
+      <p>Den gratis version hjælper dig i gang. Fuld adgang er for mennesker, der vil vende tilbage til Deeper Conversations igen og igen.</p>
+      <p>Fuld adgang låser op for hele premiumbiblioteket: 2.802 prompts og opfølgende spørgsmål, længere sessioner, intimitetsspørgsmål, Fall in Love, Life Story, Share an Experience, Mortality Conversations og flere guidede oplevelser.</p>
+      <p>Det betyder flere måder at:</p>
+  <ul>
+    <li>føle jer tættere på hinanden som par</li>
+<li>holde venskaber følelsesmæssigt levende</li>
+<li>stille familiemedlemmer spørgsmål, du måske ikke selv ville tænke på</li>
+<li>tale eftertænksomt om dødelighed, omsorg, arv, sorg og familiebeslutninger</li>
+<li>reflektere ærligt over dit eget liv</li>
+<li>fortsætte en samtale, når det første svar åbner noget vigtigt</li>
+  </ul>
+      <p class="purchase-note">Engangskøb. Intet abonnement.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privat fra starten</h2>
+      <div class="privacy-list">
+        <span>Ingen feeds.</span>
+<span>Ingen profiler.</span>
+<span>Ingen konto kræves.</span>
+<span>Intet pres for at præstere.</span>
+      </div>
+      <p>Deeper Conversations bygger på private prompts, kun i tekst. Appen indsamler, overfører eller deler ikke personligt samtaleindhold.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Tilgængelig på iPhone og iPad</h2>
+      <p>Brug den ved bordet, i sofaen, på en tur eller i et stille øjeblik alene.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Hent i App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kode? Indløs Fuld adgang gratis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Er Deeper Conversations kun for par?</summary>
+    <p>Nej. Den indeholder tilstande for par, venner, familie og egen refleksion.</p>
+  </details>
+<details>
+    <summary>Er det terapi?</summary>
+    <p>Nej. Deeper Conversations er ikke terapi eller medicinsk rådgivning. Det er en app til samtale og refleksion.</p>
+  </details>
+<details>
+    <summary>Er Fuld adgang et abonnement?</summary>
+    <p>Nej. Fuld adgang er et engangskøb, der giver livstidsadgang til hele Fuld adgang-biblioteket.</p>
+  </details>
+<details>
+    <summary>Indsamler appen mine samtaler?</summary>
+    <p>Nej. Appen indsamler, overfører eller deler ikke personligt samtaleindhold.</p>
+  </details>
+<details>
+    <summary>Hvilke enheder understøttes?</summary>
+    <p>Deeper Conversations fungerer på iPhone og iPad med iOS 18 eller nyere.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Privatlivspolitik</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-da.html
+++ b/docs/marketing/invite-da.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Tidsbegrænset tilbud:</strong> Fuld adgang er gratis til 30. juli 2026. Lås op for premiumbiblioteket med 2.800+ prompts og opfølgende spørgsmål.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Indløs Fuld adgang gratis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-da.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Spørgsmål, der bringer mennesker tættere på hinanden.</h1>
           <p>Gennemtænkte samtaleprompts til par, venner, familie og egen refleksion. Vælg, hvem du er sammen med, sæt tonen, og lad det næste spørgsmål åbne noget ægte.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Tidsbegrænset tilbud</p>
+            <h2>Fuld adgang er gratis til 30. juli 2026</h2>
+            <p>Lås op for premiumbiblioteket med 2.800+ prompts og opfølgende spørgsmål.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Indløs Fuld adgang gratis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Hent i App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Tilgængelig på iPhone og iPad</h2>
       <p>Brug den ved bordet, i sofaen, på en tur eller i et stille øjeblik alene.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Hent i App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kode? Indløs Fuld adgang gratis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Indløs Fuld adgang gratis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-de.html
+++ b/docs/marketing/invite-de.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Zeitlich begrenztes Angebot:</strong> Vollzugriff gratis bis zum 30. Juli 2026. Schalte die Premium-Bibliothek mit über 2.800 Prompts und Folgefragen frei.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Vollzugriff gratis freischalten</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-de.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Fragen, die Menschen näher bringen.</h1>
           <p>Durchdachte Gesprächsimpulse für Paare, Freunde, Familien und Selbstreflexion. Wähle, mit wem du sprichst, bestimme den Ton und lass die nächste Frage etwas Echtes öffnen.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Zeitlich begrenztes Angebot</p>
+            <h2>Vollzugriff gratis bis zum 30. Juli 2026</h2>
+            <p>Schalte die Premium-Bibliothek mit über 2.800 Prompts und Folgefragen frei.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Vollzugriff gratis freischalten</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Im App Store laden</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Verfügbar auf iPhone und iPad</h2>
       <p>Nutze es am Tisch, auf dem Sofa, unterwegs oder in einem ruhigen Moment allein.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Im App Store laden</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Hast du einen Code? Vollzugriff gratis freischalten</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Vollzugriff gratis freischalten</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-de.html
+++ b/docs/marketing/invite-de.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Fragen, die Menschen näher bringen.</title>
+  <meta name="description" content="Durchdachte Gesprächsimpulse für Paare, Freunde, Familien und Selbstreflexion. Wähle, mit wem du sprichst, bestimme den Ton und lass die nächste Frage etwas Echtes öffnen.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="de">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-de.html">
+  <meta property="og:title" content="Deeper Conversations — Fragen, die Menschen näher bringen.">
+  <meta property="og:description" content="Durchdachte Gesprächsimpulse für Paare, Freunde, Familien und Selbstreflexion. Wähle, mit wem du sprichst, bestimme den Ton und lass die nächste Frage etwas Echtes öffnen.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Durchdachte Gesprächsimpulse für Paare, Freunde, Familien und Selbstreflexion. Wähle, mit wem du sprichst, bestimme den Ton und lass die nächste Frage etwas Echtes öffnen.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-de.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html" aria-current="page">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Fragen, die Menschen näher bringen.</h1>
+          <p>Durchdachte Gesprächsimpulse für Paare, Freunde, Familien und Selbstreflexion. Wähle, mit wem du sprichst, bestimme den Ton und lass die nächste Frage etwas Echtes öffnen.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Im App Store laden</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>Die meisten Beziehungen brauchen nicht noch mehr Ratschläge.<br>Sie brauchen bessere Anfänge.</h2>
+      <p>Es ist nicht immer leicht zu wissen, wie ein bedeutungsvolles Gespräch beginnt. Deeper Conversations gibt dir sorgfältig formulierte Fragen und Folgefragen, die Menschen über Small Talk hinausführen, ohne dass der Moment gezwungen wirkt.</p>
+      <p>Nutze es für Date Night, einen Roadtrip, ein Familienessen, einen ruhigen Abend zu zweit oder einen Moment der Reflexion nur für dich.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspiriert von Forschung zu Nähe</h2>
+      <p>Deeper Conversations baut auf einer einfachen, forschungsbasierten Idee auf: Menschen fühlen sich oft näher, wenn sie Schritt für Schritt etwas von sich teilen, aufmerksam zuhören und mit echter Präsenz reagieren.</p>
+<p>In einer bekannten Studie aus dem Jahr 1997 fanden der Psychologe Arthur Aron und seine Kolleginnen und Kollegen heraus, dass fremde Gesprächspaare, die eine Reihe zunehmend persönlicher Fragen beantworteten, stärkere Gefühle von Nähe berichteten als Paare mit Small-Talk-Aufgaben.</p>
+<p>Deeper Conversations kopiert nicht die ursprünglichen 36 Fragen. Stattdessen greift die App dasselbe Grundmuster auf: sanft beginnen, mit der Zeit tiefer werden und mit durchdachten Folgefragen helfen, das Gespräch weiterzuführen, wenn sich etwas Bedeutungsvolles öffnet.</p>
+<p>Die App spiegelt auch weitere Forschung zu Intimität und Verbindung wider: Selbstoffenbarung ist wichtig, aber ebenso wichtig ist das Gefühl, verstanden, angenommen und beantwortet zu werden.</p>
+      <p>Forschung lesen:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Für Beziehungen, die zählen</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Paare</h3>
+    <p>Fühlt euch näher, versteht einander besser und sprecht über Dinge, die sonst oft unausgesprochen bleiben.</p>
+  </article>
+<article class="mini-card">
+    <h3>Freunde</h3>
+    <p>Geht über Updates und Insider-Witze hinaus zu Gesprächen, die zeigen, was wirklich los ist.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familie</h3>
+    <p>Öffnet Erinnerungen, Werte, Geschichten und Gespräche zwischen Generationen, die sonst vielleicht nie entstehen würden.</p>
+  </article>
+<article class="mini-card">
+    <h3>Selbstreflexion</h3>
+    <p>Nutze durchdachte Fragen, um klarer zu verstehen, was du fühlst, schätzt, erinnerst und willst.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Bestimme den Ton</h2>
+      <div class="tone-list">
+        <p>Beginne leicht, wenn du etwas Einfaches möchtest.</p>
+<p>Werde ehrlich, wenn der Moment bereit ist.</p>
+<p>Gehe tiefer, wenn sich etwas Echtes öffnet.</p>
+      </div>
+      <p>Jede Session kann Folgefragen enthalten, damit das Gespräch nicht bei der ersten Antwort enden muss.</p>
+    </section>
+
+    <section class="section">
+      <h2>Geführte Erlebnisse enthalten</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Ein geführtes Frageerlebnis, inspiriert von Forschung zu Nähe und schrittweiser Selbstoffenbarung.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 Fragen in 9 Lebenskapiteln, entwickelt für Gespräche mit Eltern, Großeltern, geliebten Menschen oder dir selbst über Erinnerung, Bedeutung und Vermächtnis.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Eine einfache geführte Möglichkeit, Geschichten aus deinem Leben zu erzählen und die Geschichten anderer zu hören.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Durchdachte Fragen über Tod, Fürsorge, Vermächtnis, Familie, Trauer, Vergebung und das, was am meisten zählt, wenn Zeit begrenzt wirkt.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Warum Vollzugriff sich lohnt</h2>
+      <p>Die kostenlose Version hilft dir beim Einstieg. Vollzugriff ist für Menschen, die Deeper Conversations immer wieder nutzen möchten.</p>
+      <p>Vollzugriff schaltet die komplette Premium-Bibliothek frei: 2.802 Prompts und Folgefragen, längere Sessions, Intimitätsfragen, Fall in Love, Life Story, Share an Experience, Mortality Conversations und weitere geführte Erlebnisse.</p>
+      <p>Das bedeutet mehr Möglichkeiten, um:</p>
+  <ul>
+    <li>euch als Paar näher zu fühlen</li>
+<li>Freundschaften emotional lebendig zu halten</li>
+<li>Familienmitgliedern Fragen zu stellen, an die du sonst vielleicht nicht denkst</li>
+<li>achtsam über Sterblichkeit, Fürsorge, Vermächtnis, Trauer und Familienentscheidungen zu sprechen</li>
+<li>ehrlich über dein eigenes Leben zu reflektieren</li>
+<li>ein Gespräch weiterzuführen, wenn die erste Antwort etwas Wichtiges öffnet</li>
+  </ul>
+      <p class="purchase-note">Einmaliger Kauf. Kein Abo.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privat von Grund auf</h2>
+      <div class="privacy-list">
+        <span>Keine Feeds.</span>
+<span>Keine Profile.</span>
+<span>Kein Account erforderlich.</span>
+<span>Kein Druck, etwas leisten zu müssen.</span>
+      </div>
+      <p>Deeper Conversations basiert auf privaten, textbasierten Fragen. Die App sammelt, überträgt oder teilt keine persönlichen Gesprächsinhalte.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Verfügbar auf iPhone und iPad</h2>
+      <p>Nutze es am Tisch, auf dem Sofa, unterwegs oder in einem ruhigen Moment allein.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Im App Store laden</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Hast du einen Code? Vollzugriff gratis freischalten</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Ist Deeper Conversations nur für Paare?</summary>
+    <p>Nein. Es gibt Modi für Paare, Freunde, Familie und Selbstreflexion.</p>
+  </details>
+<details>
+    <summary>Ist das Therapie?</summary>
+    <p>Nein. Deeper Conversations ist keine Therapie und keine medizinische Beratung. Es ist eine App für Gespräche und Reflexion.</p>
+  </details>
+<details>
+    <summary>Ist Vollzugriff ein Abo?</summary>
+    <p>Nein. Vollzugriff ist ein einmaliger Kauf, der lebenslangen Zugriff auf die komplette Vollzugriff-Bibliothek gibt.</p>
+  </details>
+<details>
+    <summary>Sammelt die App meine Gespräche?</summary>
+    <p>Nein. Die App sammelt, überträgt oder teilt keine persönlichen Gesprächsinhalte.</p>
+  </details>
+<details>
+    <summary>Welche Geräte werden unterstützt?</summary>
+    <p>Deeper Conversations funktioniert auf iPhone und iPad mit iOS 18 oder neuer.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Datenschutzrichtlinie</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-es-ES.html
+++ b/docs/marketing/invite-es-ES.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Oferta por tiempo limitado:</strong> Acceso completo gratis hasta el 30 de julio de 2026. Desbloquea la biblioteca premium con más de 2,800 preguntas y seguimientos.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Canjea Acceso Completo gratis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-es-ES.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Preguntas que acercan a las personas.</h1>
           <p>Preguntas cuidadosas para parejas, amigos, familias y reflexión personal. Elige con quién estás, define el tono y deja que la siguiente pregunta abra algo real.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Oferta por tiempo limitado</p>
+            <h2>Acceso completo gratis hasta el 30 de julio de 2026</h2>
+            <p>Desbloquea la biblioteca premium con más de 2,800 preguntas y seguimientos.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Canjea Acceso Completo gratis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Descargar en el App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Disponible en iPhone y iPad</h2>
       <p>Úsala al otro lado de la mesa, en el sofá, durante un viaje o en un momento tranquilo a solas.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Descargar en el App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">¿Tienes un código? Canjea Acceso Completo gratis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Canjea Acceso Completo gratis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-es-ES.html
+++ b/docs/marketing/invite-es-ES.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="es-ES">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Preguntas que acercan a las personas.</title>
+  <meta name="description" content="Preguntas cuidadosas para parejas, amigos, familias y reflexión personal. Elige con quién estás, define el tono y deja que la siguiente pregunta abra algo real.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="es-ES">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-es-ES.html">
+  <meta property="og:title" content="Deeper Conversations — Preguntas que acercan a las personas.">
+  <meta property="og:description" content="Preguntas cuidadosas para parejas, amigos, familias y reflexión personal. Elige con quién estás, define el tono y deja que la siguiente pregunta abra algo real.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Preguntas cuidadosas para parejas, amigos, familias y reflexión personal. Elige con quién estás, define el tono y deja que la siguiente pregunta abra algo real.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-es-ES.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html" aria-current="page">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Preguntas que acercan a las personas.</h1>
+          <p>Preguntas cuidadosas para parejas, amigos, familias y reflexión personal. Elige con quién estás, define el tono y deja que la siguiente pregunta abra algo real.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Descargar en el App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>La mayoría de las relaciones no necesitan más consejos.<br>Necesitan mejores formas de empezar.</h2>
+      <p>A veces cuesta saber cómo iniciar una conversación significativa. Deeper Conversations te ofrece preguntas y seguimientos cuidadosamente creados para ayudar a las personas a ir más allá de la charla superficial sin que el momento se sienta forzado.</p>
+      <p>Úsalo en una cita, un viaje por carretera, una comida familiar, una noche tranquila juntos o un momento de reflexión personal.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirado en investigación sobre la cercanía</h2>
+      <p>Deeper Conversations se basa en una idea sencilla respaldada por la investigación: las personas suelen sentirse más cerca cuando comparten poco a poco, escuchan con atención y responden con presencia real.</p>
+<p>En un conocido estudio de 1997, el psicólogo Arthur Aron y sus colegas descubrieron que parejas de desconocidos que respondían a una serie de preguntas cada vez más personales reportaban mayores sentimientos de cercanía que las parejas asignadas a tareas de charla superficial.</p>
+<p>Deeper Conversations no copia las 36 preguntas originales. En cambio, se apoya en el mismo patrón de fondo: empezar suavemente, aumentar la profundidad con el tiempo y usar seguimientos pensados para ayudar a que la conversación continúe cuando se abre algo significativo.</p>
+<p>La app también refleja investigación más amplia sobre intimidad y conexión: abrirse importa, pero también importa sentirse entendido, aceptado y respondido.</p>
+      <p>Lee la investigación:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Hecha para las relaciones que importan</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Parejas</h3>
+    <p>Sentíos más cerca, entendedos mejor y hablad de cosas que a menudo se quedan sin decir.</p>
+  </article>
+<article class="mini-card">
+    <h3>Amigos</h3>
+    <p>Id más allá de las novedades y las bromas internas hacia conversaciones que revelan lo que realmente está pasando.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familia</h3>
+    <p>Abre recuerdos, valores, historias y conversaciones entre generaciones que quizá no surgirían por sí solas.</p>
+  </article>
+<article class="mini-card">
+    <h3>Reflexión personal</h3>
+    <p>Usa preguntas cuidadosas para entender lo que sientes, valoras, recuerdas y quieres.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Elige el tono</h2>
+      <div class="tone-list">
+        <p>Empieza ligero cuando quieras algo fácil.</p>
+<p>Sé honesto cuando el momento esté listo.</p>
+<p>Profundiza cuando algo real se abra.</p>
+      </div>
+      <p>Cada sesión puede incluir preguntas de seguimiento, para que la conversación no tenga que terminar con la primera respuesta.</p>
+    </section>
+
+    <section class="section">
+      <h2>Experiencias guiadas incluidas</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Una experiencia guiada de preguntas inspirada en la investigación sobre cercanía y apertura gradual.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 preguntas en 9 capítulos de vida, pensadas para preguntar a padres, abuelos, seres queridos o a ti mismo sobre recuerdos, sentido y legado.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Una forma sencilla y guiada de contar historias de tu vida y escuchar las historias detrás de otra persona.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Preguntas cuidadosas sobre la muerte, los cuidados, el legado, la familia, el duelo, el perdón y lo que más importa cuando el tiempo se siente limitado.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Por qué merece la pena Acceso completo</h2>
+      <p>La versión gratuita te ayuda a empezar. Acceso completo es para quienes quieren volver a Deeper Conversations una y otra vez.</p>
+      <p>Acceso completo desbloquea toda la biblioteca premium: 2,802 preguntas y preguntas de seguimiento, sesiones más largas, preguntas de intimidad, Fall in Love, Life Story, Share an Experience, Mortality Conversations y más experiencias guiadas.</p>
+      <p>Eso significa más formas de:</p>
+  <ul>
+    <li>sentiros más cerca como pareja</li>
+<li>mantener emocionalmente vivas las amistades</li>
+<li>hacer a familiares preguntas que quizá no se te ocurrirían</li>
+<li>hablar con cuidado sobre mortalidad, cuidados, legado, duelo y decisiones familiares</li>
+<li>reflexionar con honestidad sobre tu propia vida</li>
+<li>continuar una conversación cuando la primera respuesta abre algo importante</li>
+  </ul>
+      <p class="purchase-note">Compra única. Sin suscripción.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privada por diseño</h2>
+      <div class="privacy-list">
+        <span>Sin feeds.</span>
+<span>Sin perfiles.</span>
+<span>Sin cuenta obligatoria.</span>
+<span>Sin presión por actuar de cierta manera.</span>
+      </div>
+      <p>Deeper Conversations está construida alrededor de preguntas privadas y solo de texto. La app no recopila, transmite ni comparte el contenido personal de tus conversaciones.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Disponible en iPhone y iPad</h2>
+      <p>Úsala al otro lado de la mesa, en el sofá, durante un viaje o en un momento tranquilo a solas.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Descargar en el App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">¿Tienes un código? Canjea Acceso Completo gratis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>¿Deeper Conversations es solo para parejas?</summary>
+    <p>No. Incluye modos para parejas, amigos, familia y reflexión personal.</p>
+  </details>
+<details>
+    <summary>¿Es terapia?</summary>
+    <p>No. Deeper Conversations no es terapia ni consejo médico. Es una app de conversación y reflexión.</p>
+  </details>
+<details>
+    <summary>¿Acceso completo es una suscripción?</summary>
+    <p>No. Acceso completo es una compra única que ofrece acceso de por vida a toda la biblioteca de Acceso completo.</p>
+  </details>
+<details>
+    <summary>¿La app recopila mis conversaciones?</summary>
+    <p>No. La app no recopila, transmite ni comparte el contenido personal de tus conversaciones.</p>
+  </details>
+<details>
+    <summary>¿Qué dispositivos son compatibles?</summary>
+    <p>Deeper Conversations funciona en iPhone y iPad con iOS 18 o posterior.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Política de privacidad</a>
+      <a href="../">Soporte</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-fi.html
+++ b/docs/marketing/invite-fi.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Rajoitetun ajan tarjous:</strong> Täysi käyttöoikeus ilmaiseksi 30. heinäkuuta 2026 asti. Avaa premiumkirjasto, jossa on yli 2 800 kehotetta ja jatkokysymystä.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lunasta Täysi käyttöoikeus ilmaiseksi</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-fi.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Kysymyksiä, jotka tuovat ihmisiä lähemmäs.</h1>
           <p>Harkittuja keskustelukehotteita pareille, ystäville, perheille ja omaan pohdintaan. Valitse, kenen kanssa olet, säädä sävy ja anna seuraavan kysymyksen avata jotakin todellista.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Rajoitetun ajan tarjous</p>
+            <h2>Täysi käyttöoikeus ilmaiseksi 30. heinäkuuta 2026 asti</h2>
+            <p>Avaa premiumkirjasto, jossa on yli 2 800 kehotetta ja jatkokysymystä.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lunasta Täysi käyttöoikeus ilmaiseksi</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Lataa App Storesta</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Saatavilla iPhonelle ja iPadille</h2>
       <p>Käytä sitä pöydän ääressä, sohvalla, matkalla tai hiljaisessa hetkessä yksin.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Lataa App Storesta</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Onko sinulla koodi? Lunasta Täysi käyttöoikeus ilmaiseksi</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lunasta Täysi käyttöoikeus ilmaiseksi</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-fi.html
+++ b/docs/marketing/invite-fi.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="fi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Kysymyksiä, jotka tuovat ihmisiä lähemmäs.</title>
+  <meta name="description" content="Harkittuja keskustelukehotteita pareille, ystäville, perheille ja omaan pohdintaan. Valitse, kenen kanssa olet, säädä sävy ja anna seuraavan kysymyksen avata jotakin todellista.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="fi">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-fi.html">
+  <meta property="og:title" content="Deeper Conversations — Kysymyksiä, jotka tuovat ihmisiä lähemmäs.">
+  <meta property="og:description" content="Harkittuja keskustelukehotteita pareille, ystäville, perheille ja omaan pohdintaan. Valitse, kenen kanssa olet, säädä sävy ja anna seuraavan kysymyksen avata jotakin todellista.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Harkittuja keskustelukehotteita pareille, ystäville, perheille ja omaan pohdintaan. Valitse, kenen kanssa olet, säädä sävy ja anna seuraavan kysymyksen avata jotakin todellista.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-fi.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html" aria-current="page">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Kysymyksiä, jotka tuovat ihmisiä lähemmäs.</h1>
+          <p>Harkittuja keskustelukehotteita pareille, ystäville, perheille ja omaan pohdintaan. Valitse, kenen kanssa olet, säädä sävy ja anna seuraavan kysymyksen avata jotakin todellista.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Lataa App Storesta</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>Useimmat ihmissuhteet eivät kaipaa lisää neuvoja.<br>Ne kaipaavat parempia alkuja.</h2>
+      <p>Merkityksellisen keskustelun aloittaminen voi olla vaikeaa. Deeper Conversations tarjoaa huolella laadittuja kehotteita ja jatkokysymyksiä, jotka auttavat ihmisiä pääsemään small talkia syvemmälle ilman että hetki tuntuu pakotetulta.</p>
+      <p>Käytä sitä treffeillä, automatkalla, perheillallisella, rauhallisena iltana yhdessä tai omassa pohdinnan hetkessä.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Läheisyyden tutkimuksesta inspiroitunut</h2>
+      <p>Deeper Conversations rakentuu yksinkertaiselle, tutkimuksen tukemalle ajatukselle: ihmiset tuntevat usein läheisyyttä, kun he jakavat asioita vähitellen, kuuntelevat tarkasti ja vastaavat aidolla läsnäololla.</p>
+<p>Tunnetussa vuoden 1997 tutkimuksessa psykologi Arthur Aron kollegoineen havaitsi, että toisilleen tuntemattomat parit, jotka vastasivat vähitellen henkilökohtaisempiin kysymyksiin, raportoivat vahvempaa läheisyyden tunnetta kuin small talk -tehtäviin asetetut parit.</p>
+<p>Deeper Conversations ei kopioi alkuperäisiä 36 kysymystä. Sen sijaan se rakentaa saman peruskaavan varaan: aloita lempeästi, lisää syvyyttä ajan myötä ja käytä harkittuja jatkokysymyksiä, jotta keskustelu voi jatkua, kun jotakin merkityksellistä avautuu.</p>
+<p>Sovellus heijastaa myös laajempaa tutkimusta intiimiydestä ja yhteydestä: itsestä kertominen on tärkeää, mutta niin on myös tunne siitä, että tulee ymmärretyksi, hyväksytyksi ja kohdatuksi.</p>
+      <p>Lue tutkimukset:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Tehty tärkeille ihmissuhteille</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Parit</h3>
+    <p>Tuntekaa olevanne lähempänä, ymmärtäkää toisianne paremmin ja puhukaa asioista, jotka usein jäävät sanomatta.</p>
+  </article>
+<article class="mini-card">
+    <h3>Ystävät</h3>
+    <p>Menkää kuulumisia ja sisäpiirin vitsejä pidemmälle keskusteluihin, jotka paljastavat, mitä oikeasti on meneillään.</p>
+  </article>
+<article class="mini-card">
+    <h3>Perhe</h3>
+    <p>Avatkaa muistoja, arvoja, tarinoita ja sukupolvien välisiä keskusteluja, joita ei ehkä syntyisi itsestään.</p>
+  </article>
+<article class="mini-card">
+    <h3>Oma pohdinta</h3>
+    <p>Käytä harkittuja kysymyksiä ymmärtääksesi, mitä tunnet, arvostat, muistat ja haluat.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Valitse sävy</h2>
+      <div class="tone-list">
+        <p>Aloita kevyesti, kun haluat jotakin helppoa.</p>
+<p>Ole rehellinen, kun hetki on valmis.</p>
+<p>Mene syvemmälle, kun jotakin todellista avautuu.</p>
+      </div>
+      <p>Jokainen sessio voi sisältää jatkokysymyksiä, jotta keskustelun ei tarvitse päättyä ensimmäiseen vastaukseen.</p>
+    </section>
+
+    <section class="section">
+      <h2>Ohjatut kokemukset mukana</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Ohjattu kysymyskokemus, joka on inspiroitunut läheisyyden ja vähittäisen itsestä kertomisen tutkimuksesta.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 kysymystä 9 elämänluvun kautta, suunniteltu vanhemmille, isovanhemmille, läheisille tai itselle esitettäviksi muistoista, merkityksestä ja perinnöstä.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Yksinkertainen ohjattu tapa kertoa tarinoita omasta elämästä ja kuulla toisen tarinoiden taustat.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Harkittuja kysymyksiä kuolemasta, hoivasta, perinnöstä, perheestä, surusta, anteeksiannosta ja siitä, mikä merkitsee eniten, kun aika tuntuu rajalliselta.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Miksi Täysi käyttöoikeus kannattaa</h2>
+      <p>Ilmainen versio auttaa alkuun. Täysi käyttöoikeus on ihmisille, jotka haluavat palata Deeper Conversationsin äärelle yhä uudelleen.</p>
+      <p>Täysi käyttöoikeus avaa koko premium-kirjaston: 2 802 kysymystä ja jatkokysymystä, pidemmät sessiot, intiimiyyskysymykset, Fall in Lovein, Life Storyn, Share an Experiencen, Mortality Conversationsin ja muita ohjattuja kokemuksia.</p>
+      <p>Se tarkoittaa enemmän tapoja:</p>
+  <ul>
+    <li>tuntea läheisyyttä parina</li>
+<li>pitää ystävyyssuhteet emotionaalisesti elävinä</li>
+<li>kysyä perheenjäseniltä kysymyksiä, joita et ehkä tulisi ajatelleeksi</li>
+<li>puhua harkiten kuolevaisuudesta, hoivasta, perinnöstä, surusta ja perheen päätöksistä</li>
+<li>pohtia omaa elämää rehellisesti</li>
+<li>jatkaa keskustelua, kun ensimmäinen vastaus avaa jotakin tärkeää</li>
+  </ul>
+      <p class="purchase-note">Kertaostos. Ei tilausta.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Yksityinen suunnittelultaan</h2>
+      <div class="privacy-list">
+        <span>Ei syötteitä.</span>
+<span>Ei profiileja.</span>
+<span>Ei pakollista tiliä.</span>
+<span>Ei painetta esiintyä.</span>
+      </div>
+      <p>Deeper Conversations rakentuu yksityisten, tekstipohjaisten kehotteiden ympärille. Sovellus ei kerää, lähetä tai jaa henkilökohtaista keskustelusisältöäsi.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Saatavilla iPhonelle ja iPadille</h2>
+      <p>Käytä sitä pöydän ääressä, sohvalla, matkalla tai hiljaisessa hetkessä yksin.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Lataa App Storesta</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Onko sinulla koodi? Lunasta Täysi käyttöoikeus ilmaiseksi</a>
+    </section>
+
+    <section class="section faq">
+      <h2>UKK</h2>
+      <details>
+    <summary>Onko Deeper Conversations vain pareille?</summary>
+    <p>Ei. Siinä on tilat pareille, ystäville, perheelle ja omaan pohdintaan.</p>
+  </details>
+<details>
+    <summary>Onko tämä terapiaa?</summary>
+    <p>Ei. Deeper Conversations ei ole terapiaa tai lääketieteellistä neuvontaa. Se on keskustelu- ja pohdintasovellus.</p>
+  </details>
+<details>
+    <summary>Onko Täysi käyttöoikeus tilaus?</summary>
+    <p>Ei. Täysi käyttöoikeus on kertaostos, joka antaa elinikäisen pääsyn koko Täysi käyttöoikeus -kirjastoon.</p>
+  </details>
+<details>
+    <summary>Kerääkö sovellus keskusteluni?</summary>
+    <p>Ei. Sovellus ei kerää, lähetä tai jaa henkilökohtaista keskustelusisältöä.</p>
+  </details>
+<details>
+    <summary>Mitä laitteita tuetaan?</summary>
+    <p>Deeper Conversations toimii iPhonella ja iPadilla, joissa on iOS 18 tai uudempi.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Tietosuojakäytäntö</a>
+      <a href="../">Tuki</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-fr.html
+++ b/docs/marketing/invite-fr.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Des questions qui rapprochent.</title>
+  <meta name="description" content="Des questions pensées pour les couples, les amis, les familles et la réflexion personnelle. Choisis avec qui tu es, règle le ton et laisse la prochaine question ouvrir quelque chose de vrai.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="fr">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-fr.html">
+  <meta property="og:title" content="Deeper Conversations — Des questions qui rapprochent.">
+  <meta property="og:description" content="Des questions pensées pour les couples, les amis, les familles et la réflexion personnelle. Choisis avec qui tu es, règle le ton et laisse la prochaine question ouvrir quelque chose de vrai.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Des questions pensées pour les couples, les amis, les familles et la réflexion personnelle. Choisis avec qui tu es, règle le ton et laisse la prochaine question ouvrir quelque chose de vrai.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-fr.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html" aria-current="page">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Des questions qui rapprochent.</h1>
+          <p>Des questions pensées pour les couples, les amis, les familles et la réflexion personnelle. Choisis avec qui tu es, règle le ton et laisse la prochaine question ouvrir quelque chose de vrai.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Télécharger sur l'App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>La plupart des relations n'ont pas besoin de plus de conseils.<br>Elles ont besoin de meilleures ouvertures.</h2>
+      <p>Il peut être difficile de savoir comment commencer une conversation qui compte. Deeper Conversations propose des questions et des relances soigneusement conçues pour aider à dépasser les petites conversations sans rendre le moment forcé.</p>
+      <p>Utilise-la pour un rendez-vous, un trajet, un dîner en famille, une soirée calme à deux ou un moment de réflexion personnelle.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirée par la recherche sur la proximité</h2>
+      <p>Deeper Conversations repose sur une idée simple, appuyée par la recherche : les personnes se sentent souvent plus proches lorsqu'elles partagent progressivement, écoutent avec attention et répondent avec une vraie présence.</p>
+<p>Dans une étude connue de 1997, le psychologue Arthur Aron et ses collègues ont montré que des paires d'inconnus répondant à une série de questions de plus en plus personnelles rapportaient un sentiment de proximité plus fort que des paires assignées à des échanges de type small talk.</p>
+<p>Deeper Conversations ne copie pas les 36 questions originales. L'app s'inspire plutôt du même principe : commencer doucement, augmenter la profondeur avec le temps et utiliser des relances réfléchies pour aider la conversation à continuer quand quelque chose d'important s'ouvre.</p>
+<p>L'app reflète aussi des recherches plus larges sur l'intimité et la connexion : se dévoiler compte, mais se sentir compris, accepté et accueilli compte aussi.</p>
+      <p>Lire la recherche :</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Pensée pour les relations qui comptent</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Couples</h3>
+    <p>Se sentir plus proches, mieux se comprendre et parler de ce qui reste souvent non dit.</p>
+  </article>
+<article class="mini-card">
+    <h3>Amis</h3>
+    <p>Aller au-delà des nouvelles et des blagues partagées vers des conversations qui révèlent ce qui se passe vraiment.</p>
+  </article>
+<article class="mini-card">
+    <h3>Famille</h3>
+    <p>Ouvrir des souvenirs, des valeurs, des histoires et des conversations entre générations qui ne viendraient peut-être pas toutes seules.</p>
+  </article>
+<article class="mini-card">
+    <h3>Réflexion personnelle</h3>
+    <p>Utiliser des questions réfléchies pour comprendre ce que tu ressens, ce que tu valorises, ce dont tu te souviens et ce que tu veux.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Choisis le ton</h2>
+      <div class="tone-list">
+        <p>Commence léger quand tu veux quelque chose de simple.</p>
+<p>Sois honnête quand le moment est prêt.</p>
+<p>Va plus profond quand quelque chose de vrai s'ouvre.</p>
+      </div>
+      <p>Chaque session peut inclure des relances, pour que la conversation ne s'arrête pas à la première réponse.</p>
+    </section>
+
+    <section class="section">
+      <h2>Expériences guidées incluses</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Une expérience guidée de questions inspirée par la recherche sur la proximité et le dévoilement progressif.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 questions à travers 9 chapitres de vie, conçues pour interroger parents, grands-parents, proches ou toi-même sur les souvenirs, le sens et l'héritage.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Une façon simple et guidée de raconter des histoires de ta vie et d'entendre les histoires derrière celles des autres.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Des questions réfléchies sur la mort, le soin, l'héritage, la famille, le deuil, le pardon et ce qui compte le plus quand le temps paraît limité.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Pourquoi l'Accès complet vaut le coup</h2>
+      <p>La version gratuite t'aide à commencer. L'Accès complet est fait pour celles et ceux qui veulent revenir à Deeper Conversations encore et encore.</p>
+      <p>L'Accès complet débloque toute la bibliothèque premium : 2 802 questions et relances, les sessions plus longues, les questions d'intimité, Fall in Love, Life Story, Share an Experience, Mortality Conversations et d'autres expériences guidées.</p>
+      <p>Cela veut dire plus de façons de :</p>
+  <ul>
+    <li>se sentir plus proches en couple</li>
+<li>garder les amitiés émotionnellement vivantes</li>
+<li>poser à sa famille des questions auxquelles on ne penserait pas toujours</li>
+<li>parler avec délicatesse de mortalité, de soin, d'héritage, de deuil et de décisions familiales</li>
+<li>réfléchir honnêtement à sa propre vie</li>
+<li>continuer une conversation quand la première réponse ouvre quelque chose d'important</li>
+  </ul>
+      <p class="purchase-note">Achat unique. Aucun abonnement.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privée par conception</h2>
+      <div class="privacy-list">
+        <span>Pas de fil d'actualité.</span>
+<span>Pas de profils.</span>
+<span>Pas de compte requis.</span>
+<span>Pas de pression pour se mettre en scène.</span>
+      </div>
+      <p>Deeper Conversations repose sur des questions privées, uniquement textuelles. L'app ne collecte, ne transmet et ne partage pas le contenu personnel de tes conversations.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Disponible sur iPhone et iPad</h2>
+      <p>Utilise-la à table, sur le canapé, en voyage ou dans un moment calme en solo.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Télécharger sur l'App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Vous avez un code ? Débloquez l'Accès complet gratuitement</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Deeper Conversations est-elle seulement pour les couples ?</summary>
+    <p>Non. Elle inclut des modes pour les couples, les amis, la famille et la réflexion personnelle.</p>
+  </details>
+<details>
+    <summary>Est-ce une thérapie ?</summary>
+    <p>Non. Deeper Conversations n'est pas une thérapie ni un conseil médical. C'est une app de conversation et de réflexion.</p>
+  </details>
+<details>
+    <summary>L'Accès complet est-il un abonnement ?</summary>
+    <p>Non. L'Accès complet est un achat unique qui donne un accès à vie à toute la bibliothèque de l'Accès complet.</p>
+  </details>
+<details>
+    <summary>L'app collecte-t-elle mes conversations ?</summary>
+    <p>Non. L'app ne collecte, ne transmet et ne partage pas le contenu personnel de tes conversations.</p>
+  </details>
+<details>
+    <summary>Quels appareils sont pris en charge ?</summary>
+    <p>Deeper Conversations fonctionne sur iPhone et iPad avec iOS 18 ou version ultérieure.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Politique de confidentialité</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-fr.html
+++ b/docs/marketing/invite-fr.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Offre à durée limitée:</strong> Accès complet gratuit jusqu'au 30 juillet 2026. Débloquez la bibliothèque premium avec plus de 2 800 questions et relances.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Débloquez l'Accès complet gratuitement</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-fr.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Des questions qui rapprochent.</h1>
           <p>Des questions pensées pour les couples, les amis, les familles et la réflexion personnelle. Choisis avec qui tu es, règle le ton et laisse la prochaine question ouvrir quelque chose de vrai.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Offre à durée limitée</p>
+            <h2>Accès complet gratuit jusqu'au 30 juillet 2026</h2>
+            <p>Débloquez la bibliothèque premium avec plus de 2 800 questions et relances.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Débloquez l'Accès complet gratuitement</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Télécharger sur l'App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Disponible sur iPhone et iPad</h2>
       <p>Utilise-la à table, sur le canapé, en voyage ou dans un moment calme en solo.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Télécharger sur l'App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Vous avez un code ? Débloquez l'Accès complet gratuitement</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Débloquez l'Accès complet gratuitement</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-it.html
+++ b/docs/marketing/invite-it.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Domande che avvicinano le persone.</title>
+  <meta name="description" content="Prompt di conversazione pensati per coppie, amici, famiglie e riflessione personale. Scegli con chi sei, imposta il tono e lascia che la prossima domanda apra qualcosa di vero.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="it">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-it.html">
+  <meta property="og:title" content="Deeper Conversations — Domande che avvicinano le persone.">
+  <meta property="og:description" content="Prompt di conversazione pensati per coppie, amici, famiglie e riflessione personale. Scegli con chi sei, imposta il tono e lascia che la prossima domanda apra qualcosa di vero.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Prompt di conversazione pensati per coppie, amici, famiglie e riflessione personale. Scegli con chi sei, imposta il tono e lascia che la prossima domanda apra qualcosa di vero.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-it.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html" aria-current="page">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Domande che avvicinano le persone.</h1>
+          <p>Prompt di conversazione pensati per coppie, amici, famiglie e riflessione personale. Scegli con chi sei, imposta il tono e lascia che la prossima domanda apra qualcosa di vero.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Scarica su App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>La maggior parte delle relazioni non ha bisogno di altri consigli.<br>Ha bisogno di modi migliori per iniziare.</h2>
+      <p>Può essere difficile capire come avviare una conversazione significativa. Deeper Conversations offre domande e approfondimenti curati con attenzione per aiutare le persone ad andare oltre le chiacchiere, senza far sembrare il momento forzato.</p>
+      <p>Usala per una serata insieme, un viaggio, una cena in famiglia, una serata tranquilla a due o un momento di riflessione personale.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Ispirata dalla ricerca sulla vicinanza</h2>
+      <p>Deeper Conversations si basa su un'idea semplice e sostenuta dalla ricerca: spesso le persone si sentono più vicine quando condividono gradualmente, ascoltano con attenzione e rispondono con vera presenza.</p>
+<p>In un noto studio del 1997, lo psicologo Arthur Aron e colleghi hanno scoperto che coppie di sconosciuti che rispondevano a una serie di domande sempre più personali riferivano un maggiore senso di vicinanza rispetto a coppie assegnate a compiti di conversazione superficiale.</p>
+<p>Deeper Conversations non copia le 36 domande originali. Si basa invece sullo stesso schema di fondo: iniziare con delicatezza, aumentare la profondità nel tempo e usare approfondimenti pensati per aiutare la conversazione a continuare quando si apre qualcosa di significativo.</p>
+<p>L'app riflette anche ricerche più ampie su intimità e connessione: aprirsi conta, ma conta anche sentirsi compresi, accolti e ascoltati.</p>
+      <p>Leggi la ricerca:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Pensata per le relazioni che contano</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Coppie</h3>
+    <p>Sentitevi più vicini, capitevi meglio e parlate delle cose che spesso restano non dette.</p>
+  </article>
+<article class="mini-card">
+    <h3>Amici</h3>
+    <p>Andate oltre aggiornamenti e battute interne verso conversazioni che rivelano cosa sta succedendo davvero.</p>
+  </article>
+<article class="mini-card">
+    <h3>Famiglia</h3>
+    <p>Aprite ricordi, valori, storie e conversazioni tra generazioni che forse non nascerebbero da sole.</p>
+  </article>
+<article class="mini-card">
+    <h3>Riflessione personale</h3>
+    <p>Usa domande attente per capire cosa senti, cosa conta per te, cosa ricordi e cosa vuoi.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Scegli il tono</h2>
+      <div class="tone-list">
+        <p>Inizia in modo leggero quando vuoi qualcosa di semplice.</p>
+<p>Sii sincero quando il momento è pronto.</p>
+<p>Vai più in profondità quando si apre qualcosa di vero.</p>
+      </div>
+      <p>Ogni sessione può includere domande di approfondimento, così la conversazione non deve fermarsi alla prima risposta.</p>
+    </section>
+
+    <section class="section">
+      <h2>Esperienze guidate incluse</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Un'esperienza guidata di domande ispirata alla ricerca sulla vicinanza e sull'apertura graduale.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 domande in 9 capitoli di vita, pensate per chiedere a genitori, nonni, persone care o a te stesso di memoria, significato ed eredità.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Un modo semplice e guidato per raccontare storie della tua vita e ascoltare le storie dietro quelle degli altri.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Domande attente sulla morte, la cura, l'eredità, la famiglia, il lutto, il perdono e ciò che conta di più quando il tempo sembra limitato.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Perché Accesso completo vale la pena</h2>
+      <p>La versione gratuita ti aiuta a iniziare. Accesso completo è per chi vuole tornare a Deeper Conversations ancora e ancora.</p>
+      <p>Accesso completo sblocca l'intera libreria premium: 2.802 prompt e domande di approfondimento, sessioni più lunghe, domande sull'intimità, Fall in Love, Life Story, Share an Experience, Mortality Conversations e altre esperienze guidate.</p>
+      <p>Significa più modi per:</p>
+  <ul>
+    <li>sentirvi più vicini come coppia</li>
+<li>mantenere vive emotivamente le amicizie</li>
+<li>fare ai familiari domande che forse non penseresti di porre</li>
+<li>parlare con delicatezza di mortalità, cura, eredità, lutto e decisioni familiari</li>
+<li>riflettere con sincerità sulla tua vita</li>
+<li>continuare una conversazione quando la prima risposta apre qualcosa di importante</li>
+  </ul>
+      <p class="purchase-note">Acquisto una tantum. Nessun abbonamento.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privata per scelta</h2>
+      <div class="privacy-list">
+        <span>Nessun feed.</span>
+<span>Nessun profilo.</span>
+<span>Nessun account richiesto.</span>
+<span>Nessuna pressione a esibirsi.</span>
+      </div>
+      <p>Deeper Conversations è costruita attorno a prompt privati, solo testuali. L'app non raccoglie, trasmette né condivide il contenuto personale delle tue conversazioni.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Disponibile su iPhone e iPad</h2>
+      <p>Usala a tavola, sul divano, in viaggio o in un momento tranquillo da solo.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Scarica su App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Hai un codice? Riscatta l'Accesso completo gratis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Deeper Conversations è solo per coppie?</summary>
+    <p>No. Include modalità per coppie, amici, famiglia e riflessione personale.</p>
+  </details>
+<details>
+    <summary>È una terapia?</summary>
+    <p>No. Deeper Conversations non è terapia né consulenza medica. È un'app per conversazione e riflessione.</p>
+  </details>
+<details>
+    <summary>Accesso completo è un abbonamento?</summary>
+    <p>No. Accesso completo è un acquisto una tantum che dà accesso a vita alla libreria completa di Accesso completo.</p>
+  </details>
+<details>
+    <summary>L'app raccoglie le mie conversazioni?</summary>
+    <p>No. L'app non raccoglie, trasmette né condivide il contenuto personale delle tue conversazioni.</p>
+  </details>
+<details>
+    <summary>Quali dispositivi sono supportati?</summary>
+    <p>Deeper Conversations funziona su iPhone e iPad con iOS 18 o versioni successive.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Informativa sulla privacy</a>
+      <a href="../">Supporto</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-it.html
+++ b/docs/marketing/invite-it.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Offerta a tempo limitato:</strong> Accesso completo gratis fino al 30 luglio 2026. Sblocca la libreria premium con oltre 2.800 prompt e domande di approfondimento.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Riscatta l'Accesso completo gratis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-it.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Domande che avvicinano le persone.</h1>
           <p>Prompt di conversazione pensati per coppie, amici, famiglie e riflessione personale. Scegli con chi sei, imposta il tono e lascia che la prossima domanda apra qualcosa di vero.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Offerta a tempo limitato</p>
+            <h2>Accesso completo gratis fino al 30 luglio 2026</h2>
+            <p>Sblocca la libreria premium con oltre 2.800 prompt e domande di approfondimento.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Riscatta l'Accesso completo gratis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Scarica su App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Disponibile su iPhone e iPad</h2>
       <p>Usala a tavola, sul divano, in viaggio o in un momento tranquillo da solo.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Scarica su App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Hai un codice? Riscatta l'Accesso completo gratis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Riscatta l'Accesso completo gratis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-ja.html
+++ b/docs/marketing/invite-ja.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>期間限定オファー:</strong> 2026年7月30日までフルアクセス無料. 2,800以上の質問とフォローアップ質問を含むプレミアムライブラリを利用できます。</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">フルアクセスを無料で利用</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-ja.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>人と人を近づける質問。</h1>
           <p>カップル、友人、家族、ひとりの振り返りのための、丁寧に作られた会話プロンプト。誰と話すかを選び、トーンを決めて、次の質問から本当の会話を開いていきます。</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">期間限定オファー</p>
+            <h2>2026年7月30日までフルアクセス無料</h2>
+            <p>2,800以上の質問とフォローアップ質問を含むプレミアムライブラリを利用できます。</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">フルアクセスを無料で利用</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">App Storeでダウンロード</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>iPhoneとiPadで利用できます</h2>
       <p>テーブル越しに、ソファで、旅先で、またはひとりの静かな時間に。</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">App Storeでダウンロード</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">コードをお持ちですか？フルアクセスを無料で利用</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">フルアクセスを無料で利用</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-ja.html
+++ b/docs/marketing/invite-ja.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — 人と人を近づける質問。</title>
+  <meta name="description" content="カップル、友人、家族、ひとりの振り返りのための、丁寧に作られた会話プロンプト。誰と話すかを選び、トーンを決めて、次の質問から本当の会話を開いていきます。">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="ja">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-ja.html">
+  <meta property="og:title" content="Deeper Conversations — 人と人を近づける質問。">
+  <meta property="og:description" content="カップル、友人、家族、ひとりの振り返りのための、丁寧に作られた会話プロンプト。誰と話すかを選び、トーンを決めて、次の質問から本当の会話を開いていきます。">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="カップル、友人、家族、ひとりの振り返りのための、丁寧に作られた会話プロンプト。誰と話すかを選び、トーンを決めて、次の質問から本当の会話を開いていきます。">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-ja.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html" aria-current="page">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>人と人を近づける質問。</h1>
+          <p>カップル、友人、家族、ひとりの振り返りのための、丁寧に作られた会話プロンプト。誰と話すかを選び、トーンを決めて、次の質問から本当の会話を開いていきます。</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">App Storeでダウンロード</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>多くの関係に必要なのは、もっと多くのアドバイスではありません。<br>必要なのは、話し始めるためのよりよいきっかけです。</h2>
+      <p>意味のある会話をどう始めればいいのか、迷うことがあります。Deeper Conversations は、雑談の先へ自然に進めるように作られたプロンプトとフォローアップ質問で、無理に感じさせずに会話を深める手助けをします。</p>
+      <p>デート、旅の途中、家族との食事、静かな夜、またはひとりで自分と向き合う時間に使えます。</p>
+    </section>
+
+    <section class="section research">
+      <h2>親密さに関する研究から着想</h2>
+      <p>Deeper Conversations は、研究に支えられたシンプルな考え方をもとにしています。人は少しずつ自分を開き、丁寧に聞き、相手にきちんと応答するとき、より近く感じやすくなります。</p>
+<p>1997年のよく知られた研究で、心理学者 Arthur Aron らは、徐々に個人的になっていく一連の質問に答えた初対面のペアが、雑談課題を行ったペアよりも強い親密さを報告したことを示しました。</p>
+<p>Deeper Conversations は、その元の36問をそのまま使っているわけではありません。代わりに、同じ基本的な流れを大切にしています。やさしく始め、少しずつ深め、意味のあるものが開いたときに会話を続けられるよう、考え抜かれたフォローアップを使います。</p>
+<p>このアプリは、親密さやつながりに関するより広い研究も反映しています。自分を開くことは大切ですが、理解され、受け入れられ、応答されていると感じることも同じくらい大切です。</p>
+      <p>研究を読む：</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>大切な関係のために</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>カップル</h3>
+    <p>もっと近く感じ、より深く理解し、普段は言葉になりにくいことを話せるように。</p>
+  </article>
+<article class="mini-card">
+    <h3>友人</h3>
+    <p>近況報告や内輪の冗談を越えて、本当に起きていることが見えてくる会話へ。</p>
+  </article>
+<article class="mini-card">
+    <h3>家族</h3>
+    <p>自然には生まれにくい記憶、価値観、物語、世代を越えた会話を開くために。</p>
+  </article>
+<article class="mini-card">
+    <h3>ひとりの振り返り</h3>
+    <p>自分が何を感じ、何を大切にし、何を覚えていて、何を望んでいるのかを理解するために。</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>トーンを選ぶ</h2>
+      <div class="tone-list">
+        <p>気軽に始めたいときは軽く。</p>
+<p>準備ができたときは正直に。</p>
+<p>何か本当のものが開いたときは、さらに深く。</p>
+      </div>
+      <p>各セッションにはフォローアップ質問を含められるので、会話は最初の答えだけで終わりません。</p>
+    </section>
+
+    <section class="section">
+      <h2>ガイド付き体験も含まれます</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>親密さと段階的な自己開示に関する研究から着想を得た、ガイド付きの質問体験。</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>人生の9つの章にわたる50の質問。親、祖父母、大切な人、または自分自身に、記憶、意味、受け継ぐものについて尋ねるために作られています。</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>自分の人生の出来事を語り、相手の物語の背景を聞くための、シンプルなガイド付き体験。</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>死、ケア、受け継ぐもの、家族、悲しみ、ゆるし、そして時間が限られていると感じるときに本当に大切なことについての、丁寧な質問。</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>フルアクセスに価値がある理由</h2>
+      <p>無料版は、始めるためのきっかけになります。フルアクセスは、Deeper Conversations に何度も戻ってきたい人のためのものです。</p>
+      <p>フルアクセスでは、2,802個の質問とフォローアップ質問を含むすべてのプレミアムライブラリ、長めのセッション、親密さに関する質問、Fall in Love、Life Story、Share an Experience、Mortality Conversations、その他のガイド付き体験が使えるようになります。</p>
+      <p>つまり、次のことがしやすくなります：</p>
+  <ul>
+    <li>カップルとしてより近く感じる</li>
+<li>友情を感情的に生きたものに保つ</li>
+<li>家族に、普段は思いつかない質問をする</li>
+<li>死、ケア、受け継ぐもの、悲しみ、家族の決断について丁寧に話す</li>
+<li>自分の人生を正直に振り返る</li>
+<li>最初の答えが大切なものを開いたとき、会話を続ける</li>
+  </ul>
+      <p class="purchase-note">一度きりの購入。サブスクリプションではありません。</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>プライバシーを大切に設計</h2>
+      <div class="privacy-list">
+        <span>フィードなし。</span>
+<span>プロフィールなし。</span>
+<span>アカウント不要。</span>
+<span>うまく振る舞う必要もありません。</span>
+      </div>
+      <p>Deeper Conversations は、プライベートなテキストだけのプロンプトを中心に作られています。アプリは個人的な会話内容を収集、送信、共有しません。</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>iPhoneとiPadで利用できます</h2>
+      <p>テーブル越しに、ソファで、旅先で、またはひとりの静かな時間に。</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">App Storeでダウンロード</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">コードをお持ちですか？フルアクセスを無料で利用</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Deeper Conversations はカップル専用ですか？</summary>
+    <p>いいえ。カップル、友人、家族、ひとりの振り返りのためのモードがあります。</p>
+  </details>
+<details>
+    <summary>これはセラピーですか？</summary>
+    <p>いいえ。Deeper Conversations はセラピーでも医療アドバイスでもありません。会話と振り返りのためのアプリです。</p>
+  </details>
+<details>
+    <summary>フルアクセスはサブスクリプションですか？</summary>
+    <p>いいえ。フルアクセスは一度きりの購入で、完全なフルアクセスライブラリを生涯使えます。</p>
+  </details>
+<details>
+    <summary>アプリは私の会話を収集しますか？</summary>
+    <p>いいえ。アプリは個人的な会話内容を収集、送信、共有しません。</p>
+  </details>
+<details>
+    <summary>対応しているデバイスは？</summary>
+    <p>Deeper Conversations は iOS 18 以降の iPhone と iPad で動作します。</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">プライバシーポリシー</a>
+      <a href="../">サポート</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-nb.html
+++ b/docs/marketing/invite-nb.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="nb">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Spørsmål som bringer mennesker nærmere.</title>
+  <meta name="description" content="Gjennomtenkte samtaleprompter for par, venner, familie og egen refleksjon. Velg hvem du er med, sett tonen og la neste spørsmål åpne noe ekte.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="nb">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-nb.html">
+  <meta property="og:title" content="Deeper Conversations — Spørsmål som bringer mennesker nærmere.">
+  <meta property="og:description" content="Gjennomtenkte samtaleprompter for par, venner, familie og egen refleksjon. Velg hvem du er med, sett tonen og la neste spørsmål åpne noe ekte.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Gjennomtenkte samtaleprompter for par, venner, familie og egen refleksjon. Velg hvem du er med, sett tonen og la neste spørsmål åpne noe ekte.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-nb.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html" aria-current="page">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Spørsmål som bringer mennesker nærmere.</h1>
+          <p>Gjennomtenkte samtaleprompter for par, venner, familie og egen refleksjon. Velg hvem du er med, sett tonen og la neste spørsmål åpne noe ekte.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Last ned i App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>De fleste relasjoner trenger ikke flere råd.<br>De trenger bedre åpninger.</h2>
+      <p>Det kan være vanskelig å vite hvordan man starter en meningsfull samtale. Deeper Conversations gir deg nøye utformede prompter og oppfølgingsspørsmål som hjelper mennesker forbi småprat uten at øyeblikket føles tvunget.</p>
+      <p>Bruk den på en datekveld, en biltur, en familiemiddag, en rolig kveld sammen eller et øyeblikk med egen refleksjon.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirert av forskning på nærhet</h2>
+      <p>Deeper Conversations bygger på en enkel, forskningsstøttet idé: mennesker føler seg ofte nærmere hverandre når de deler gradvis, lytter oppmerksomt og svarer med ekte tilstedeværelse.</p>
+<p>I en kjent studie fra 1997 fant psykologen Arthur Aron og kolleger at par av fremmede som svarte på en serie stadig mer personlige spørsmål, rapporterte sterkere følelser av nærhet enn par som fikk småprat-oppgaver.</p>
+<p>Deeper Conversations kopierer ikke de opprinnelige 36 spørsmålene. I stedet bygger appen på det samme underliggende mønsteret: begynn forsiktig, øk dybden over tid, og bruk gjennomtenkte oppfølgingsspørsmål for å hjelpe samtalen videre når noe meningsfullt åpner seg.</p>
+<p>Appen speiler også bredere forskning på intimitet og kontakt: selvåpenhet betyr noe, men det gjør også følelsen av å bli forstått, akseptert og møtt.</p>
+      <p>Les forskningen:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Laget for relasjonene som betyr noe</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Par</h3>
+    <p>Føl dere nærmere hverandre, forstå hverandre bedre og snakk om ting som ofte blir usagt.</p>
+  </article>
+<article class="mini-card">
+    <h3>Venner</h3>
+    <p>Gå forbi oppdateringer og interne vitser til samtaler som viser hva som egentlig foregår.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familie</h3>
+    <p>Åpne minner, verdier, historier og samtaler mellom generasjoner som kanskje ikke ville oppstått av seg selv.</p>
+  </article>
+<article class="mini-card">
+    <h3>Egen refleksjon</h3>
+    <p>Bruk gjennomtenkte spørsmål til å forstå hva du føler, verdsetter, husker og ønsker.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Sett tonen</h2>
+      <div class="tone-list">
+        <p>Start lett når du vil ha noe enkelt.</p>
+<p>Vær ærlig når øyeblikket er klart.</p>
+<p>Gå dypere når noe ekte åpner seg.</p>
+      </div>
+      <p>Hver økt kan inneholde oppfølgingsspørsmål, slik at samtalen ikke trenger å stoppe ved det første svaret.</p>
+    </section>
+
+    <section class="section">
+      <h2>Guidede opplevelser inkludert</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>En guidet spørsmålsopplevelse inspirert av forskning på nærhet og gradvis selvåpenhet.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 spørsmål gjennom 9 livskapitler, laget for å spørre foreldre, besteforeldre, nære personer eller deg selv om minner, mening og arv.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>En enkel guidet måte å fortelle historier fra livet ditt og høre historiene bak noen andres.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Gjennomtenkte spørsmål om døden, omsorg, arv, familie, sorg, tilgivelse og det som betyr mest når tiden føles begrenset.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Hvorfor Full tilgang er verdt det</h2>
+      <p>Gratisversjonen hjelper deg i gang. Full tilgang er for dem som vil komme tilbake til Deeper Conversations igjen og igjen.</p>
+      <p>Full tilgang låser opp hele premiumbiblioteket: 2 802 prompter og oppfølgingsspørsmål, lengre økter, intimitetsspørsmål, Fall in Love, Life Story, Share an Experience, Mortality Conversations og flere guidede opplevelser.</p>
+      <p>Det betyr flere måter å:</p>
+  <ul>
+    <li>føle dere nærmere hverandre som par</li>
+<li>holde vennskap følelsesmessig levende</li>
+<li>stille familiemedlemmer spørsmål du kanskje ikke ville tenkt på</li>
+<li>snakke varsomt om dødelighet, omsorg, arv, sorg og familiebeslutninger</li>
+<li>reflektere ærlig over ditt eget liv</li>
+<li>fortsette en samtale når det første svaret åpner noe viktig</li>
+  </ul>
+      <p class="purchase-note">Engangskjøp. Ingen abonnement.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privat av design</h2>
+      <div class="privacy-list">
+        <span>Ingen feeder.</span>
+<span>Ingen profiler.</span>
+<span>Ingen konto kreves.</span>
+<span>Ingen press om å prestere.</span>
+      </div>
+      <p>Deeper Conversations er bygget rundt private, tekstbaserte prompter. Appen samler ikke inn, overfører ikke og deler ikke personlig samtaleinnhold.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Tilgjengelig på iPhone og iPad</h2>
+      <p>Bruk den over bordet, på sofaen, på tur eller i et stille øyeblikk alene.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Last ned i App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kode? Løs inn Full tilgang gratis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Er Deeper Conversations bare for par?</summary>
+    <p>Nei. Den inkluderer moduser for par, venner, familie og egen refleksjon.</p>
+  </details>
+<details>
+    <summary>Er dette terapi?</summary>
+    <p>Nei. Deeper Conversations er ikke terapi eller medisinsk rådgivning. Det er en app for samtale og refleksjon.</p>
+  </details>
+<details>
+    <summary>Er Full tilgang et abonnement?</summary>
+    <p>Nei. Full tilgang er et engangskjøp som gir livstidstilgang til hele Full tilgang-biblioteket.</p>
+  </details>
+<details>
+    <summary>Samler appen inn samtalene mine?</summary>
+    <p>Nei. Appen samler ikke inn, overfører ikke og deler ikke personlig samtaleinnhold.</p>
+  </details>
+<details>
+    <summary>Hvilke enheter støttes?</summary>
+    <p>Deeper Conversations fungerer på iPhone og iPad med iOS 18 eller nyere.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Personvernerklæring</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-nb.html
+++ b/docs/marketing/invite-nb.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Tidsbegrenset tilbud:</strong> Full tilgang er gratis til 30. juli 2026. Lås opp premiumbiblioteket med 2 800+ prompter og oppfølgingsspørsmål.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Løs inn Full tilgang gratis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-nb.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Spørsmål som bringer mennesker nærmere.</h1>
           <p>Gjennomtenkte samtaleprompter for par, venner, familie og egen refleksjon. Velg hvem du er med, sett tonen og la neste spørsmål åpne noe ekte.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Tidsbegrenset tilbud</p>
+            <h2>Full tilgang er gratis til 30. juli 2026</h2>
+            <p>Lås opp premiumbiblioteket med 2 800+ prompter og oppfølgingsspørsmål.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Løs inn Full tilgang gratis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Last ned i App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Tilgjengelig på iPhone og iPad</h2>
       <p>Bruk den over bordet, på sofaen, på tur eller i et stille øyeblikk alene.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Last ned i App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kode? Løs inn Full tilgang gratis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Løs inn Full tilgang gratis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-nl.html
+++ b/docs/marketing/invite-nl.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Tijdelijke aanbieding:</strong> Volledige toegang gratis tot 30 juli 2026. Ontgrendel de premiumbibliotheek met 2.800+ prompts en vervolgvragen.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Verzilver gratis Volledige toegang</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-nl.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Vragen die mensen dichter bij elkaar brengen.</h1>
           <p>Doordachte gespreksprompts voor stellen, vrienden, familie en zelfreflectie. Kies met wie je bent, bepaal de toon en laat de volgende vraag iets echts openen.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Tijdelijke aanbieding</p>
+            <h2>Volledige toegang gratis tot 30 juli 2026</h2>
+            <p>Ontgrendel de premiumbibliotheek met 2.800+ prompts en vervolgvragen.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Verzilver gratis Volledige toegang</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Download in de App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Beschikbaar op iPhone en iPad</h2>
       <p>Gebruik het aan tafel, op de bank, onderweg of tijdens een rustig moment alleen.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Download in de App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Heb je een code? Verzilver gratis Volledige toegang</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Verzilver gratis Volledige toegang</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-nl.html
+++ b/docs/marketing/invite-nl.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Vragen die mensen dichter bij elkaar brengen.</title>
+  <meta name="description" content="Doordachte gespreksprompts voor stellen, vrienden, familie en zelfreflectie. Kies met wie je bent, bepaal de toon en laat de volgende vraag iets echts openen.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="nl">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-nl.html">
+  <meta property="og:title" content="Deeper Conversations — Vragen die mensen dichter bij elkaar brengen.">
+  <meta property="og:description" content="Doordachte gespreksprompts voor stellen, vrienden, familie en zelfreflectie. Kies met wie je bent, bepaal de toon en laat de volgende vraag iets echts openen.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Doordachte gespreksprompts voor stellen, vrienden, familie en zelfreflectie. Kies met wie je bent, bepaal de toon en laat de volgende vraag iets echts openen.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-nl.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html" aria-current="page">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Vragen die mensen dichter bij elkaar brengen.</h1>
+          <p>Doordachte gespreksprompts voor stellen, vrienden, familie en zelfreflectie. Kies met wie je bent, bepaal de toon en laat de volgende vraag iets echts openen.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Download in de App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>De meeste relaties hebben niet meer advies nodig.<br>Ze hebben betere openingen nodig.</h2>
+      <p>Het kan lastig zijn om te weten hoe je een betekenisvol gesprek begint. Deeper Conversations geeft je zorgvuldig gemaakte prompts en vervolgvragen die mensen helpen voorbij smalltalk te komen, zonder dat het moment geforceerd voelt.</p>
+      <p>Gebruik het voor een date, een roadtrip, een familiediner, een rustige avond samen of een moment van reflectie voor jezelf.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Geïnspireerd door onderzoek naar nabijheid</h2>
+      <p>Deeper Conversations is gebouwd rond een eenvoudig, door onderzoek ondersteund idee: mensen voelen zich vaak dichter bij elkaar wanneer ze geleidelijk delen, aandachtig luisteren en met echte aandacht reageren.</p>
+<p>In een bekende studie uit 1997 ontdekten psycholoog Arthur Aron en collega's dat paren vreemden die een reeks steeds persoonlijkere vragen beantwoordden, meer gevoelens van nabijheid rapporteerden dan paren die smalltalk-opdrachten deden.</p>
+<p>Deeper Conversations kopieert de oorspronkelijke 36 vragen niet. In plaats daarvan bouwt de app voort op hetzelfde onderliggende patroon: rustig beginnen, de diepte geleidelijk vergroten en doordachte vervolgvragen gebruiken om het gesprek verder te helpen wanneer er iets betekenisvols opengaat.</p>
+<p>De app weerspiegelt ook breder onderzoek naar intimiteit en verbinding: zelfonthulling is belangrijk, maar je begrepen, geaccepteerd en beantwoord voelen is dat ook.</p>
+      <p>Lees het onderzoek:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Gemaakt voor relaties die ertoe doen</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Stellen</h3>
+    <p>Voel je dichter bij elkaar, begrijp elkaar beter en praat over dingen die vaak onuitgesproken blijven.</p>
+  </article>
+<article class="mini-card">
+    <h3>Vrienden</h3>
+    <p>Ga voorbij updates en inside jokes naar gesprekken die laten zien wat er echt speelt.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familie</h3>
+    <p>Open herinneringen, waarden, verhalen en gesprekken tussen generaties die misschien niet vanzelf ontstaan.</p>
+  </article>
+<article class="mini-card">
+    <h3>Zelfreflectie</h3>
+    <p>Gebruik doordachte vragen om te begrijpen wat je voelt, belangrijk vindt, herinnert en wilt.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Kies de toon</h2>
+      <div class="tone-list">
+        <p>Begin luchtig wanneer je iets eenvoudigs wilt.</p>
+<p>Word eerlijk wanneer het moment er klaar voor is.</p>
+<p>Ga dieper wanneer er iets echts opengaat.</p>
+      </div>
+      <p>Elke sessie kan vervolgvragen bevatten, zodat het gesprek niet hoeft te stoppen bij het eerste antwoord.</p>
+    </section>
+
+    <section class="section">
+      <h2>Begeleide ervaringen inbegrepen</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Een begeleide vragenervaring, geïnspireerd door onderzoek naar nabijheid en geleidelijke zelfonthulling.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 vragen verdeeld over 9 levenshoofdstukken, ontworpen om ouders, grootouders, dierbaren of jezelf te vragen naar herinnering, betekenis en nalatenschap.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Een eenvoudige begeleide manier om verhalen uit je leven te delen en de verhalen achter iemand anders te horen.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Doordachte vragen over de dood, zorg, nalatenschap, familie, rouw, vergeving en wat het meest telt wanneer tijd beperkt voelt.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Waarom Volledige toegang de moeite waard is</h2>
+      <p>De gratis versie helpt je op weg. Volledige toegang is voor mensen die steeds opnieuw naar Deeper Conversations willen terugkeren.</p>
+      <p>Volledige toegang ontgrendelt de complete premiumbibliotheek: 2.802 prompts en vervolgvragen, langere sessies, intimiteitsvragen, Fall in Love, Life Story, Share an Experience, Mortality Conversations en meer begeleide ervaringen.</p>
+      <p>Dat betekent meer manieren om:</p>
+  <ul>
+    <li>je als stel dichter bij elkaar te voelen</li>
+<li>vriendschappen emotioneel levend te houden</li>
+<li>familieleden vragen te stellen waar je misschien zelf niet aan denkt</li>
+<li>zorgvuldig te praten over sterfelijkheid, zorg, nalatenschap, rouw en familiebeslissingen</li>
+<li>eerlijk op je eigen leven te reflecteren</li>
+<li>een gesprek voort te zetten wanneer het eerste antwoord iets belangrijks opent</li>
+  </ul>
+      <p class="purchase-note">Eenmalige aankoop. Geen abonnement.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privé ontworpen</h2>
+      <div class="privacy-list">
+        <span>Geen feeds.</span>
+<span>Geen profielen.</span>
+<span>Geen account nodig.</span>
+<span>Geen druk om te presteren.</span>
+      </div>
+      <p>Deeper Conversations is gebouwd rond privéprompts die alleen uit tekst bestaan. De app verzamelt, verzendt of deelt geen persoonlijke gespreksinhoud.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Beschikbaar op iPhone en iPad</h2>
+      <p>Gebruik het aan tafel, op de bank, onderweg of tijdens een rustig moment alleen.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Download in de App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Heb je een code? Verzilver gratis Volledige toegang</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Is Deeper Conversations alleen voor stellen?</summary>
+    <p>Nee. De app bevat modi voor stellen, vrienden, familie en zelfreflectie.</p>
+  </details>
+<details>
+    <summary>Is dit therapie?</summary>
+    <p>Nee. Deeper Conversations is geen therapie en geen medisch advies. Het is een app voor gesprek en reflectie.</p>
+  </details>
+<details>
+    <summary>Is Volledige toegang een abonnement?</summary>
+    <p>Nee. Volledige toegang is een eenmalige aankoop die levenslange toegang geeft tot de complete Volledige toegang-bibliotheek.</p>
+  </details>
+<details>
+    <summary>Verzamelt de app mijn gesprekken?</summary>
+    <p>Nee. De app verzamelt, verzendt of deelt geen persoonlijke gespreksinhoud.</p>
+  </details>
+<details>
+    <summary>Welke apparaten worden ondersteund?</summary>
+    <p>Deeper Conversations werkt op iPhone en iPad met iOS 18 of later.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Privacybeleid</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-pl.html
+++ b/docs/marketing/invite-pl.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Oferta ograniczona czasowo:</strong> Pełny dostęp za darmo do 30 lipca 2026. Odblokuj bibliotekę premium z ponad 2 800 promptami i pytaniami pogłębiającymi.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Odbierz Pełny dostęp za darmo</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-pl.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Pytania, które zbliżają ludzi.</h1>
           <p>Przemyślane prompty do rozmów dla par, przyjaciół, rodzin i refleksji solo. Wybierz, z kim rozmawiasz, ustaw ton i pozwól, by kolejne pytanie otworzyło coś prawdziwego.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Oferta ograniczona czasowo</p>
+            <h2>Pełny dostęp za darmo do 30 lipca 2026</h2>
+            <p>Odblokuj bibliotekę premium z ponad 2 800 promptami i pytaniami pogłębiającymi.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Odbierz Pełny dostęp za darmo</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Pobierz z App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Dostępne na iPhone i iPad</h2>
       <p>Używaj przy stole, na kanapie, w podróży albo w spokojnej chwili sam na sam.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Pobierz z App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Masz kod? Odbierz Pełny dostęp za darmo</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Odbierz Pełny dostęp za darmo</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-pl.html
+++ b/docs/marketing/invite-pl.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Pytania, które zbliżają ludzi.</title>
+  <meta name="description" content="Przemyślane prompty do rozmów dla par, przyjaciół, rodzin i refleksji solo. Wybierz, z kim rozmawiasz, ustaw ton i pozwól, by kolejne pytanie otworzyło coś prawdziwego.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="pl">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-pl.html">
+  <meta property="og:title" content="Deeper Conversations — Pytania, które zbliżają ludzi.">
+  <meta property="og:description" content="Przemyślane prompty do rozmów dla par, przyjaciół, rodzin i refleksji solo. Wybierz, z kim rozmawiasz, ustaw ton i pozwól, by kolejne pytanie otworzyło coś prawdziwego.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Przemyślane prompty do rozmów dla par, przyjaciół, rodzin i refleksji solo. Wybierz, z kim rozmawiasz, ustaw ton i pozwól, by kolejne pytanie otworzyło coś prawdziwego.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-pl.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html" aria-current="page">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Pytania, które zbliżają ludzi.</h1>
+          <p>Przemyślane prompty do rozmów dla par, przyjaciół, rodzin i refleksji solo. Wybierz, z kim rozmawiasz, ustaw ton i pozwól, by kolejne pytanie otworzyło coś prawdziwego.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Pobierz z App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>Większość relacji nie potrzebuje więcej porad.<br>Potrzebuje lepszych początków.</h2>
+      <p>Trudno czasem wiedzieć, jak zacząć naprawdę znaczącą rozmowę. Deeper Conversations daje starannie przygotowane prompty i pytania pogłębiające, które pomagają wyjść poza small talk bez poczucia sztuczności.</p>
+      <p>Użyj jej na randce, w podróży, przy rodzinnym obiedzie, podczas spokojnego wieczoru we dwoje albo w chwili własnej refleksji.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirowane badaniami nad bliskością</h2>
+      <p>Deeper Conversations opiera się na prostej idei wspieranej przez badania: ludzie często czują się bliżej, gdy stopniowo się otwierają, uważnie słuchają i reagują z prawdziwą obecnością.</p>
+<p>W znanym badaniu z 1997 roku psycholog Arthur Aron i jego współpracownicy odkryli, że pary nieznajomych odpowiadające na serię coraz bardziej osobistych pytań zgłaszały większe poczucie bliskości niż pary wykonujące zadania oparte na small talku.</p>
+<p>Deeper Conversations nie kopiuje oryginalnych 36 pytań. Zamiast tego rozwija ten sam podstawowy wzorzec: zacząć łagodnie, stopniowo zwiększać głębię i używać przemyślanych pytań pogłębiających, aby rozmowa mogła trwać, gdy otwiera się coś ważnego.</p>
+<p>Aplikacja odzwierciedla też szersze badania nad intymnością i więzią: otwartość ma znaczenie, ale równie ważne jest poczucie bycia zrozumianym, zaakceptowanym i usłyszanym.</p>
+      <p>Przeczytaj badania:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Stworzone dla relacji, które mają znaczenie</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Pary</h3>
+    <p>Poczujcie się bliżej, lepiej się zrozumcie i porozmawiajcie o tym, co często zostaje niewypowiedziane.</p>
+  </article>
+<article class="mini-card">
+    <h3>Przyjaciele</h3>
+    <p>Wyjdźcie poza aktualności i żarty, w stronę rozmów, które pokazują, co naprawdę się dzieje.</p>
+  </article>
+<article class="mini-card">
+    <h3>Rodzina</h3>
+    <p>Otwórzcie wspomnienia, wartości, historie i rozmowy międzypokoleniowe, które same mogłyby się nie wydarzyć.</p>
+  </article>
+<article class="mini-card">
+    <h3>Refleksja solo</h3>
+    <p>Używaj przemyślanych pytań, by lepiej zrozumieć, co czujesz, cenisz, pamiętasz i czego chcesz.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Wybierz ton</h2>
+      <div class="tone-list">
+        <p>Zacznij lekko, gdy chcesz czegoś prostego.</p>
+<p>Bądź szczery, gdy chwila jest gotowa.</p>
+<p>Wejdź głębiej, gdy otwiera się coś prawdziwego.</p>
+      </div>
+      <p>Każda sesja może zawierać pytania pogłębiające, więc rozmowa nie musi kończyć się na pierwszej odpowiedzi.</p>
+    </section>
+
+    <section class="section">
+      <h2>Prowadzone doświadczenia w zestawie</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Prowadzone doświadczenie pytań inspirowane badaniami nad bliskością i stopniowym otwieraniem się.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 pytań w 9 rozdziałach życia, zaprojektowanych do rozmów z rodzicami, dziadkami, bliskimi albo samym sobą o pamięci, sensie i dziedzictwie.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Prosty, prowadzony sposób opowiadania historii ze swojego życia i słuchania historii stojących za życiem drugiej osoby.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Przemyślane pytania o śmierć, opiekę, dziedzictwo, rodzinę, żałobę, przebaczenie i to, co najważniejsze, gdy czas wydaje się ograniczony.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Dlaczego Pełny dostęp jest tego wart</h2>
+      <p>Darmowa wersja pomaga zacząć. Pełny dostęp jest dla osób, które chcą wracać do Deeper Conversations wielokrotnie.</p>
+      <p>Pełny dostęp odblokowuje kompletną bibliotekę premium: 2 802 promptów i pytań pogłębiających, dłuższe sesje, pytania o intymność, Fall in Love, Life Story, Share an Experience, Mortality Conversations i więcej prowadzonych doświadczeń.</p>
+      <p>To oznacza więcej sposobów, by:</p>
+  <ul>
+    <li>poczuć się bliżej jako para</li>
+<li>utrzymać emocjonalną żywotność przyjaźni</li>
+<li>zadać rodzinie pytania, które mogłyby nie przyjść do głowy</li>
+<li>rozmawiać uważnie o śmiertelności, opiece, dziedzictwie, żałobie i decyzjach rodzinnych</li>
+<li>szczerze zastanowić się nad własnym życiem</li>
+<li>kontynuować rozmowę, gdy pierwsza odpowiedź otwiera coś ważnego</li>
+  </ul>
+      <p class="purchase-note">Jednorazowy zakup. Bez subskrypcji.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Prywatność od początku</h2>
+      <div class="privacy-list">
+        <span>Bez feedów.</span>
+<span>Bez profili.</span>
+<span>Bez wymaganego konta.</span>
+<span>Bez presji, by wypaść w określony sposób.</span>
+      </div>
+      <p>Deeper Conversations opiera się na prywatnych, tekstowych promptach. Aplikacja nie zbiera, nie przesyła ani nie udostępnia osobistych treści rozmów.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Dostępne na iPhone i iPad</h2>
+      <p>Używaj przy stole, na kanapie, w podróży albo w spokojnej chwili sam na sam.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Pobierz z App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Masz kod? Odbierz Pełny dostęp za darmo</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Czy Deeper Conversations jest tylko dla par?</summary>
+    <p>Nie. Zawiera tryby dla par, przyjaciół, rodziny i refleksji solo.</p>
+  </details>
+<details>
+    <summary>Czy to terapia?</summary>
+    <p>Nie. Deeper Conversations nie jest terapią ani poradą medyczną. To aplikacja do rozmowy i refleksji.</p>
+  </details>
+<details>
+    <summary>Czy Pełny dostęp to subskrypcja?</summary>
+    <p>Nie. Pełny dostęp to jednorazowy zakup, który daje dożywotni dostęp do kompletnej biblioteki Pełnego dostępu.</p>
+  </details>
+<details>
+    <summary>Czy aplikacja zbiera moje rozmowy?</summary>
+    <p>Nie. Aplikacja nie zbiera, nie przesyła ani nie udostępnia osobistych treści rozmów.</p>
+  </details>
+<details>
+    <summary>Jakie urządzenia są obsługiwane?</summary>
+    <p>Deeper Conversations działa na iPhonie i iPadzie z iOS 18 lub nowszym.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Polityka prywatności</a>
+      <a href="../">Wsparcie</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-pt-BR.html
+++ b/docs/marketing/invite-pt-BR.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Perguntas que aproximam as pessoas.</title>
+  <meta name="description" content="Prompts de conversa pensados para casais, amigos, família e reflexão pessoal. Escolha com quem você está, defina o tom e deixe a próxima pergunta abrir algo real.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="pt-BR">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-pt-BR.html">
+  <meta property="og:title" content="Deeper Conversations — Perguntas que aproximam as pessoas.">
+  <meta property="og:description" content="Prompts de conversa pensados para casais, amigos, família e reflexão pessoal. Escolha com quem você está, defina o tom e deixe a próxima pergunta abrir algo real.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Prompts de conversa pensados para casais, amigos, família e reflexão pessoal. Escolha com quem você está, defina o tom e deixe a próxima pergunta abrir algo real.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-pt-BR.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html" aria-current="page">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Perguntas que aproximam as pessoas.</h1>
+          <p>Prompts de conversa pensados para casais, amigos, família e reflexão pessoal. Escolha com quem você está, defina o tom e deixe a próxima pergunta abrir algo real.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Baixar na App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>A maioria das relações não precisa de mais conselhos.<br>Precisa de melhores começos.</h2>
+      <p>Pode ser difícil saber como começar uma conversa significativa. Deeper Conversations oferece prompts e perguntas de acompanhamento cuidadosamente criados para ajudar as pessoas a irem além da conversa superficial sem deixar o momento forçado.</p>
+      <p>Use em um encontro, uma viagem, um jantar em família, uma noite tranquila a dois ou um momento de reflexão só seu.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirado em pesquisas sobre proximidade</h2>
+      <p>Deeper Conversations é construído em torno de uma ideia simples, apoiada por pesquisas: muitas vezes, as pessoas se sentem mais próximas quando compartilham aos poucos, escutam com atenção e respondem com presença de verdade.</p>
+<p>Em um estudo conhecido de 1997, o psicólogo Arthur Aron e seus colegas descobriram que pares de desconhecidos que responderam a uma série de perguntas cada vez mais pessoais relataram maior sensação de proximidade do que pares designados para tarefas de conversa superficial.</p>
+<p>Deeper Conversations não copia as 36 perguntas originais. Em vez disso, ele se baseia no mesmo padrão: começar com leveza, aumentar a profundidade com o tempo e usar acompanhamentos cuidadosos para ajudar a conversa a continuar quando algo significativo se abre.</p>
+<p>O app também reflete pesquisas mais amplas sobre intimidade e conexão: se abrir importa, mas sentir-se compreendido, aceito e respondido também importa.</p>
+      <p>Leia a pesquisa:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Feito para as relações que importam</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Casais</h3>
+    <p>Sintam-se mais próximos, entendam-se melhor e conversem sobre coisas que muitas vezes ficam sem dizer.</p>
+  </article>
+<article class="mini-card">
+    <h3>Amigos</h3>
+    <p>Vão além das novidades e piadas internas para conversas que revelam o que realmente está acontecendo.</p>
+  </article>
+<article class="mini-card">
+    <h3>Família</h3>
+    <p>Abra memórias, valores, histórias e conversas entre gerações que talvez não surgissem sozinhas.</p>
+  </article>
+<article class="mini-card">
+    <h3>Reflexão pessoal</h3>
+    <p>Use perguntas cuidadosas para entender o que você sente, valoriza, lembra e deseja.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Escolha o tom</h2>
+      <div class="tone-list">
+        <p>Comece leve quando quiser algo fácil.</p>
+<p>Seja honesto quando o momento estiver pronto.</p>
+<p>Vá mais fundo quando algo real se abrir.</p>
+      </div>
+      <p>Cada sessão pode incluir perguntas de acompanhamento, para que a conversa não precise parar na primeira resposta.</p>
+    </section>
+
+    <section class="section">
+      <h2>Experiências guiadas incluídas</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Uma experiência guiada de perguntas inspirada em pesquisas sobre proximidade e abertura gradual.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 perguntas em 9 capítulos de vida, pensadas para perguntar a pais, avós, pessoas queridas ou a você mesmo sobre memória, significado e legado.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Uma forma simples e guiada de contar histórias da sua vida e ouvir as histórias por trás da vida de outra pessoa.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Perguntas cuidadosas sobre morte, cuidado, legado, família, luto, perdão e o que mais importa quando o tempo parece limitado.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Por que Acesso completo vale a pena</h2>
+      <p>A versão gratuita ajuda você a começar. Acesso completo é para quem quer voltar ao Deeper Conversations muitas vezes.</p>
+      <p>Acesso completo desbloqueia toda a biblioteca premium: 2.802 prompts e perguntas de acompanhamento, sessões mais longas, perguntas de intimidade, Fall in Love, Life Story, Share an Experience, Mortality Conversations e outras experiências guiadas.</p>
+      <p>Isso significa mais formas de:</p>
+  <ul>
+    <li>sentir mais proximidade como casal</li>
+<li>manter amizades emocionalmente vivas</li>
+<li>fazer a familiares perguntas que talvez você não pensasse em fazer</li>
+<li>conversar com cuidado sobre mortalidade, cuidado, legado, luto e decisões familiares</li>
+<li>refletir honestamente sobre a própria vida</li>
+<li>continuar uma conversa quando a primeira resposta abre algo importante</li>
+  </ul>
+      <p class="purchase-note">Compra única. Sem assinatura.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privado por design</h2>
+      <div class="privacy-list">
+        <span>Sem feeds.</span>
+<span>Sem perfis.</span>
+<span>Sem necessidade de conta.</span>
+<span>Sem pressão para performar.</span>
+      </div>
+      <p>Deeper Conversations é construído em torno de prompts privados, apenas em texto. O app não coleta, transmite nem compartilha o conteúdo pessoal das suas conversas.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Disponível para iPhone e iPad</h2>
+      <p>Use à mesa, no sofá, em uma viagem ou durante um momento tranquilo sozinho.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Baixar na App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Tem um código? Resgate o Acesso Completo grátis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Deeper Conversations é só para casais?</summary>
+    <p>Não. Ele inclui modos para casais, amigos, família e reflexão pessoal.</p>
+  </details>
+<details>
+    <summary>Isso é terapia?</summary>
+    <p>Não. Deeper Conversations não é terapia nem orientação médica. É um app de conversa e reflexão.</p>
+  </details>
+<details>
+    <summary>Acesso completo é uma assinatura?</summary>
+    <p>Não. Acesso completo é uma compra única que dá acesso vitalício à biblioteca completa de Acesso completo.</p>
+  </details>
+<details>
+    <summary>O app coleta minhas conversas?</summary>
+    <p>Não. O app não coleta, transmite nem compartilha o conteúdo pessoal das suas conversas.</p>
+  </details>
+<details>
+    <summary>Quais dispositivos são compatíveis?</summary>
+    <p>Deeper Conversations funciona em iPhone e iPad com iOS 18 ou posterior.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Política de Privacidade</a>
+      <a href="../">Suporte</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-pt-BR.html
+++ b/docs/marketing/invite-pt-BR.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Oferta por tempo limitado:</strong> Acesso Completo grátis até 30 de julho de 2026. Desbloqueie a biblioteca premium com mais de 2.800 prompts e perguntas de acompanhamento.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Resgate o Acesso Completo grátis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-pt-BR.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Perguntas que aproximam as pessoas.</h1>
           <p>Prompts de conversa pensados para casais, amigos, família e reflexão pessoal. Escolha com quem você está, defina o tom e deixe a próxima pergunta abrir algo real.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Oferta por tempo limitado</p>
+            <h2>Acesso Completo grátis até 30 de julho de 2026</h2>
+            <p>Desbloqueie a biblioteca premium com mais de 2.800 prompts e perguntas de acompanhamento.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Resgate o Acesso Completo grátis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Baixar na App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Disponível para iPhone e iPad</h2>
       <p>Use à mesa, no sofá, em uma viagem ou durante um momento tranquilo sozinho.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Baixar na App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Tem um código? Resgate o Acesso Completo grátis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Resgate o Acesso Completo grátis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-ru.html
+++ b/docs/marketing/invite-ru.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Вопросы, которые сближают людей.</title>
+  <meta name="description" content="Продуманные подсказки для разговоров в паре, с друзьями, семьей и наедине с собой. Выбери, с кем ты говоришь, задай тон и позволь следующему вопросу открыть что-то настоящее.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="ru">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-ru.html">
+  <meta property="og:title" content="Deeper Conversations — Вопросы, которые сближают людей.">
+  <meta property="og:description" content="Продуманные подсказки для разговоров в паре, с друзьями, семьей и наедине с собой. Выбери, с кем ты говоришь, задай тон и позволь следующему вопросу открыть что-то настоящее.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Продуманные подсказки для разговоров в паре, с друзьями, семьей и наедине с собой. Выбери, с кем ты говоришь, задай тон и позволь следующему вопросу открыть что-то настоящее.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-ru.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html" aria-current="page">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Вопросы, которые сближают людей.</h1>
+          <p>Продуманные подсказки для разговоров в паре, с друзьями, семьей и наедине с собой. Выбери, с кем ты говоришь, задай тон и позволь следующему вопросу открыть что-то настоящее.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Скачать в App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>Большинству отношений не нужно больше советов.<br>Им нужны лучшие начала.</h2>
+      <p>Иногда трудно понять, как начать по-настоящему значимый разговор. Deeper Conversations предлагает тщательно созданные подсказки и уточняющие вопросы, которые помогают выйти за рамки светской беседы без ощущения принужденности.</p>
+      <p>Используй приложение на свидании, в поездке, за семейным ужином, тихим вечером вдвоем или в момент личной рефлексии.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Вдохновлено исследованиями близости</h2>
+      <p>Deeper Conversations строится вокруг простой идеи, поддержанной исследованиями: люди часто чувствуют больше близости, когда постепенно делятся личным, внимательно слушают и отвечают с настоящим вниманием.</p>
+<p>В известном исследовании 1997 года психолог Arthur Aron и его коллеги обнаружили, что пары незнакомцев, отвечавшие на серию все более личных вопросов, сообщали о более сильном чувстве близости, чем пары, выполнявшие задания для светской беседы.</p>
+<p>Deeper Conversations не копирует исходные 36 вопросов. Вместо этого приложение опирается на тот же базовый принцип: начать мягко, со временем углубляться и использовать продуманные уточнения, чтобы разговор продолжался, когда открывается что-то значимое.</p>
+<p>Приложение также отражает более широкие исследования интимности и связи: важно не только раскрывать себя, но и чувствовать, что тебя понимают, принимают и откликаются на тебя.</p>
+      <p>Прочитать исследования:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Для отношений, которые важны</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Пары</h3>
+    <p>Почувствуйте больше близости, лучше поймите друг друга и поговорите о том, что часто остается невысказанным.</p>
+  </article>
+<article class="mini-card">
+    <h3>Друзья</h3>
+    <p>Выйдите за рамки новостей и внутренних шуток к разговорам, которые показывают, что происходит на самом деле.</p>
+  </article>
+<article class="mini-card">
+    <h3>Семья</h3>
+    <p>Откройте воспоминания, ценности, истории и разговоры между поколениями, которые могли бы не возникнуть сами.</p>
+  </article>
+<article class="mini-card">
+    <h3>Личная рефлексия</h3>
+    <p>Используй продуманные вопросы, чтобы понять, что ты чувствуешь, ценишь, помнишь и хочешь.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Задай тон</h2>
+      <div class="tone-list">
+        <p>Начни легко, когда хочется чего-то простого.</p>
+<p>Говори честно, когда момент готов.</p>
+<p>Иди глубже, когда открывается что-то настоящее.</p>
+      </div>
+      <p>Каждая сессия может включать уточняющие вопросы, чтобы разговор не останавливался на первом ответе.</p>
+    </section>
+
+    <section class="section">
+      <h2>Проводимые форматы включены</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>Проводимый формат вопросов, вдохновленный исследованиями близости и постепенного самораскрытия.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 вопросов в 9 главах жизни, созданных для разговоров с родителями, бабушками и дедушками, близкими людьми или с самим собой о памяти, смысле и наследии.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Простой проводимый способ рассказывать истории из своей жизни и слышать истории, стоящие за жизнью другого человека.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Бережные вопросы о смерти, заботе, наследии, семье, горе, прощении и о том, что важнее всего, когда время кажется ограниченным.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Почему Полный доступ того стоит</h2>
+      <p>Бесплатная версия помогает начать. Полный доступ создан для тех, кто хочет возвращаться к Deeper Conversations снова и снова.</p>
+      <p>Полный доступ открывает всю премиум-библиотеку: 2 802 основных и уточняющих вопроса, более длинные сессии, вопросы об интимности, Fall in Love, Life Story, Share an Experience, Mortality Conversations и другие проводимые форматы.</p>
+      <p>Это дает больше способов:</p>
+  <ul>
+    <li>чувствовать близость в паре</li>
+<li>сохранять дружбу эмоционально живой</li>
+<li>задавать семье вопросы, которые могли бы не прийти в голову</li>
+<li>бережно говорить о смертности, заботе, наследии, горе и семейных решениях</li>
+<li>честно размышлять о собственной жизни</li>
+<li>продолжать разговор, когда первый ответ открывает что-то важное</li>
+  </ul>
+      <p class="purchase-note">Разовая покупка. Без подписки.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Приватность по замыслу</h2>
+      <div class="privacy-list">
+        <span>Без лент.</span>
+<span>Без профилей.</span>
+<span>Без обязательного аккаунта.</span>
+<span>Без давления что-то изображать.</span>
+      </div>
+      <p>Deeper Conversations строится вокруг приватных текстовых подсказок. Приложение не собирает, не передает и не делится личным содержанием ваших разговоров.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Доступно на iPhone и iPad</h2>
+      <p>Используй за столом, на диване, в поездке или в тихий момент наедине с собой.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Скачать в App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Есть код? Получите полный доступ бесплатно</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Deeper Conversations только для пар?</summary>
+    <p>Нет. В приложении есть режимы для пар, друзей, семьи и личной рефлексии.</p>
+  </details>
+<details>
+    <summary>Это терапия?</summary>
+    <p>Нет. Deeper Conversations не является терапией или медицинской консультацией. Это приложение для разговоров и рефлексии.</p>
+  </details>
+<details>
+    <summary>Полный доступ — это подписка?</summary>
+    <p>Нет. Полный доступ — это разовая покупка, которая дает пожизненный доступ ко всей библиотеке Полного доступа.</p>
+  </details>
+<details>
+    <summary>Приложение собирает мои разговоры?</summary>
+    <p>Нет. Приложение не собирает, не передает и не делится личным содержанием разговоров.</p>
+  </details>
+<details>
+    <summary>Какие устройства поддерживаются?</summary>
+    <p>Deeper Conversations работает на iPhone и iPad с iOS 18 или новее.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Политика конфиденциальности</a>
+      <a href="../">Поддержка</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-ru.html
+++ b/docs/marketing/invite-ru.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Предложение ограничено по времени:</strong> Полный доступ бесплатен до 30 июля 2026 года. Откройте премиум-библиотеку с 2 800+ вопросами и уточняющими подсказками.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Получите полный доступ бесплатно</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-ru.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Вопросы, которые сближают людей.</h1>
           <p>Продуманные подсказки для разговоров в паре, с друзьями, семьей и наедине с собой. Выбери, с кем ты говоришь, задай тон и позволь следующему вопросу открыть что-то настоящее.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Предложение ограничено по времени</p>
+            <h2>Полный доступ бесплатен до 30 июля 2026 года</h2>
+            <p>Откройте премиум-библиотеку с 2 800+ вопросами и уточняющими подсказками.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Получите полный доступ бесплатно</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Скачать в App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Доступно на iPhone и iPad</h2>
       <p>Используй за столом, на диване, в поездке или в тихий момент наедине с собой.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Скачать в App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Есть код? Получите полный доступ бесплатно</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Получите полный доступ бесплатно</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-sv.html
+++ b/docs/marketing/invite-sv.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="sv">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — Frågor som för människor närmare varandra.</title>
+  <meta name="description" content="Genomtänkta samtalsprompter för par, vänner, familj och egen reflektion. Välj vem du är med, sätt tonen och låt nästa fråga öppna något äkta.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="sv">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-sv.html">
+  <meta property="og:title" content="Deeper Conversations — Frågor som för människor närmare varandra.">
+  <meta property="og:description" content="Genomtänkta samtalsprompter för par, vänner, familj och egen reflektion. Välj vem du är med, sätt tonen och låt nästa fråga öppna något äkta.">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="Genomtänkta samtalsprompter för par, vänner, familj och egen reflektion. Välj vem du är med, sätt tonen och låt nästa fråga öppna något äkta.">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-sv.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html" aria-current="page">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>Frågor som för människor närmare varandra.</h1>
+          <p>Genomtänkta samtalsprompter för par, vänner, familj och egen reflektion. Välj vem du är med, sätt tonen och låt nästa fråga öppna något äkta.</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">Ladda ner från App Store</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>De flesta relationer behöver inte fler råd.<br>De behöver bättre öppningar.</h2>
+      <p>Det kan vara svårt att veta hur man börjar ett meningsfullt samtal. Deeper Conversations ger dig noggrant formulerade prompter och uppföljningsfrågor som hjälper människor bortom småprat utan att stunden känns påtvingad.</p>
+      <p>Använd den på en dejt, en bilresa, en familjemiddag, en lugn kväll tillsammans eller en stund för egen reflektion.</p>
+    </section>
+
+    <section class="section research">
+      <h2>Inspirerad av forskning om närhet</h2>
+      <p>Deeper Conversations bygger på en enkel, forskningsstödd idé: människor känner sig ofta närmare varandra när de delar gradvis, lyssnar uppmärksamt och svarar med verklig närvaro.</p>
+<p>I en välkänd studie från 1997 fann psykologen Arthur Aron och kollegor att par av främlingar som besvarade en serie allt mer personliga frågor rapporterade starkare känslor av närhet än par som fick småpratsuppgifter.</p>
+<p>Deeper Conversations kopierar inte de ursprungliga 36 frågorna. I stället bygger appen vidare på samma grundmönster: börja mjukt, öka djupet med tiden och använd genomtänkta uppföljningar för att hjälpa samtalet vidare när något meningsfullt öppnar sig.</p>
+<p>Appen speglar också bredare forskning om intimitet och kontakt: självutlämnande spelar roll, men det gör även känslan av att bli förstådd, accepterad och bemött.</p>
+      <p>Läs forskningen:</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>Skapad för relationer som betyder något</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Par</h3>
+    <p>Känn er närmare varandra, förstå varandra bättre och prata om saker som ofta förblir osagda.</p>
+  </article>
+<article class="mini-card">
+    <h3>Vänner</h3>
+    <p>Gå bortom uppdateringar och interna skämt till samtal som visar vad som faktiskt pågår.</p>
+  </article>
+<article class="mini-card">
+    <h3>Familj</h3>
+    <p>Öppna minnen, värderingar, berättelser och generationssamtal som kanske inte uppstår av sig själva.</p>
+  </article>
+<article class="mini-card">
+    <h3>Egen reflektion</h3>
+    <p>Använd genomtänkta frågor för att förstå vad du känner, värdesätter, minns och vill.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>Sätt tonen</h2>
+      <div class="tone-list">
+        <p>Börja lätt när du vill ha något enkelt.</p>
+<p>Var ärlig när stunden är redo.</p>
+<p>Gå djupare när något äkta öppnar sig.</p>
+      </div>
+      <p>Varje session kan innehålla uppföljningsfrågor, så samtalet behöver inte stanna vid det första svaret.</p>
+    </section>
+
+    <section class="section">
+      <h2>Guidade upplevelser ingår</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>En guidad frågeupplevelse inspirerad av forskning om närhet och gradvis självutlämnande.</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>50 frågor genom 9 livskapitel, utformade för att fråga föräldrar, mor- och farföräldrar, nära personer eller dig själv om minnen, mening och arv.</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>Ett enkelt guidat sätt att berätta historier från ditt liv och höra historierna bakom någon annans.</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>Genomtänkta frågor om döden, omsorg, arv, familj, sorg, förlåtelse och det som betyder mest när tiden känns begränsad.</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>Varför Full åtkomst är värd det</h2>
+      <p>Gratisversionen hjälper dig att börja. Full åtkomst är för dig som vill återvända till Deeper Conversations om och om igen.</p>
+      <p>Full åtkomst låser upp hela premiumbiblioteket: 2 802 promptar och uppföljningsfrågor, längre sessioner, intimitetsfrågor, Fall in Love, Life Story, Share an Experience, Mortality Conversations och fler guidade upplevelser.</p>
+      <p>Det betyder fler sätt att:</p>
+  <ul>
+    <li>känna er närmare varandra som par</li>
+<li>hålla vänskaper känslomässigt levande</li>
+<li>ställa frågor till familjemedlemmar som du kanske inte annars skulle tänka på</li>
+<li>tala varsamt om dödlighet, omsorg, arv, sorg och familjebeslut</li>
+<li>reflektera ärligt över ditt eget liv</li>
+<li>fortsätta ett samtal när det första svaret öppnar något viktigt</li>
+  </ul>
+      <p class="purchase-note">Engångsköp. Ingen prenumeration.</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>Privat från början</h2>
+      <div class="privacy-list">
+        <span>Inga flöden.</span>
+<span>Inga profiler.</span>
+<span>Inget konto krävs.</span>
+<span>Ingen press att prestera.</span>
+      </div>
+      <p>Deeper Conversations är byggd kring privata, textbaserade prompter. Appen samlar inte in, överför inte och delar inte personligt samtalsinnehåll.</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>Tillgänglig på iPhone och iPad</h2>
+      <p>Använd den vid bordet, i soffan, på resa eller under en stilla stund ensam.</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">Ladda ner från App Store</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kod? Lös in Full åtkomst gratis</a>
+    </section>
+
+    <section class="section faq">
+      <h2>FAQ</h2>
+      <details>
+    <summary>Är Deeper Conversations bara för par?</summary>
+    <p>Nej. Den innehåller lägen för par, vänner, familj och egen reflektion.</p>
+  </details>
+<details>
+    <summary>Är detta terapi?</summary>
+    <p>Nej. Deeper Conversations är inte terapi eller medicinsk rådgivning. Det är en app för samtal och reflektion.</p>
+  </details>
+<details>
+    <summary>Är Full åtkomst en prenumeration?</summary>
+    <p>Nej. Full åtkomst är ett engångsköp som ger livstidsåtkomst till hela Full åtkomst-biblioteket.</p>
+  </details>
+<details>
+    <summary>Samlar appen in mina samtal?</summary>
+    <p>Nej. Appen samlar inte in, överför inte och delar inte personligt samtalsinnehåll.</p>
+  </details>
+<details>
+    <summary>Vilka enheter stöds?</summary>
+    <p>Deeper Conversations fungerar på iPhone och iPad med iOS 18 eller senare.</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">Integritetspolicy</a>
+      <a href="../">Support</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-sv.html
+++ b/docs/marketing/invite-sv.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Tidsbegränsat erbjudande:</strong> Full åtkomst är gratis till 30 juli 2026. Lås upp premiumbiblioteket med 2 800+ prompter och uppföljningsfrågor.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lös in Full åtkomst gratis</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-sv.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Frågor som för människor närmare varandra.</h1>
           <p>Genomtänkta samtalsprompter för par, vänner, familj och egen reflektion. Välj vem du är med, sätt tonen och låt nästa fråga öppna något äkta.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Tidsbegränsat erbjudande</p>
+            <h2>Full åtkomst är gratis till 30 juli 2026</h2>
+            <p>Lås upp premiumbiblioteket med 2 800+ prompter och uppföljningsfrågor.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lös in Full åtkomst gratis</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Ladda ner från App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Tillgänglig på iPhone och iPad</h2>
       <p>Använd den vid bordet, i soffan, på resa eller under en stilla stund ensam.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Ladda ner från App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Har du en kod? Lös in Full åtkomst gratis</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Lös in Full åtkomst gratis</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite-zh-Hans.html
+++ b/docs/marketing/invite-zh-Hans.html
@@ -1,0 +1,203 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Deeper Conversations — 让人与人更靠近的问题。</title>
+  <meta name="description" content="为伴侣、朋友、家人和自我反思设计的用心对话提示。选择你和谁在一起，设定语气，让下一个问题打开真实的交流。">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Deeper Conversations">
+  <meta property="og:locale" content="zh-Hans">
+  <meta property="og:url" content="https://skytan4.github.io/Connections/marketing/invite-zh-Hans.html">
+  <meta property="og:title" content="Deeper Conversations — 让人与人更靠近的问题。">
+  <meta property="og:description" content="为伴侣、朋友、家人和自我反思设计的用心对话提示。选择你和谁在一起，设定语气，让下一个问题打开真实的交流。">
+  <meta property="og:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Deeper Conversations">
+  <meta name="twitter:description" content="为伴侣、朋友、家人和自我反思设计的用心对话提示。选择你和谁在一起，设定语气，让下一个问题打开真实的交流。">
+  <meta name="twitter:image" content="https://skytan4.github.io/Connections/marketing/preview.png">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <header class="hero">
+      <div class="topbar">
+        <a class="brand" href="invite-zh-Hans.html" aria-label="Deeper Conversations">
+          <span class="mark" aria-hidden="true"><span></span><span></span></span>
+          <span>Deeper Conversations</span>
+        </a>
+        <nav class="language-nav" aria-label="Language">
+    <a href="invite.html">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html" aria-current="page">简体中文</a>
+<a href="invite-ru.html">Русский</a>
+  </nav>
+      </div>
+
+      <section class="hero-grid">
+        <div class="hero-copy">
+          <p class="eyebrow">Deeper Conversations</p>
+          <h1>让人与人更靠近的问题。</h1>
+          <p>为伴侣、朋友、家人和自我反思设计的用心对话提示。选择你和谁在一起，设定语气，让下一个问题打开真实的交流。</p>
+          <a class="button" href="https://apps.apple.com/app/id6763803257">在 App Store 下载</a>
+        </div>
+        <div class="visual-card" aria-hidden="true">
+          <div class="shape-square"></div>
+          <div class="shape-circle"></div>
+          <div class="shape-glow"></div>
+        </div>
+      </section>
+    </header>
+
+    <section class="section opener">
+      <h2>大多数关系并不需要更多建议。<br>它们需要更好的开场。</h2>
+      <p>有时候，很难知道怎样开始一场有意义的对话。Deeper Conversations 提供精心设计的提示和追问，帮助人们自然走出闲聊，而不让这一刻显得生硬。</p>
+      <p>你可以在约会之夜、旅途中、家庭晚餐、安静相处的夜晚，或独自反思的时刻使用它。</p>
+    </section>
+
+    <section class="section research">
+      <h2>受到亲密关系研究启发</h2>
+      <p>Deeper Conversations 建立在一个有研究支持的简单想法之上：当人们逐渐分享、认真倾听，并以真实的注意力回应时，往往更容易感到彼此靠近。</p>
+<p>在一项著名的 1997 年研究中，心理学家 Arthur Aron 及其同事发现，成对陌生人回答一组逐渐加深的个人问题后，比完成闲聊任务的参与者报告了更强的亲近感。</p>
+<p>Deeper Conversations 并不是复制原始的 36 个问题。它借鉴的是同一种底层模式：温和开始，随着时间加深，并用细致的追问帮助对话在有意义的内容出现时继续下去。</p>
+<p>这款 app 也反映了关于亲密和连接的更广泛研究：自我表露很重要，但感到被理解、被接纳、被回应同样重要。</p>
+      <p>阅读研究：</p>
+  <ul>
+    <li><a href="https://journals.sagepub.com/doi/10.1177/0146167297234003">Aron et al. (1997), &quot;The Experimental Generation of Interpersonal Closeness&quot;</a></li>
+<li><a href="https://www.affective-science.org/pubs/1998/LaurenFBPl1998.pdf">Laurenceau, Barrett &amp; Pietromonaco (1998), &quot;Intimacy as an Interpersonal Process&quot;</a></li>
+  </ul>
+    </section>
+
+    <section class="section">
+      <h2>为重要的关系而设计</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>伴侣</h3>
+    <p>感到更靠近，更理解彼此，也更容易谈起那些常常没说出口的事。</p>
+  </article>
+<article class="mini-card">
+    <h3>朋友</h3>
+    <p>从近况和玩笑走向能看见真实状态的对话。</p>
+  </article>
+<article class="mini-card">
+    <h3>家人</h3>
+    <p>打开记忆、价值观、故事和跨代交流，这些对话也许不会自然发生。</p>
+  </article>
+<article class="mini-card">
+    <h3>自我反思</h3>
+    <p>用用心设计的问题，更清楚地理解你的感受、重视的事、记忆和想要的生活。</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section tone">
+      <h2>选择语气</h2>
+      <div class="tone-list">
+        <p>想轻松一点时，从轻松开始。</p>
+<p>当时机成熟时，变得更坦诚。</p>
+<p>当真实的内容打开时，继续深入。</p>
+      </div>
+      <p>每个会话都可以包含追问，所以对话不必停在第一个答案。</p>
+    </section>
+
+    <section class="section">
+      <h2>包含引导式体验</h2>
+      <div class="card-grid">
+        <article class="mini-card">
+    <h3>Fall in Love</h3>
+    <p>一种引导式提问体验，受到亲近感和逐步自我表露研究的启发。</p>
+  </article>
+<article class="mini-card">
+    <h3>Life Story</h3>
+    <p>横跨 9 个生命章节的 50 个问题，适合向父母、祖父母、亲近的人或自己询问记忆、意义和传承。</p>
+  </article>
+<article class="mini-card">
+    <h3>Share an Experience</h3>
+    <p>一种简单的引导方式，用来讲述你生命中的故事，也听见别人故事背后的内容。</p>
+  </article>
+<article class="mini-card">
+    <h3>Mortality Conversations</h3>
+    <p>关于死亡、照护、传承、家庭、哀伤、宽恕，以及当时间显得有限时什么最重要的用心问题。</p>
+  </article>
+      </div>
+    </section>
+
+    <section class="section purchase">
+      <h2>为什么完整访问值得购买</h2>
+      <p>免费版本帮助你开始。完整访问适合那些想一次又一次回到 Deeper Conversations 的人。</p>
+      <p>完整访问会解锁完整的高级内容库：2,802 个问题和跟进问题、更长会话、亲密关系问题、Fall in Love、Life Story、Share an Experience、Mortality Conversations，以及更多引导式体验。</p>
+      <p>这意味着你可以用更多方式：</p>
+  <ul>
+    <li>作为伴侣感到更靠近</li>
+<li>让友谊保持情感上的鲜活</li>
+<li>向家人提出你也许不会想到的问题</li>
+<li>谨慎谈论死亡、照护、传承、哀伤和家庭决定</li>
+<li>诚实地反思自己的人生</li>
+<li>当第一个回答打开重要内容时，继续对话</li>
+  </ul>
+      <p class="purchase-note">一次购买。无订阅。</p>
+    </section>
+
+    <section class="section privacy">
+      <h2>以隐私为核心设计</h2>
+      <div class="privacy-list">
+        <span>没有信息流。</span>
+<span>没有个人主页。</span>
+<span>不需要账户。</span>
+<span>没有表现压力。</span>
+      </div>
+      <p>Deeper Conversations 以私密的纯文本提示为核心。App 不会收集、传输或分享你的个人对话内容。</p>
+    </section>
+
+    <section class="section final-cta">
+      <h2>可在 iPhone 和 iPad 上使用</h2>
+      <p>可以在餐桌旁、沙发上、旅途中，或独处的安静时刻使用。</p>
+      <a class="button" href="https://apps.apple.com/app/id6763803257">在 App Store 下载</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">有兑换码？免费解锁完整版</a>
+    </section>
+
+    <section class="section faq">
+      <h2>常见问题</h2>
+      <details>
+    <summary>Deeper Conversations 只适合伴侣使用吗？</summary>
+    <p>不是。它包含伴侣、朋友、家庭和自我反思模式。</p>
+  </details>
+<details>
+    <summary>这是心理治疗吗？</summary>
+    <p>不是。Deeper Conversations 不是心理治疗，也不是医疗建议。它是一款对话和反思 app。</p>
+  </details>
+<details>
+    <summary>完整访问是订阅吗？</summary>
+    <p>不是。完整访问是一次性购买，购买后可终身访问完整访问内容库。</p>
+  </details>
+<details>
+    <summary>App 会收集我的对话吗？</summary>
+    <p>不会。App 不会收集、传输或分享你的个人对话内容。</p>
+  </details>
+<details>
+    <summary>支持哪些设备？</summary>
+    <p>Deeper Conversations 支持运行 iOS 18 或更高版本的 iPhone 和 iPad。</p>
+  </details>
+    </section>
+
+    <footer class="footer">
+      <a href="../privacy">隐私政策</a>
+      <a href="../">支持</a>
+      <span>© 2026 John Tanner</span>
+    </footer>
+  </main>
+</body>
+</html>

--- a/docs/marketing/invite-zh-Hans.html
+++ b/docs/marketing/invite-zh-Hans.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>限时优惠:</strong> 完整版免费开放至 2026 年 7 月 30 日. 解锁高级内容库，包含 2,800 多个问题和跟进问题。</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">免费解锁完整版</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite-zh-Hans.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>让人与人更靠近的问题。</h1>
           <p>为伴侣、朋友、家人和自我反思设计的用心对话提示。选择你和谁在一起，设定语气，让下一个问题打开真实的交流。</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">限时优惠</p>
+            <h2>完整版免费开放至 2026 年 7 月 30 日</h2>
+            <p>解锁高级内容库，包含 2,800 多个问题和跟进问题。</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">免费解锁完整版</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">在 App Store 下载</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>可在 iPhone 和 iPad 上使用</h2>
       <p>可以在餐桌旁、沙发上、旅途中，或独处的安静时刻使用。</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">在 App Store 下载</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">有兑换码？免费解锁完整版</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">免费解锁完整版</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite.html
+++ b/docs/marketing/invite.html
@@ -22,6 +22,10 @@
 </head>
 <body>
   <main class="page">
+    <aside class="offer-strip">
+      <p><strong>Limited-time offer:</strong> Full Access is free through July 30, 2026. Unlock the premium library with 2,800+ prompts and follow-up questions.</p>
+      <a class="button button-strip" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Redeem Full Access Free</a>
+    </aside>
     <header class="hero">
       <div class="topbar">
         <a class="brand" href="invite.html" aria-label="Deeper Conversations">
@@ -52,6 +56,12 @@
           <p class="eyebrow">Deeper Conversations</p>
           <h1>Questions that bring people closer.</h1>
           <p>Thoughtful conversation prompts for couples, friends, families, and solo reflection. Choose who you're with, set the tone, and let the next question open something real.</p>
+          <aside class="offer-card">
+            <p class="offer-eyebrow">Limited-time offer</p>
+            <h2>Full Access is free through July 30, 2026</h2>
+            <p>Unlock the premium library with 2,800+ prompts and follow-up questions.</p>
+            <a class="button button-offer" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Redeem Full Access Free</a>
+          </aside>
           <a class="button" href="https://apps.apple.com/app/id6763803257">Download on the App Store</a>
         </div>
         <div class="visual-card" aria-hidden="true">
@@ -166,7 +176,7 @@
       <h2>Available on iPhone and iPad</h2>
       <p>Use it across the table, on the couch, on a trip, or during a quiet moment alone.</p>
       <a class="button" href="https://apps.apple.com/app/id6763803257">Download on the App Store</a>
-      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Have a code? Redeem Full Access free</a>
+      <a class="button button-secondary" href="https://apps.apple.com/redeem?ctx=offercodes&id=6763803257&code=GETSTARTED">Redeem Full Access Free</a>
     </section>
 
     <section class="section faq">

--- a/docs/marketing/invite.html
+++ b/docs/marketing/invite.html
@@ -24,26 +24,26 @@
   <main class="page">
     <header class="hero">
       <div class="topbar">
-        <a class="brand" href="./" aria-label="Deeper Conversations">
+        <a class="brand" href="invite.html" aria-label="Deeper Conversations">
           <span class="mark" aria-hidden="true"><span></span><span></span></span>
           <span>Deeper Conversations</span>
         </a>
         <nav class="language-nav" aria-label="Language">
-    <a href="./" aria-current="page">English</a>
-<a href="es-ES.html">Español</a>
-<a href="fr.html">Français</a>
-<a href="de.html">Deutsch</a>
-<a href="pt-BR.html">Português (BR)</a>
-<a href="nl.html">Nederlands</a>
-<a href="it.html">Italiano</a>
-<a href="sv.html">Svenska</a>
-<a href="da.html">Dansk</a>
-<a href="nb.html">Norsk bokmål</a>
-<a href="fi.html">Suomi</a>
-<a href="pl.html">Polski</a>
-<a href="ja.html">日本語</a>
-<a href="zh-Hans.html">简体中文</a>
-<a href="ru.html">Русский</a>
+    <a href="invite.html" aria-current="page">English</a>
+<a href="invite-es-ES.html">Español</a>
+<a href="invite-fr.html">Français</a>
+<a href="invite-de.html">Deutsch</a>
+<a href="invite-pt-BR.html">Português (BR)</a>
+<a href="invite-nl.html">Nederlands</a>
+<a href="invite-it.html">Italiano</a>
+<a href="invite-sv.html">Svenska</a>
+<a href="invite-da.html">Dansk</a>
+<a href="invite-nb.html">Norsk bokmål</a>
+<a href="invite-fi.html">Suomi</a>
+<a href="invite-pl.html">Polski</a>
+<a href="invite-ja.html">日本語</a>
+<a href="invite-zh-Hans.html">简体中文</a>
+<a href="invite-ru.html">Русский</a>
   </nav>
       </div>
 

--- a/docs/marketing/styles.css
+++ b/docs/marketing/styles.css
@@ -27,6 +27,10 @@ body {
 a { color: var(--gold); text-decoration: none; }
 a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .page { width: min(1120px, calc(100% - 36px)); margin: 0 auto; padding: 28px 0 64px; }
+.offer-strip { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 0 0 26px; padding: 14px 16px; border: 1px solid rgba(242, 195, 95, 0.54); border-radius: 20px; background: linear-gradient(145deg, rgba(242, 195, 95, 0.2), rgba(255, 246, 222, 0.08)); box-shadow: 0 18px 58px rgba(0,0,0,.2); }
+.offer-strip p { margin: 0; color: var(--muted); font-size: 0.98rem; line-height: 1.35; }
+.offer-strip strong { color: var(--gold); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.82rem; }
+.button-strip { flex: 0 0 auto; min-height: 42px; margin-top: 0; background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.78); box-shadow: 0 14px 40px rgba(242, 195, 95, 0.24); }
 .topbar { display: flex; align-items: center; justify-content: space-between; gap: 18px; margin-bottom: 54px; }
 .brand { display: inline-flex; align-items: center; gap: 12px; color: var(--text); font-weight: 760; letter-spacing: -0.02em; }
 .mark { position: relative; width: 36px; height: 36px; border-radius: 12px; overflow: hidden; background: #0f251f; box-shadow: inset 0 0 0 1px var(--border); }
@@ -41,7 +45,12 @@ a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .hero-copy p { max-width: 680px; color: var(--muted); font-size: clamp(1.08rem, 2vw, 1.34rem); }
 .eyebrow { color: var(--gold) !important; font-size: 0.78rem !important; text-transform: uppercase; letter-spacing: 0.18em; font-weight: 780; margin-bottom: 12px; }
 .button { display: inline-flex; align-items: center; justify-content: center; min-height: 48px; margin-top: 18px; padding: 0 20px; border-radius: 999px; background: var(--gold); color: #17100b; font-weight: 780; box-shadow: 0 12px 40px rgba(217, 133, 31, 0.26); }
-.button-secondary { background: transparent; color: var(--gold); border: 1px solid var(--border); box-shadow: none; margin-left: 10px; }
+.button-secondary { background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.72); box-shadow: 0 14px 42px rgba(242, 195, 95, 0.22); margin-left: 10px; }
+.offer-card { max-width: 640px; margin-top: 22px; padding: 22px; border: 1px solid rgba(242, 195, 95, 0.48); border-radius: 26px; background: linear-gradient(145deg, rgba(242, 195, 95, 0.18), rgba(255, 246, 222, 0.07)); box-shadow: 0 20px 70px rgba(0,0,0,.22); }
+.offer-card .offer-eyebrow { margin: 0 0 8px; color: var(--gold); font-size: 0.76rem; font-weight: 820; letter-spacing: 0.16em; text-transform: uppercase; }
+.offer-card h2 { margin: 0; color: var(--cream); font-size: clamp(1.42rem, 2.4vw, 2rem); line-height: 1.08; letter-spacing: -0.035em; }
+.offer-card p { margin: 10px 0 0; color: var(--muted); font-size: 1.02rem; }
+.button-offer { width: 100%; min-height: 54px; margin-top: 18px; background: var(--cream); color: #17100b; border: 1px solid rgba(255, 224, 161, 0.78); box-shadow: 0 18px 50px rgba(242, 195, 95, 0.26); }
 .visual-card { position: relative; min-height: 420px; border: 1px solid var(--border); border-radius: 36px; overflow: hidden; background: linear-gradient(145deg, #11251e, #08110f); box-shadow: var(--shadow); }
 .shape-square { position: absolute; width: 78%; height: 78%; left: -23%; top: 11%; border-radius: 30%; background: linear-gradient(145deg, #ffe4a7, #c99039); box-shadow: inset 0 0 18px rgba(255,255,255,.24); }
 .shape-circle { position: absolute; width: 76%; height: 76%; right: -25%; top: 12%; border-radius: 50%; background: linear-gradient(145deg, #1d4b3e, #07110f); box-shadow: inset 0 0 14px rgba(255,224,161,.16); }
@@ -69,10 +78,13 @@ a:hover { text-decoration: underline; text-underline-offset: 0.18em; }
 .footer { display: flex; justify-content: center; gap: 18px; flex-wrap: wrap; color: var(--soft); padding: 34px 0 0; font-size: 0.95rem; }
 .footer a { color: var(--soft); text-decoration: underline; text-underline-offset: 0.18em; }
 @media (max-width: 820px) {
+  .offer-strip { align-items: stretch; flex-direction: column; }
+  .button-strip { width: 100%; }
   .topbar { align-items: flex-start; flex-direction: column; }
   .language-nav { justify-content: flex-start; }
   .hero-grid { grid-template-columns: 1fr; }
   .visual-card { min-height: 290px; }
+  .button-secondary { margin-left: 0; }
   .card-grid, .privacy-list { grid-template-columns: 1fr; }
   .section { border-radius: 24px; }
 }


### PR DESCRIPTION
## Summary
- generate localized invite pages for every supported marketing locale
- keep the invite page language switcher inside invite URLs so users do not lose the redeem CTA when switching languages
- keep the invite brand link on the current invite page instead of routing to the general marketing page

## Verification
- node docs/marketing-page/build-html.mjs
- checked normal pages have no redeem button
- checked every invite*.html page has exactly one redeem button
- checked invite language links point to invite*.html instead of general localized pages